### PR TITLE
Update the READMEs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,11 +13,11 @@ in [Rust](https://www.rust-lang.org/en-US/).
 Althougth the maintainer of this repository is a Microsoft employee, this project is not an official Microsoft product
 and is not an endorsement of any future product offering from Microsoft.
 
-This project is simply a labor of love by a developer who would like to see Rust adoption flourish.
+This project is simply a labor of love by a developer who would like to see the Rust ecosystem flourish.
 
-## Examples
+## Example
 
-An example anonymous, HTTP-triggered Azure Function:
+A simple HTTP-triggered Azure Function:
 
 ```rust
 use azure_functions::bindings::{HttpRequest, HttpResponse};
@@ -26,7 +26,8 @@ use azure_functions::func;
 #[func]
 #[binding(name = "req", auth_level = "anonymous")]
 pub fn greet(req: &HttpRequest) -> HttpResponse {
-    info!("The request was: {:?}", req);
+    // Log the message with the Azure Functions Host
+    info!("Request: {:?}", req);
 
     format!(
         "Hello from Rust, {}!\n",
@@ -35,22 +36,7 @@ pub fn greet(req: &HttpRequest) -> HttpResponse {
 }
 ```
 
-A timer-triggered Azure Function that is invoked every 5 minutes:
-
-```rust
-use azure_functions::bindings::TimerInfo;
-use azure_functions::func;
-
-#[func]
-#[binding(name = "info", schedule = "0 */5 * * * *")]
-pub fn timer(info: &TimerInfo) {
-    info!("Rust function invoked by timer!");
-}
-```
-
-_Note: the `info!` macro used in the above examples comes from the [log crate](https://crates.io/crates/log); the messages will be logged on the Azure Functions Host._
-
-See the [examples](https://github.com/peterhuene/azure-functions-rs/tree/master/examples) directory for the complete source code.
+See the [examples](https://github.com/peterhuene/azure-functions-rs/tree/master/examples) directory for the complete list of examples.
 
 # Documentation
 
@@ -137,61 +123,3 @@ cargo test
 ```
 
 Right now there are only doc tests, but more tests are coming soon.
-
-## Running the examples locally
-
-Currently, the Azure Functions Host does not support the Rust language worker.  Until that time, Azure Functions written in Rust must be executed locally using a [fork of the Azure Functions Host that does](https://github.com/peterhuene/azure-functions-host/tree/rust-worker-provider).
-
-### Run the HTTP example
-
-Run the following commands:
-
-```
-cd examples/http
-cargo run -q -- --create root
-```
-
-This will build and run the sample to create the Azure Functions "script root" containing the Rust worker and the example Azure Function metadata.
-
-Remember the path to the root directory from this step, it will be needed for running the Azure Functions Host (see below).
-
-### Download a .NET SDK
-
-The Azure Functions Host is implemented with .NET Core, so download and install a [.NET Core SDK](https://www.microsoft.com/net/download).
-
-### Clone the fork of the Azure Functions Host
-
-Run the following command to clone the fork:
-
-```
-git clone -b rust-worker-provider git@github.com:peterhuene/azure-functions-host.git
-```
-
-### Run the Azure Functions Host
-
-Run the following commands to run the Azure Functions Host locally:
-
-```
-cd azure-functions-host/src/WebJobs.Script.WebHost
-AzureWebJobsScriptRoot=$SCRIPT_ROOT_PATH dotnet run
-```
-
-Where `$SCRIPT_ROOT_PATH` above represents the path to the root directory created from running `cargo run` above.
-
-_Note: the syntax above works on macOS and Linux; on Windows, set the `AzureWebJobsScriptRoot` environment variable before running `dotnet run`._
-
-_Note: if using bindings that require storage (such as timer triggers), you must set the `AzureWebJobsStorage` environment variable to an Azure Storage connection string._
-
-### Invoke the `greet` function
-
-The easiest way to invoke the function is to use `curl` (substitute for your preferred method of sending HTTP requests):
-
-```
-curl localhost:5000/api/greet\?name=Peter
-```
-
-With any luck, you should see the following output:
-
-```
-Hello from Rust, Peter!
-```

--- a/codegen/src/func.rs
+++ b/codegen/src/func.rs
@@ -318,7 +318,7 @@ fn bind_argument(
                                 None => Err(tp
                                     .span()
                                     .unstable()
-                                    .error("expected an Azure Function trigger or input binding type"))
+                                    .error("expected an Azure Functions trigger or input binding type"))
                             },
                         },
                     }?;
@@ -344,10 +344,10 @@ fn bind_argument(
                     .ty
                     .span()
                     .unstable()
-                    .error("expected an Azure Function trigger or input binding type")),
+                    .error("expected an Azure Functions trigger or input binding type")),
             },
             _ => Err(arg.ty.span().unstable().error(
-                "expected an Azure Function trigger or input binding type passed by reference",
+                "expected an Azure Functions trigger or input binding type passed by reference",
             )),
         },
         FnArg::SelfRef(_) | FnArg::SelfValue(_) => Err(arg
@@ -383,12 +383,12 @@ fn bind_return_type(
                 None => Err(tp
                     .span()
                     .unstable()
-                    .error("expected an Azure Function output binding type")),
+                    .error("expected an Azure Functions output binding type")),
             },
             _ => Err(ty
                 .span()
                 .unstable()
-                .error("expected an Azure Function output binding type")),
+                .error("expected an Azure Functions output binding type")),
         },
     }
 }

--- a/codegen/src/func.rs
+++ b/codegen/src/func.rs
@@ -547,6 +547,7 @@ pub fn func_attr_impl(args: TokenStream, input: TokenStream) -> TokenStream {
     let invoker = TargetInvoker(&target);
 
     let expanded = quote!{
+        #[allow(unused_variables)]
         #target
 
         #invoker

--- a/examples/http/README.md
+++ b/examples/http/README.md
@@ -1,0 +1,93 @@
+# Example HTTP Azure Function
+
+This package is an example of a simple HTTP-triggered Azure Function.
+
+## Example function implementation
+
+The example anonymous, HTTP-triggered Azure Function:
+
+```rust
+use azure_functions::bindings::{HttpRequest, HttpResponse};
+use azure_functions::{func, Context};
+
+#[func]
+#[binding(name = "req", auth_level = "anonymous")]
+pub fn greet(context: &Context, req: &HttpRequest) -> HttpResponse {
+    info!("Context: {:?}, Request: {:?}", context, req);
+
+    format!(
+        "Hello from Rust, {}!\n",
+        req.query_params().get("name").map_or("stranger", |x| x)
+    ).into()
+}
+```
+
+# Running the example
+
+## Prerequisites
+
+### Nightly Rust compiler
+
+This example requires the use of a nightly Rust compiler due the use of the experimental procedural macros feature.
+
+Use [rustup](https://github.com/rust-lang-nursery/rustup.rs) to install a nightly compiler:
+
+```
+rustup install nightly
+rustup default nightly
+```
+
+### .NET Core SDK
+
+The Azure Functions Host is implemented with .NET Core, so download and install a [.NET Core SDK](https://www.microsoft.com/net/download).
+
+### Custom fork of Azure Functions Host
+
+Currently, the Azure Functions Host does not support the Rust language worker.  Until that time, Azure Functions written in Rust must be executed locally using a [fork of the Azure Functions Host that does](https://github.com/peterhuene/azure-functions-host/tree/rust-worker-provider).
+
+Run the following command to clone the fork:
+
+```
+git clone -b rust-worker-provider git@github.com:peterhuene/azure-functions-host.git
+```
+
+## Create the script root
+
+Run the following command to create the "script root" for the example:
+
+```
+cargo run -q -- --create root
+```
+
+This will build and run the sample to create the "script root" containing the Rust worker and the example Azure Function metadata.
+
+Remember the path to the root directory from this step as it will be needed for running the Azure Functions Host below.
+
+## Start the Azure Functions Host
+
+Run the following commands to start the Azure Functions Host:
+
+```
+cd azure-functions-host/src/WebJobs.Script.WebHost
+AzureWebJobsScriptRoot=$SCRIPT_ROOT_PATH dotnet run
+```
+
+Where `$SCRIPT_ROOT_PATH` above represents the path to the root directory created from running `cargo run` above.
+
+_Note: the syntax above works on macOS and Linux; on Windows, set the `AzureWebJobsScriptRoot` environment variable before running `dotnet run`._
+
+_Note: if using bindings that require storage (such as timer triggers), you must set the `AzureWebJobsStorage` environment variable to an Azure Storage connection string._
+
+## Invoke the `greet` function
+
+The easiest way to invoke the function is to use `curl`:
+
+```
+curl localhost:5000/api/greet\?name=Peter
+```
+
+With any luck, you should see the following output:
+
+```
+Hello from Rust, Peter!
+```

--- a/examples/timer/README.md
+++ b/examples/timer/README.md
@@ -1,0 +1,91 @@
+# Example Timer Azure Function
+
+This package is an example of a simple timer-triggered Azure Function.
+
+## Example function implementation
+
+The example timer-triggered Azure Function that runs every minute:
+
+```rust
+use azure_functions::bindings::TimerInfo;
+use azure_functions::func;
+
+#[func]
+#[binding(name = "info", schedule = "0 */1 * * * *")]
+pub fn timer(info: &TimerInfo) {
+    info!("Hello every minute from Rust!");
+}
+```
+
+# Running the example
+
+## Prerequisites
+
+### Nightly Rust compiler
+
+This example requires the use of a nightly Rust compiler due the use of the experimental procedural macros feature.
+
+Use [rustup](https://github.com/rust-lang-nursery/rustup.rs) to install a nightly compiler:
+
+```
+rustup install nightly
+rustup default nightly
+```
+
+### .NET Core SDK
+
+The Azure Functions Host is implemented with .NET Core, so download and install a [.NET Core SDK](https://www.microsoft.com/net/download).
+
+### Custom fork of Azure Functions Host
+
+Currently, the Azure Functions Host does not support the Rust language worker.  Until that time, Azure Functions written in Rust must be executed locally using a [fork of the Azure Functions Host that does](https://github.com/peterhuene/azure-functions-host/tree/rust-worker-provider).
+
+Run the following command to clone the fork:
+
+```
+git clone -b rust-worker-provider git@github.com:peterhuene/azure-functions-host.git
+```
+
+## Create the script root
+
+Run the following command to create the "script root" for the example:
+
+```
+cargo run -q -- --create root
+```
+
+This will build and run the sample to create the "script root" containing the Rust worker and the example Azure Function metadata.
+
+Remember the path to the root directory from this step as it will be needed for running the Azure Functions Host below.
+
+## Start the Azure Functions Host
+
+Run the following commands to start the Azure Functions Host:
+
+```
+cd azure-functions-host/src/WebJobs.Script.WebHost
+AzureWebJobsScriptRoot=$SCRIPT_ROOT AzureWebJobsStorage=$CONNECTION_STRING dotnet run
+```
+
+Where `$SCRIPT_ROOT` above represents the path to the root directory created from running `cargo run` above and `$CONNECTION_STRING` is the Azure Storage connection string the Azure Functions host should use.
+
+_Note: the syntax above works on macOS and Linux; on Windows, set the environment variables before running `dotnet run`._
+
+## Invoke the `timer` function
+
+The example function is automatically invoked by the Azure Functions Host when the timer expires.
+
+Wait a minute and then check the Azure Functions Host output.
+
+With any luck, you should see the following output:
+
+```
+info: Function.timer[0]
+      => System.Collections.Generic.Dictionary`2[System.String,System.Object]
+      Executing 'Functions.timer' (Reason='Timer fired at 2018-07-15T23:34:00.0200030-07:00', Id=99936a5b-8df1-48c7-97b7-afec3b579215)
+info: Worker.Rust.7ed9c518-6f7e-4c0b-bc5d-0fdb77a0d1b1[0]
+      Hello every minute from Rust!
+info: Function.timer[0]
+      => System.Collections.Generic.Dictionary`2[System.String,System.Object]
+      Executed 'Functions.timer' (Succeeded, Id=99936a5b-8df1-48c7-97b7-afec3b579215)
+```

--- a/examples/timer/src/timer.rs
+++ b/examples/timer/src/timer.rs
@@ -1,9 +1,8 @@
 use azure_functions::bindings::TimerInfo;
 use azure_functions::func;
 
-// Example of an Azure Function that is invoked every 5 minutes
 #[func]
-#[binding(name = "info", schedule = "0 */5 * * * *")]
+#[binding(name = "info", schedule = "0 */1 * * * *")]
 pub fn timer(info: &TimerInfo) {
-    info!("Info: {:?}", info);
+    info!("Hello every minute from Rust!");
 }

--- a/lib/src/cli.rs
+++ b/lib/src/cli.rs
@@ -7,9 +7,9 @@ use std::fs;
 use std::sync::{Arc, Mutex};
 
 pub fn create_app<'a, 'b>() -> App<'a, 'b> {
-    App::new("Azure Function Language Worker for Rust")
+    App::new("Azure Functions Language Worker for Rust")
         .version(env!("CARGO_PKG_VERSION"))
-        .about("Provides an Azure Function Worker for functions written in Rust.")
+        .about("Provides an Azure Functions Worker for functions written in Rust.")
         .arg(
             Arg::with_name("host")
                 .long("host")
@@ -128,7 +128,7 @@ pub fn generate_functions_app(root: &str, registry: Arc<Mutex<Registry>>) {
         );
         fs::write(
             &script_file,
-            "// This file is intentionally empty.\n// It is needed by Azure Functions Host to register the Azure function."
+            "// This file is intentionally empty.\n// It is needed by the Azure Functions Host to register the Azure Function."
         ).expect(&format!("Failed to create '{}'", script_file.display()));
 
         let function_json = function_dir.join(FUNCTION_FILE);


### PR DESCRIPTION
Update the READMEs.

Correct use of "Azure Function" where "Azure Functions" should have been used.

Allow unused variables for binding parameters.