### PR TITLE
Remove allow(unused_variables) from generated code.

### DIFF
--- a/codegen/src/bindings/http.rs
+++ b/codegen/src/bindings/http.rs
@@ -2,8 +2,8 @@ use proc_macro::Diagnostic;
 use quote::ToTokens;
 use std::convert::TryFrom;
 use syn::spanned::Spanned;
-use syn::{Ident, Lit};
-use util::AttributeArguments;
+use syn::Lit;
+use util::{to_camel_case, AttributeArguments};
 
 #[derive(Debug)]
 pub struct Http {
@@ -22,18 +22,7 @@ impl<'a> TryFrom<&'a AttributeArguments> for Http {
             match key_str.as_str() {
                 "name" => match value {
                     Lit::Str(s) => {
-                        let v = s.value();
-                        name = match v.as_ref() {
-                            "$return" => Some(v),
-                            _ => s
-                                .parse::<Ident>()
-                                .map(|x| Some(x.to_string()))
-                                .map_err(|_| {
-                                    value.span().unstable().error(
-                                            "a legal parameter identifier is required for the 'name' argument",
-                                        )
-                                })?,
-                        };
+                        name = Some(to_camel_case(&s.value()));
                     }
                     _ => {
                         return Err(value

--- a/codegen/src/bindings/http_trigger.rs
+++ b/codegen/src/bindings/http_trigger.rs
@@ -2,8 +2,8 @@ use proc_macro::Diagnostic;
 use quote::ToTokens;
 use std::convert::TryFrom;
 use syn::spanned::Spanned;
-use syn::{Ident, Lit};
-use util::{AttributeArguments, QuotableOption};
+use syn::Lit;
+use util::{to_camel_case, AttributeArguments, QuotableOption};
 
 #[derive(Debug)]
 pub struct HttpTrigger {
@@ -30,14 +30,7 @@ impl<'a> TryFrom<&'a AttributeArguments> for HttpTrigger {
             match key_str.as_str() {
                 "name" => match value {
                     Lit::Str(s) => {
-                        name = s
-                            .parse::<Ident>()
-                            .map(|x| Some(x.to_string()))
-                            .map_err(|_| {
-                                value.span().unstable().error(
-                                "a legal parameter identifier is required for the 'name' argument",
-                            )
-                            })?;
+                        name = Some(to_camel_case(&s.value()));
                     }
                     _ => {
                         return Err(value

--- a/codegen/src/bindings/mod.rs
+++ b/codegen/src/bindings/mod.rs
@@ -51,6 +51,15 @@ pub enum Binding {
 }
 
 impl Binding {
+    pub fn name(&self) -> Option<&str> {
+        match self {
+            Binding::Context => None,
+            Binding::HttpTrigger(b) => Some(&b.name),
+            Binding::Http(b) => Some(&b.name),
+            Binding::TimerTrigger(b) => Some(&b.name),
+        }
+    }
+
     pub fn is_context(&self) -> bool {
         match self {
             Binding::Context => true,

--- a/codegen/src/bindings/timer_trigger.rs
+++ b/codegen/src/bindings/timer_trigger.rs
@@ -2,8 +2,8 @@ use proc_macro::Diagnostic;
 use quote::ToTokens;
 use std::convert::TryFrom;
 use syn::spanned::Spanned;
-use syn::{Ident, Lit};
-use util::{AttributeArguments, QuotableOption};
+use syn::Lit;
+use util::{to_camel_case, AttributeArguments, QuotableOption};
 
 #[derive(Debug)]
 pub struct TimerTrigger {
@@ -28,14 +28,7 @@ impl<'a> TryFrom<&'a AttributeArguments> for TimerTrigger {
             match key_str.as_str() {
                 "name" => match value {
                     Lit::Str(s) => {
-                        name = s
-                            .parse::<Ident>()
-                            .map(|x| Some(x.to_string()))
-                            .map_err(|_| {
-                                value.span().unstable().error(
-                                "a legal parameter identifier is required for the 'name' argument",
-                            )
-                            })?;
+                        name = Some(to_camel_case(&s.value()));
                     }
                     _ => {
                         return Err(value

--- a/codegen/src/util.rs
+++ b/codegen/src/util.rs
@@ -8,6 +8,25 @@ use syn::spanned::Spanned;
 use syn::synom::Synom;
 use syn::{parse, parse2, Attribute, Ident, Lit, LitStr, Path};
 
+pub fn to_camel_case(input: &str) -> String {
+    let mut result = String::new();
+    let mut capitalize = false;
+    let mut first = true;
+    for ch in input.chars() {
+        if ch == '_' {
+            capitalize = true;
+        } else {
+            result.push(match capitalize && !first {
+                true => ch.to_ascii_uppercase(),
+                false => ch,
+            });
+            first = false;
+            capitalize = false;
+        }
+    }
+    result
+}
+
 #[derive(Default)]
 pub struct PathVec {
     paths: Vec<Path>,

--- a/examples/timer/README.md
+++ b/examples/timer/README.md
@@ -11,8 +11,8 @@ use azure_functions::bindings::TimerInfo;
 use azure_functions::func;
 
 #[func]
-#[binding(name = "info", schedule = "0 */1 * * * *")]
-pub fn timer(info: &TimerInfo) {
+#[binding(name = "_info", schedule = "0 */1 * * * *")]
+pub fn timer(_info: &TimerInfo) {
     info!("Hello every minute from Rust!");
 }
 ```

--- a/examples/timer/src/timer.rs
+++ b/examples/timer/src/timer.rs
@@ -2,7 +2,7 @@ use azure_functions::bindings::TimerInfo;
 use azure_functions::func;
 
 #[func]
-#[binding(name = "info", schedule = "0 */1 * * * *")]
-pub fn timer(info: &TimerInfo) {
+#[binding(name = "_info", schedule = "0 */1 * * * *")]
+pub fn timer(_info: &TimerInfo) {
     info!("Hello every minute from Rust!");
 }

--- a/lib/src/bindings/timer_info.rs
+++ b/lib/src/bindings/timer_info.rs
@@ -15,8 +15,8 @@ use timer::ScheduleStatus;
 /// use azure_functions::func;
 ///
 /// #[func]
-/// #[binding(name = "info", schedule = "0 */5 * * * *")]
-/// pub fn timer(info: &TimerInfo) {
+/// #[binding(name = "_info", schedule = "0 */5 * * * *")]
+/// pub fn timer(_info: &TimerInfo) {
 ///     info!("Rust Azure function ran!");
 /// }
 /// ```


### PR DESCRIPTION
This commit removes allow(unused_variables) from the generated code.

We now camel case the binding names from the Rust identifiers and ensure two
parameters don't camel case to the same value.

This enables developers to receive the unused variables warnings and to solve
the warnings (i.e. prefix the variable name with `_`) in the suggested,
Rust-idiomatic way.

Fixes #6.