### PR TITLE
Change declarations to in-band lifetimes.

### DIFF
--- a/azure-functions-codegen/src/func/binding.rs
+++ b/azure-functions-codegen/src/func/binding.rs
@@ -10,7 +10,7 @@ use util::AttributeArguments;
 
 pub struct Binding<'a>(pub &'a codegen::Binding);
 
-impl<'a> ToTokens for Binding<'a> {
+impl ToTokens for Binding<'_> {
     fn to_tokens(&self, tokens: &mut TokenStream) {
         match self.0 {
             codegen::Binding::Context => panic!("context bindings cannot be tokenized"),
@@ -38,11 +38,12 @@ impl<'a> ToTokens for Binding<'a> {
     }
 }
 
-pub type BindingFactory = fn(&AttributeArguments) -> Result<codegen::Binding, Diagnostic>;
+pub type BindingFactory = fn(AttributeArguments) -> Result<codegen::Binding, Diagnostic>;
+type BindingMap = HashMap<&'static str, BindingFactory>;
 
 lazy_static! {
-    pub static ref TRIGGERS: HashMap<&'static str, BindingFactory> = {
-        let mut map: HashMap<&'static str, BindingFactory> = HashMap::new();
+    pub static ref TRIGGERS: BindingMap = {
+        let mut map: BindingMap = HashMap::new();
         map.insert("HttpRequest", |args| {
             Ok(codegen::Binding::HttpTrigger(
                 HttpTrigger::try_from(args)?.0.into_owned(),
@@ -60,16 +61,16 @@ lazy_static! {
         });
         map
     };
-    pub static ref INPUT_BINDINGS: HashMap<&'static str, BindingFactory> = {
-        let map: HashMap<&'static str, BindingFactory> = HashMap::new();
+    pub static ref INPUT_BINDINGS: BindingMap = {
+        let map: BindingMap = HashMap::new();
         map
     };
-    pub static ref INPUT_OUTPUT_BINDINGS: HashMap<&'static str, BindingFactory> = {
-        let map: HashMap<&'static str, BindingFactory> = HashMap::new();
+    pub static ref INPUT_OUTPUT_BINDINGS: BindingMap = {
+        let map: BindingMap = HashMap::new();
         map
     };
-    pub static ref OUTPUT_BINDINGS: HashMap<&'static str, BindingFactory> = {
-        let mut map: HashMap<&'static str, BindingFactory> = HashMap::new();
+    pub static ref OUTPUT_BINDINGS: BindingMap = {
+        let mut map: BindingMap = HashMap::new();
         map.insert("HttpResponse", |args| {
             Ok(codegen::Binding::Http(Http::try_from(args)?.0.into_owned()))
         });

--- a/azure-functions-codegen/src/func/bindings/http.rs
+++ b/azure-functions-codegen/src/func/bindings/http.rs
@@ -10,10 +10,10 @@ use util::{to_camel_case, AttributeArguments, QuotableBorrowedStr};
 
 pub struct Http<'a>(pub Cow<'a, codegen::bindings::Http>);
 
-impl<'a> TryFrom<&'a AttributeArguments> for Http<'a> {
+impl TryFrom<AttributeArguments> for Http<'_> {
     type Error = Diagnostic;
 
-    fn try_from(args: &AttributeArguments) -> Result<Self, Self::Error> {
+    fn try_from(args: AttributeArguments) -> Result<Self, Self::Error> {
         let mut name = None;
 
         for (key, value) in args.list.iter() {
@@ -46,7 +46,7 @@ impl<'a> TryFrom<&'a AttributeArguments> for Http<'a> {
     }
 }
 
-impl<'a> ToTokens for Http<'a> {
+impl ToTokens for Http<'_> {
     fn to_tokens(&self, tokens: &mut TokenStream) {
         let name = QuotableBorrowedStr(&self.0.name);
         quote!(::azure_functions::codegen::bindings::Http { name: #name }).to_tokens(tokens)

--- a/azure-functions-codegen/src/func/bindings/http_trigger.rs
+++ b/azure-functions-codegen/src/func/bindings/http_trigger.rs
@@ -10,10 +10,10 @@ use util::{to_camel_case, AttributeArguments, QuotableBorrowedStr, QuotableOptio
 
 pub struct HttpTrigger<'a>(pub Cow<'a, codegen::bindings::HttpTrigger>);
 
-impl<'a> TryFrom<&'a AttributeArguments> for HttpTrigger<'a> {
+impl TryFrom<AttributeArguments> for HttpTrigger<'_> {
     type Error = Diagnostic;
 
-    fn try_from(args: &AttributeArguments) -> Result<Self, Self::Error> {
+    fn try_from(args: AttributeArguments) -> Result<Self, Self::Error> {
         let mut name = None;
         let mut auth_level = None;
         let mut methods = Vec::new();
@@ -134,7 +134,7 @@ impl<'a> TryFrom<&'a AttributeArguments> for HttpTrigger<'a> {
     }
 }
 
-impl<'a> ToTokens for HttpTrigger<'a> {
+impl ToTokens for HttpTrigger<'_> {
     fn to_tokens(&self, tokens: &mut TokenStream) {
         let name = QuotableBorrowedStr(&self.0.name);
         let auth_level = QuotableOption(self.0.auth_level.as_ref().map(|x| QuotableBorrowedStr(x)));

--- a/azure-functions-codegen/src/func/bindings/queue.rs
+++ b/azure-functions-codegen/src/func/bindings/queue.rs
@@ -9,10 +9,10 @@ use util::{to_camel_case, AttributeArguments, QuotableBorrowedStr, QuotableOptio
 
 pub struct Queue<'a>(pub Cow<'a, codegen::bindings::Queue>);
 
-impl<'a> TryFrom<&'a AttributeArguments> for Queue<'a> {
+impl TryFrom<AttributeArguments> for Queue<'_> {
     type Error = Diagnostic;
 
-    fn try_from(args: &'a AttributeArguments) -> Result<Self, Self::Error> {
+    fn try_from(args: AttributeArguments) -> Result<Self, Self::Error> {
         let mut name = None;
         let mut queue_name = None;
         let mut connection = None;
@@ -75,7 +75,7 @@ impl<'a> TryFrom<&'a AttributeArguments> for Queue<'a> {
     }
 }
 
-impl<'a> ToTokens for Queue<'a> {
+impl ToTokens for Queue<'_> {
     fn to_tokens(&self, tokens: &mut ::proc_macro2::TokenStream) {
         let name = QuotableBorrowedStr(&self.0.name);
         let queue_name = QuotableBorrowedStr(&self.0.queue_name);

--- a/azure-functions-codegen/src/func/bindings/queue_trigger.rs
+++ b/azure-functions-codegen/src/func/bindings/queue_trigger.rs
@@ -9,10 +9,10 @@ use util::{to_camel_case, AttributeArguments, QuotableBorrowedStr, QuotableOptio
 
 pub struct QueueTrigger<'a>(pub Cow<'a, codegen::bindings::QueueTrigger>);
 
-impl<'a> TryFrom<&'a AttributeArguments> for QueueTrigger<'a> {
+impl TryFrom<AttributeArguments> for QueueTrigger<'_> {
     type Error = Diagnostic;
 
-    fn try_from(args: &'a AttributeArguments) -> Result<Self, Self::Error> {
+    fn try_from(args: AttributeArguments) -> Result<Self, Self::Error> {
         let mut name = None;
         let mut queue_name = None;
         let mut connection = None;
@@ -75,7 +75,7 @@ impl<'a> TryFrom<&'a AttributeArguments> for QueueTrigger<'a> {
     }
 }
 
-impl<'a> ToTokens for QueueTrigger<'a> {
+impl ToTokens for QueueTrigger<'_> {
     fn to_tokens(&self, tokens: &mut ::proc_macro2::TokenStream) {
         let name = QuotableBorrowedStr(&self.0.name);
         let queue_name = QuotableBorrowedStr(&self.0.queue_name);

--- a/azure-functions-codegen/src/func/bindings/timer_trigger.rs
+++ b/azure-functions-codegen/src/func/bindings/timer_trigger.rs
@@ -10,10 +10,10 @@ use util::{to_camel_case, AttributeArguments, QuotableBorrowedStr, QuotableOptio
 
 pub struct TimerTrigger<'a>(pub Cow<'a, codegen::bindings::TimerTrigger>);
 
-impl<'a> TryFrom<&'a AttributeArguments> for TimerTrigger<'a> {
+impl TryFrom<AttributeArguments> for TimerTrigger<'_> {
     type Error = Diagnostic;
 
-    fn try_from(args: &AttributeArguments) -> Result<Self, Self::Error> {
+    fn try_from(args: AttributeArguments) -> Result<Self, Self::Error> {
         let mut name = None;
         let mut schedule = None;
         let mut run_on_startup = None;
@@ -83,7 +83,7 @@ impl<'a> TryFrom<&'a AttributeArguments> for TimerTrigger<'a> {
     }
 }
 
-impl<'a> ToTokens for TimerTrigger<'a> {
+impl ToTokens for TimerTrigger<'_> {
     fn to_tokens(&self, tokens: &mut TokenStream) {
         let name = QuotableBorrowedStr(&self.0.name);
         let schedule = QuotableOption(self.0.schedule.as_ref().map(|x| QuotableBorrowedStr(x)));

--- a/azure-functions-codegen/src/func/function.rs
+++ b/azure-functions-codegen/src/func/function.rs
@@ -11,7 +11,7 @@ use util::{AttributeArguments, QuotableBorrowedStr, QuotableOption};
 
 pub struct Function<'a>(pub Cow<'a, codegen::Function>);
 
-impl<'a> TryFrom<TokenStream> for Function<'a> {
+impl TryFrom<TokenStream> for Function<'_> {
     type Error = Diagnostic;
 
     fn try_from(stream: TokenStream) -> Result<Self, Self::Error> {
@@ -68,7 +68,7 @@ impl<'a> TryFrom<TokenStream> for Function<'a> {
     }
 }
 
-impl<'a> ToTokens for Function<'a> {
+impl ToTokens for Function<'_> {
     fn to_tokens(&self, tokens: &mut ::proc_macro2::TokenStream) {
         let name = QuotableBorrowedStr(&self.0.name);
         let disabled = self.0.disabled;

--- a/azure-functions-codegen/src/func/invoker.rs
+++ b/azure-functions-codegen/src/func/invoker.rs
@@ -8,13 +8,11 @@ const INVOKER_PREFIX: &'static str = "__invoke_";
 
 pub struct Invoker<'a>(pub &'a ItemFn);
 
-impl<'a> Invoker<'a> {
+impl Invoker<'a> {
     pub fn name(&self) -> String {
         format!("{}{}", INVOKER_PREFIX, self.0.ident)
     }
-}
 
-impl<'a> Invoker<'a> {
     fn get_args(&self) -> (Vec<&'a Ident>, Vec<&'a Type>) {
         self.iter_args()
             .filter_map(|(name, arg_type)| {
@@ -70,7 +68,7 @@ impl<'a> Invoker<'a> {
     }
 }
 
-impl<'a> ToTokens for Invoker<'a> {
+impl ToTokens for Invoker<'_> {
     fn to_tokens(&self, tokens: &mut ::proc_macro2::TokenStream) {
         let invoker = Ident::new(
             &format!("{}{}", INVOKER_PREFIX, self.0.ident.to_string()),

--- a/azure-functions-codegen/src/func/mod.rs
+++ b/azure-functions-codegen/src/func/mod.rs
@@ -145,8 +145,8 @@ fn bind_argument(
                         Pat::Ident(name) => {
                             let name_str = name.ident.to_string();
                             match binding_args.remove(&name_str) {
-                                Some(args) => (*factory)(&args),
-                                None => (*factory)(&AttributeArguments::with_name(
+                                Some(args) => (*factory)(args),
+                                None => (*factory)(AttributeArguments::with_name(
                                     &name_str,
                                     name.ident.span(),
                                 )),
@@ -193,8 +193,8 @@ fn bind_return_type(
         ReturnType::Type(_, ty) => match &**ty {
             Type::Path(tp) => match OUTPUT_BINDINGS.get(last_ident_in_path(&tp.path).as_str()) {
                 Some(factory) => match binding_args.remove(RETURN_BINDING_NAME) {
-                    Some(args) => (*factory)(&args),
-                    None => (*factory)(&AttributeArguments::with_name(
+                    Some(args) => (*factory)(args),
+                    None => (*factory)(AttributeArguments::with_name(
                         RETURN_BINDING_NAME,
                         ty.span(),
                     )),

--- a/azure-functions-codegen/src/func/return_value_setter.rs
+++ b/azure-functions-codegen/src/func/return_value_setter.rs
@@ -3,7 +3,7 @@ use syn::ReturnType;
 
 pub struct ReturnValueSetter<'a>(pub &'a ReturnType);
 
-impl<'a> ToTokens for ReturnValueSetter<'a> {
+impl ToTokens for ReturnValueSetter<'_> {
     fn to_tokens(&self, tokens: &mut ::proc_macro2::TokenStream) {
         match self.0 {
             ReturnType::Default => {}

--- a/azure-functions-codegen/src/lib.rs
+++ b/azure-functions-codegen/src/lib.rs
@@ -1,7 +1,7 @@
 //! # Azure Functions for Rust
 //!
 //! This crate supports the code generation for the `azure-functions` crate.
-
+#![feature(rust_2018_preview)]
 #![feature(proc_macro_diagnostic)]
 #![feature(drain_filter)]
 #![feature(try_from)]

--- a/azure-functions-codegen/src/util.rs
+++ b/azure-functions-codegen/src/util.rs
@@ -129,7 +129,7 @@ impl Synom for ArgumentAssignmentExpr {
 
 pub struct QuotableBorrowedStr<'a>(pub &'a str);
 
-impl<'a> ToTokens for QuotableBorrowedStr<'a> {
+impl ToTokens for QuotableBorrowedStr<'_> {
     fn to_tokens(&self, tokens: &mut ::proc_macro2::TokenStream) {
         let s = self.0;
         quote!(::std::borrow::Cow::Borrowed(#s)).to_tokens(tokens);

--- a/azure-functions-shared/src/context.rs
+++ b/azure-functions-shared/src/context.rs
@@ -9,7 +9,7 @@ pub struct Context<'a> {
     name: &'a str,
 }
 
-impl<'a> Context<'a> {
+impl Context<'a> {
     /// Creates a new function invocation context.
     pub fn new(invocation_id: &'a str, function_id: &'a str, name: &'a str) -> Self {
         Context {

--- a/azure-functions-shared/src/lib.rs
+++ b/azure-functions-shared/src/lib.rs
@@ -1,6 +1,7 @@
 //! # Azure Functions for Rust
 //!
 //! This crate shares types between the `azure-functions-codegen` and `azure-functions` crates.
+#![feature(rust_2018_preview)]
 #![feature(use_extern_macros)]
 #![feature(proc_macro_mod)]
 #![feature(proc_macro_gen)]

--- a/azure-functions/src/bindings/http_request.rs
+++ b/azure-functions/src/bindings/http_request.rs
@@ -29,7 +29,7 @@ use std::collections::HashMap;
 #[derive(Debug)]
 pub struct HttpRequest<'a>(&'a protocol::RpcHttp);
 
-impl<'a> HttpRequest<'a> {
+impl HttpRequest<'_> {
     /// Gets the HTTP method (e.g. "GET") for the request.
     pub fn method(&self) -> &str {
         &self.0.method
@@ -89,7 +89,7 @@ impl<'a> HttpRequest<'a> {
     }
 }
 
-impl<'a> From<&'a protocol::TypedData> for HttpRequest<'a> {
+impl From<&'a protocol::TypedData> for HttpRequest<'a> {
     fn from(data: &'a protocol::TypedData) -> Self {
         if !data.has_http() {
             panic!("unexpected type data for HTTP request.");
@@ -98,6 +98,6 @@ impl<'a> From<&'a protocol::TypedData> for HttpRequest<'a> {
     }
 }
 
-impl<'a> Trigger<'a> for HttpRequest<'a> {
+impl Trigger<'a> for HttpRequest<'a> {
     fn read_metadata(&mut self, _: &'a HashMap<String, protocol::TypedData>) {}
 }

--- a/azure-functions/src/bindings/http_response.rs
+++ b/azure-functions/src/bindings/http_response.rs
@@ -164,17 +164,17 @@ impl Into<protocol::RpcHttp> for HttpResponse {
     }
 }
 
-impl<'a, T> From<T> for HttpResponse
+impl<T> From<T> for HttpResponse
 where
-    T: Into<Body<'a>>,
+    T: Into<Body<'_>>,
 {
     fn from(data: T) -> Self {
         HttpResponse::build().body(data).into()
     }
 }
 
-impl<'a> From<&'a mut ResponseBuilder> for HttpResponse {
-    fn from(builder: &'a mut ResponseBuilder) -> Self {
+impl From<&mut ResponseBuilder> for HttpResponse {
+    fn from(builder: &mut ResponseBuilder) -> Self {
         replace(&mut builder.0, HttpResponse::new())
     }
 }

--- a/azure-functions/src/bindings/queue_message.rs
+++ b/azure-functions/src/bindings/queue_message.rs
@@ -5,9 +5,9 @@ use rpc::protocol;
 #[derive(Debug)]
 pub struct QueueMessage(protocol::TypedData);
 
-impl<'a, T> From<T> for QueueMessage
+impl<T> From<T> for QueueMessage
 where
-    T: Into<MessageBody<'a>>,
+    T: Into<MessageBody<'_>>,
 {
     fn from(data: T) -> Self {
         let data: MessageBody = data.into();
@@ -15,13 +15,7 @@ where
     }
 }
 
-impl<'a> From<&'a MessageBody<'a>> for QueueMessage {
-    fn from(data: &'a MessageBody) -> Self {
-        QueueMessage(data.clone().into())
-    }
-}
-
-impl<'a> Into<protocol::TypedData> for QueueMessage {
+impl Into<protocol::TypedData> for QueueMessage {
     fn into(self) -> protocol::TypedData {
         self.0
     }

--- a/azure-functions/src/bindings/queue_trigger.rs
+++ b/azure-functions/src/bindings/queue_trigger.rs
@@ -23,14 +23,14 @@ pub struct QueueTrigger<'a> {
     pub pop_receipt: &'a str,
 }
 
-impl<'a> QueueTrigger<'a> {
+impl QueueTrigger<'_> {
     /// Gets the message that triggered the function.
     pub fn message(&self) -> MessageBody {
         MessageBody::from(self.data)
     }
 }
 
-impl<'a> From<&'a protocol::TypedData> for QueueTrigger<'a> {
+impl From<&'a protocol::TypedData> for QueueTrigger<'a> {
     fn from(data: &'a protocol::TypedData) -> Self {
         QueueTrigger {
             data: data,
@@ -44,7 +44,7 @@ impl<'a> From<&'a protocol::TypedData> for QueueTrigger<'a> {
     }
 }
 
-impl<'a> Trigger<'a> for QueueTrigger<'a> {
+impl Trigger<'a> for QueueTrigger<'a> {
     fn read_metadata(&mut self, metadata: &'a HashMap<String, protocol::TypedData>) {
         if let Some(id) = metadata.get("Id") {
             self.id = id.get_string();

--- a/azure-functions/src/bindings/timer_info.rs
+++ b/azure-functions/src/bindings/timer_info.rs
@@ -32,7 +32,7 @@ pub struct TimerInfo {
     pub is_past_due: bool,
 }
 
-impl<'a> From<&'a protocol::TypedData> for TimerInfo {
+impl From<&'a protocol::TypedData> for TimerInfo {
     fn from(data: &'a protocol::TypedData) -> Self {
         if !data.has_json() {
             panic!("expected JSON data for timer trigger binding");
@@ -42,6 +42,6 @@ impl<'a> From<&'a protocol::TypedData> for TimerInfo {
     }
 }
 
-impl<'a> Trigger<'a> for TimerInfo {
+impl Trigger<'a> for TimerInfo {
     fn read_metadata(&mut self, _: &'a HashMap<String, protocol::TypedData>) {}
 }

--- a/azure-functions/src/cli.rs
+++ b/azure-functions/src/cli.rs
@@ -1,6 +1,6 @@
 use clap::{App, Arg, SubCommand};
 
-pub fn create_app<'a, 'b>() -> App<'a, 'b> {
+pub fn create_app() -> App<'a, 'b> {
     App::new("Azure Functions Language Worker for Rust")
         .version(env!("CARGO_PKG_VERSION"))
         .about("Provides an Azure Functions Worker for functions written in Rust.")

--- a/azure-functions/src/http/body.rs
+++ b/azure-functions/src/http/body.rs
@@ -19,7 +19,7 @@ pub enum Body<'a> {
     Bytes(Cow<'a, [u8]>),
 }
 
-impl<'a> Body<'a> {
+impl Body<'_> {
     /// Gets the default content type for a body.
     ///
     /// Returns `application/json` for `Body::Json`.
@@ -68,7 +68,7 @@ impl<'a> Body<'a> {
     }
 
     /// Deserializes the body as JSON to the requested type.
-    pub fn from_json<'b, T>(&'b self) -> Result<T>
+    pub fn from_json<T>(&'b self) -> Result<T>
     where
         T: Deserialize<'b>,
     {
@@ -83,13 +83,13 @@ impl<'a> Body<'a> {
     }
 }
 
-impl<'a> fmt::Display for Body<'a> {
+impl fmt::Display for Body<'_> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.as_str().unwrap_or(""))
     }
 }
 
-impl<'a> From<&'a protocol::TypedData> for Body<'a> {
+impl From<&'a protocol::TypedData> for Body<'a> {
     fn from(data: &'a protocol::TypedData) -> Self {
         if data.has_string() {
             return Body::String(Cow::Borrowed(data.get_string()));
@@ -108,37 +108,37 @@ impl<'a> From<&'a protocol::TypedData> for Body<'a> {
     }
 }
 
-impl<'a> From<&'a str> for Body<'a> {
+impl From<&'a str> for Body<'a> {
     fn from(data: &'a str) -> Self {
         Body::String(Cow::Borrowed(data))
     }
 }
 
-impl<'a> From<String> for Body<'a> {
+impl From<String> for Body<'_> {
     fn from(data: String) -> Self {
         Body::String(Cow::Owned(data))
     }
 }
 
-impl<'a> From<Value> for Body<'a> {
+impl From<Value> for Body<'_> {
     fn from(data: Value) -> Self {
         Body::Json(Cow::Owned(data.to_string()))
     }
 }
 
-impl<'a> From<&'a [u8]> for Body<'a> {
+impl From<&'a [u8]> for Body<'a> {
     fn from(data: &'a [u8]) -> Self {
         Body::Bytes(Cow::Borrowed(data))
     }
 }
 
-impl<'a> From<Vec<u8>> for Body<'a> {
+impl From<Vec<u8>> for Body<'_> {
     fn from(data: Vec<u8>) -> Self {
         Body::Bytes(Cow::Owned(data))
     }
 }
 
-impl<'a> Into<protocol::TypedData> for Body<'a> {
+impl Into<protocol::TypedData> for Body<'_> {
     fn into(self) -> protocol::TypedData {
         let mut data = protocol::TypedData::new();
 

--- a/azure-functions/src/http/response_builder.rs
+++ b/azure-functions/src/http/response_builder.rs
@@ -82,7 +82,10 @@ impl ResponseBuilder {
     ///     message
     /// );
     /// ```
-    pub fn body<'a, B: Into<Body<'a>>>(&mut self, body: B) -> &mut Self {
+    pub fn body<B>(&mut self, body: B) -> &mut Self
+    where
+        B: Into<Body<'a>>,
+    {
         let body = body.into();
         match &body {
             Body::Empty => {

--- a/azure-functions/src/lib.rs
+++ b/azure-functions/src/lib.rs
@@ -91,6 +91,7 @@
 //! The above Azure Function can be invoked with `http://localhost:5000/api/greet?name=John`.
 //!
 //! The expected response would be `Hello from Rust, John!`.
+#![feature(rust_2018_preview)]
 #![feature(use_extern_macros)]
 #![feature(proc_macro_mod)]
 #![feature(proc_macro_gen)]
@@ -141,7 +142,7 @@ use std::fs;
 use std::path::Path;
 use std::sync::{Arc, Mutex};
 
-fn initialize_app(worker_path: &str, script_root: &str, registry: Arc<Mutex<Registry>>) {
+fn initialize_app(worker_path: &str, script_root: &str, registry: Arc<Mutex<Registry<'static>>>) {
     const FUNCTION_FILE: &'static str = "function.json";
     const RUST_SCRIPT_FILE: &'static str = "run.rs";
 
@@ -238,12 +239,12 @@ fn initialize_app(worker_path: &str, script_root: &str, registry: Arc<Mutex<Regi
     }
 }
 
-fn run_worker<'a>(
+fn run_worker(
     worker_id: &str,
     host: &str,
     port: u32,
     max_message_length: Option<i32>,
-    registry: Arc<Mutex<Registry>>,
+    registry: Arc<Mutex<Registry<'static>>>,
 ) {
     let client = rpc::Client::new(worker_id.to_string(), max_message_length);
 

--- a/azure-functions/src/queue/message_body.rs
+++ b/azure-functions/src/queue/message_body.rs
@@ -17,7 +17,7 @@ pub enum MessageBody<'a> {
     Bytes(Cow<'a, [u8]>),
 }
 
-impl<'a> MessageBody<'a> {
+impl MessageBody<'_> {
     /// Gets the contents of the message as a string.
     ///
     /// Returns None if there is no valid string representation of the message.
@@ -39,7 +39,7 @@ impl<'a> MessageBody<'a> {
     }
 
     /// Deserializes the message as JSON to the requested type.
-    pub fn from_json<'b, T>(&'b self) -> Result<T>
+    pub fn from_json<T>(&'b self) -> Result<T>
     where
         T: Deserialize<'b>,
     {
@@ -53,13 +53,13 @@ impl<'a> MessageBody<'a> {
     }
 }
 
-impl<'a> fmt::Display for MessageBody<'a> {
+impl fmt::Display for MessageBody<'_> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", self.as_str().unwrap_or(""))
     }
 }
 
-impl<'a> From<&'a protocol::TypedData> for MessageBody<'a> {
+impl From<&'a protocol::TypedData> for MessageBody<'a> {
     fn from(data: &'a protocol::TypedData) -> Self {
         if data.has_string() {
             return MessageBody::String(Cow::Borrowed(data.get_string()));
@@ -78,37 +78,37 @@ impl<'a> From<&'a protocol::TypedData> for MessageBody<'a> {
     }
 }
 
-impl<'a> From<&'a str> for MessageBody<'a> {
+impl From<&'a str> for MessageBody<'a> {
     fn from(data: &'a str) -> Self {
         MessageBody::String(Cow::Borrowed(data))
     }
 }
 
-impl<'a> From<String> for MessageBody<'a> {
+impl From<String> for MessageBody<'_> {
     fn from(data: String) -> Self {
         MessageBody::String(Cow::Owned(data))
     }
 }
 
-impl<'a> From<Value> for MessageBody<'a> {
+impl From<Value> for MessageBody<'_> {
     fn from(data: Value) -> Self {
         MessageBody::Json(Cow::Owned(data.to_string()))
     }
 }
 
-impl<'a> From<&'a [u8]> for MessageBody<'a> {
+impl From<&'a [u8]> for MessageBody<'a> {
     fn from(data: &'a [u8]) -> Self {
         MessageBody::Bytes(Cow::Borrowed(data))
     }
 }
 
-impl<'a> From<Vec<u8>> for MessageBody<'a> {
+impl From<Vec<u8>> for MessageBody<'_> {
     fn from(data: Vec<u8>) -> Self {
         MessageBody::Bytes(Cow::Owned(data))
     }
 }
 
-impl<'a> Into<protocol::TypedData> for MessageBody<'a> {
+impl Into<protocol::TypedData> for MessageBody<'_> {
     fn into(self) -> protocol::TypedData {
         let mut data = protocol::TypedData::new();
 

--- a/azure-functions/src/registry.rs
+++ b/azure-functions/src/registry.rs
@@ -2,13 +2,13 @@ use codegen::Function;
 use std::collections::hash_map::Iter;
 use std::collections::HashMap;
 
-pub struct Registry {
-    functions: HashMap<String, &'static Function>,
-    registered: HashMap<String, &'static Function>,
+pub struct Registry<'a> {
+    functions: HashMap<String, &'a Function>,
+    registered: HashMap<String, &'a Function>,
 }
 
-impl Registry {
-    pub fn new(functions: &[&'static Function]) -> Registry {
+impl Registry<'a> {
+    pub fn new(functions: &[&'a Function]) -> Registry<'a> {
         Registry {
             functions: functions
                 .iter()
@@ -33,11 +33,11 @@ impl Registry {
         }
     }
 
-    pub fn get(&self, id: &str) -> Option<&'static Function> {
+    pub fn get(&self, id: &str) -> Option<&'a Function> {
         self.registered.get(id).map(|x| *x)
     }
 
-    pub fn iter(&self) -> Iter<String, &'static Function> {
+    pub fn iter(&self) -> Iter<String, &'a Function> {
         self.functions.iter()
     }
 }

--- a/azure-functions/src/rpc/client.rs
+++ b/azure-functions/src/rpc/client.rs
@@ -146,7 +146,7 @@ impl Client {
 
     pub fn process_all_messages(
         mut self,
-        registry: Arc<Mutex<Registry>>,
+        registry: Arc<Mutex<Registry<'static>>>,
     ) -> impl Future<Item = Client, Error = ()> {
         let pool = tokio_threadpool::ThreadPool::new();
 
@@ -219,7 +219,7 @@ impl Client {
     }
 
     fn handle_function_load_request(
-        registry: Arc<Mutex<Registry>>,
+        registry: Arc<Mutex<Registry<'static>>>,
         sender: Sender,
         req: &protocol::FunctionLoadRequest,
     ) {
@@ -259,7 +259,7 @@ impl Client {
     }
 
     fn handle_invocation_request(
-        registry: Arc<Mutex<Registry>>,
+        registry: Arc<Mutex<Registry<'static>>>,
         sender: Sender,
         req: &protocol::InvocationRequest,
     ) {
@@ -334,7 +334,7 @@ impl Client {
     }
 
     fn handle_request(
-        registry: Arc<Mutex<Registry>>,
+        registry: Arc<Mutex<Registry<'static>>>,
         sender: Sender,
         msg: &protocol::StreamingMessage,
     ) {

--- a/azure-functions/src/util.rs
+++ b/azure-functions/src/util.rs
@@ -4,7 +4,7 @@ use serde::Deserialize;
 use serde_json::from_str;
 use std::str::{from_utf8, FromStr};
 
-pub fn convert_from<'a, T>(data: &'a protocol::TypedData) -> Result<T, ()>
+pub fn convert_from<T>(data: &'a protocol::TypedData) -> Result<T, ()>
 where
     T: FromStr + Deserialize<'a>,
 {


### PR DESCRIPTION
Rust 2018 will have support for in-band lifetimes, which means lifetimes can be
declared when first used rather than in `impl<...>` or `fn func<...>` generic
parameter lists.

This commit turns on Rust 2018 support and scrubs unnecessary lifetime
declarations.