### PR TITLE
Add tests for the azure-functions crate.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,6 +40,7 @@ dependencies = [
  "futures 0.1.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "grpcio 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "matches 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.70 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.70 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -255,6 +256,8 @@ version = "0.1.0"
 dependencies = [
  "azure-functions 0.1.4",
  "log 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 1.0.70 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive 1.0.70 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/azure-functions/Cargo.toml
+++ b/azure-functions/Cargo.toml
@@ -18,3 +18,6 @@ serde = "1.0.66"
 serde_json = "1.0.20"
 serde_derive = "1.0.66"
 chrono = { version = "0.4.4", features = ["serde"] }
+
+[dev-dependencies]
+matches = "0.1.7"

--- a/azure-functions/src/bindings/http_response.rs
+++ b/azure-functions/src/bindings/http_response.rs
@@ -1,13 +1,10 @@
 use http::{Body, ResponseBuilder, Status};
 use rpc::protocol;
 use std::collections::HashMap;
-use std::mem::replace;
 
 /// Represents a HTTP output binding.
 ///
-/// # Usage
-///
-/// Responses can be easily created for any type that implements `Into<Body>`.
+/// Responses can be created for any type that implements `Into<Body>`.
 ///
 /// # Examples
 ///
@@ -27,10 +24,7 @@ use std::mem::replace;
 ///         .unwrap(),
 ///     "text/plain");
 /// assert_eq!(
-///     match response.body() {
-///         Body::String(s) => s,
-///         _ => panic!("unexpected body.")
-///     },
+///     response.body().as_str().unwrap(),
 ///     "hello world"
 /// );
 /// ```
@@ -54,10 +48,7 @@ use std::mem::replace;
 ///     "application/json"
 /// );
 /// assert_eq!(
-///     match response.body() {
-///         Body::Json(s) => s,
-///         _ => panic!("unexpected body.")
-///     },
+///     response.body().as_str().unwrap(),
 ///     "{\"hello\":\"world!\"}"
 /// );
 /// ```
@@ -68,7 +59,7 @@ use std::mem::replace;
 /// use azure_functions::bindings::HttpResponse;
 /// use azure_functions::http::{Body, Status};
 ///
-/// let response: HttpResponse = [1u8, 2u8, 3u8][..].into();
+/// let response: HttpResponse = [1, 2, 3][..].into();
 ///
 /// assert_eq!(response.status(), Status::Ok);
 /// assert_eq!(
@@ -79,11 +70,8 @@ use std::mem::replace;
 ///     "application/octet-stream"
 /// );
 /// assert_eq!(
-///     &match response.body() {
-///         Body::Bytes(bytes) => bytes,
-///         _ => panic!("unexpected body.")
-///     }[..],
-///     [1u8, 2u8, 3u8]
+///     response.body().as_bytes(),
+///     [1, 2, 3]
 /// );
 /// ```
 ///
@@ -111,10 +99,7 @@ use std::mem::replace;
 ///     url
 /// );
 /// assert_eq!(
-///     match response.body() {
-///         Body::String(s) => s,
-///         _ => panic!("unexpected body.")
-///     },
+///     response.body().as_str().unwrap(),
 ///     body
 /// );
 /// ```
@@ -133,16 +118,45 @@ impl HttpResponse {
     }
 
     /// Creates a new [ResponseBuilder](../http/struct.ResponseBuilder.html) for building a response.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use azure_functions::bindings::HttpResponse;
+    /// use azure_functions::http::Status;
+    ///
+    /// let response: HttpResponse = HttpResponse::build().status(Status::NotFound).into();
+    /// assert_eq!(response.status(), Status::NotFound);
+    /// ```
     pub fn build() -> ResponseBuilder {
         ResponseBuilder::new()
     }
 
     /// Gets the status code for the response.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use azure_functions::bindings::HttpResponse;
+    /// use azure_functions::http::Status;
+    ///
+    /// let response: HttpResponse = HttpResponse::build().status(Status::BadRequest).into();
+    /// assert_eq!(response.status(), Status::BadRequest);
+    /// ```
     pub fn status(&self) -> Status {
         self.status
     }
 
     /// Gets the body of the response.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use azure_functions::bindings::HttpResponse;
+    ///
+    /// let response: HttpResponse = HttpResponse::build().body("example").into();
+    /// assert_eq!(response.body().as_str().unwrap(), "example");
+    /// ```
     pub fn body(&self) -> Body {
         if self.data.has_body() {
             Body::from(self.data.get_body())
@@ -152,15 +166,17 @@ impl HttpResponse {
     }
 
     /// Gets the headers of the response.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use azure_functions::bindings::HttpResponse;
+    ///
+    /// let response: HttpResponse = HttpResponse::build().header("Content-Type", "text/plain").into();
+    /// assert_eq!(response.headers().get("Content-Type").unwrap(), "text/plain");
+    /// ```
     pub fn headers(&self) -> &HashMap<String, String> {
         &self.data.headers
-    }
-}
-
-impl Into<protocol::RpcHttp> for HttpResponse {
-    fn into(mut self) -> protocol::RpcHttp {
-        self.data.set_status_code(self.status.to_string());
-        self.data
     }
 }
 
@@ -173,16 +189,130 @@ where
     }
 }
 
-impl From<&mut ResponseBuilder> for HttpResponse {
-    fn from(builder: &mut ResponseBuilder) -> Self {
-        replace(&mut builder.0, HttpResponse::new())
+impl From<ResponseBuilder> for HttpResponse {
+    fn from(builder: ResponseBuilder) -> Self {
+        builder.0
     }
 }
 
 impl Into<protocol::TypedData> for HttpResponse {
-    fn into(self) -> protocol::TypedData {
+    fn into(mut self) -> protocol::TypedData {
+        self.data.set_status_code(self.status.to_string());
+
         let mut data = protocol::TypedData::new();
         data.set_http(self.data);
         data
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_is_empty_by_default() {
+        let response = HttpResponse::new();
+
+        assert_eq!(response.status(), Status::Ok);
+        assert!(matches!(response.body(), Body::Empty));
+    }
+
+    #[test]
+    fn it_is_empty_from_a_builder() {
+        let response: HttpResponse = HttpResponse::build().into();
+
+        assert_eq!(response.status(), Status::Ok);
+        assert!(matches!(response.body(), Body::Empty));
+    }
+
+    #[test]
+    fn it_builds_with_a_status() {
+        let response: HttpResponse = HttpResponse::build().status(Status::Continue).into();
+
+        assert_eq!(response.status(), Status::Continue);
+    }
+
+    #[test]
+    fn it_builds_with_a_string_body() {
+        const BODY: &'static str = "test body";
+
+        let response: HttpResponse = HttpResponse::build().body(BODY).into();
+
+        assert_eq!(
+            response.headers().get("Content-Type").unwrap(),
+            "text/plain"
+        );
+        assert_eq!(response.body().as_str().unwrap(), BODY);
+    }
+
+    #[test]
+    fn it_builds_with_a_json_body() {
+        #[derive(Serialize, Deserialize)]
+        struct Data {
+            message: String,
+        };
+
+        const MESSAGE: &'static str = "test";
+
+        let data = Data {
+            message: MESSAGE.to_string(),
+        };
+
+        let response: HttpResponse = HttpResponse::build()
+            .body(::serde_json::to_value(data).unwrap())
+            .into();
+
+        assert_eq!(
+            response.headers().get("Content-Type").unwrap(),
+            "application/json"
+        );
+        assert_eq!(
+            response.body().from_json::<Data>().unwrap().message,
+            MESSAGE
+        );
+    }
+
+    #[test]
+    fn it_builds_with_a_bytes_body() {
+        const BODY: &'static [u8] = &[1, 2, 3];
+
+        let response: HttpResponse = HttpResponse::build().body(BODY).into();
+
+        assert_eq!(
+            response.headers().get("Content-Type").unwrap(),
+            "application/octet-stream"
+        );
+        assert_eq!(response.body().as_bytes(), BODY);
+    }
+
+    #[test]
+    fn it_builds_with_headers() {
+        let response: HttpResponse = HttpResponse::build()
+            .header("header1", "value1")
+            .header("header2", "value2")
+            .header("header3", "value3")
+            .into();
+
+        assert_eq!(response.headers().get("header1").unwrap(), "value1");
+        assert_eq!(response.headers().get("header2").unwrap(), "value2");
+        assert_eq!(response.headers().get("header3").unwrap(), "value3");
+    }
+
+    #[test]
+    fn it_converts_to_typed_data() {
+        let response: HttpResponse = HttpResponse::build()
+            .status(Status::BadRequest)
+            .header("header", "value")
+            .body("body")
+            .into();
+
+        let data: protocol::TypedData = response.into();
+        assert!(data.has_http());
+
+        let http = data.get_http();
+        assert_eq!(http.get_status_code(), "400");
+        assert_eq!(http.get_headers().get("header").unwrap(), "value");
+        assert!(http.get_body().has_string());
+        assert_eq!(http.get_body().get_string(), "body");
     }
 }

--- a/azure-functions/src/bindings/queue_message.rs
+++ b/azure-functions/src/bindings/queue_message.rs
@@ -2,8 +2,62 @@ use queue::MessageBody;
 use rpc::protocol;
 
 /// Represents an Azure Storage Queue message output binding.
+///
+/// Queue messages can be created for any type that implements `Into<MessageBody>`.
+///
+/// # Examples
+///
+/// Creating a queue message from a string:
+///
+/// ```rust
+/// use azure_functions::bindings::QueueMessage;
+///
+/// let message: QueueMessage = "hello world!".into();
+/// assert_eq!(message.body().as_str().unwrap(), "hello world!");
+/// ```
+///
+/// Creating a queue message from a JSON value (see the [json! macro](https://docs.serde.rs/serde_json/macro.json.html) from the `serde_json` crate):
+///
+/// ```rust
+/// # #[macro_use] extern crate serde_json;
+/// # extern crate azure_functions;
+/// use azure_functions::bindings::QueueMessage;
+///
+/// let message: QueueMessage = json!({ "hello": "world!" }).into();
+///
+/// assert_eq!(message.body().as_str().unwrap(), r#"{"hello":"world!"}"#);
+/// ```
+///
+/// Creating a queue message from a sequence of bytes:
+///
+/// ```rust
+/// use azure_functions::bindings::QueueMessage;
+///
+/// let message: QueueMessage = [1, 2, 3][..].into();
+///
+/// assert_eq!(
+///     message.body().as_bytes(),
+///     [1, 2, 3]
+/// );
+/// ```
 #[derive(Debug)]
 pub struct QueueMessage(protocol::TypedData);
+
+impl QueueMessage {
+    /// Gets the body of the message.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use azure_functions::bindings::QueueMessage;
+    ///
+    /// let message: QueueMessage = "hello world!".into();
+    /// assert_eq!(message.body().as_str().unwrap(), "hello world!");
+    /// ```
+    pub fn body(&self) -> MessageBody {
+        (&self.0).into()
+    }
+}
 
 impl<T> From<T> for QueueMessage
 where
@@ -18,5 +72,52 @@ where
 impl Into<protocol::TypedData> for QueueMessage {
     fn into(self) -> protocol::TypedData {
         self.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_has_a_string_body() {
+        const BODY: &'static str = "test body";
+
+        let message: QueueMessage = BODY.into();
+        assert_eq!(message.body().as_str().unwrap(), BODY);
+
+        let data: protocol::TypedData = message.into();
+        assert_eq!(data.get_string(), BODY);
+    }
+
+    #[test]
+    fn it_has_a_json_body() {
+        #[derive(Serialize, Deserialize)]
+        struct Data {
+            message: String,
+        };
+
+        const MESSAGE: &'static str = "test";
+
+        let data = Data {
+            message: MESSAGE.to_string(),
+        };
+
+        let message: QueueMessage = ::serde_json::to_value(data).unwrap().into();
+        assert_eq!(message.body().from_json::<Data>().unwrap().message, MESSAGE);
+
+        let data: protocol::TypedData = message.into();
+        assert_eq!(data.get_json(), r#"{"message":"test"}"#);
+    }
+
+    #[test]
+    fn it_has_a_bytes_body() {
+        const BODY: &'static [u8] = &[1, 2, 3];
+
+        let message: QueueMessage = BODY.into();
+        assert_eq!(message.body().as_bytes(), BODY);
+
+        let data: protocol::TypedData = message.into();
+        assert_eq!(data.get_bytes(), BODY);
     }
 }

--- a/azure-functions/src/bindings/timer_info.rs
+++ b/azure-functions/src/bindings/timer_info.rs
@@ -26,6 +26,7 @@ use timer::ScheduleStatus;
 #[serde(rename_all = "PascalCase")]
 pub struct TimerInfo {
     /// The schedule status for the timer.
+    ///
     /// If schedule monitoring is not enabled for the timer, this field will be `None`.
     pub schedule_status: Option<ScheduleStatus>,
     /// Determines if the timer invocation is due to a missed schedule occurrence.
@@ -44,4 +45,30 @@ impl From<&'a protocol::TypedData> for TimerInfo {
 
 impl Trigger<'a> for TimerInfo {
     fn read_metadata(&mut self, _: &'a HashMap<String, protocol::TypedData>) {}
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_has_json_data() {
+        const JSON: &'static str = r#"{"Schedule":{},"ScheduleStatus":{"Last":"0001-01-01T00:00:00","Next":"2018-07-24T23:24:00-07:00","LastUpdated":"0001-01-01T00:00:00"},"IsPastDue":true}"#;
+
+        let mut data = protocol::TypedData::new();
+        data.set_json(JSON.to_string());
+
+        let info: TimerInfo = (&data).into();
+
+        assert!(info.schedule_status.is_some());
+        assert!(info.is_past_due);
+
+        let status = info.schedule_status.as_ref().unwrap();
+        assert_eq!(status.last.to_rfc3339(), "0001-01-01T00:00:00+00:00");
+        assert_eq!(status.next.to_rfc3339(), "2018-07-25T06:24:00+00:00");
+        assert_eq!(
+            status.last_updated.to_rfc3339(),
+            "0001-01-01T00:00:00+00:00"
+        );
+    }
 }

--- a/azure-functions/src/http/status.rs
+++ b/azure-functions/src/http/status.rs
@@ -109,3 +109,21 @@ impl From<u16> for Status {
         Status::from_code(code)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_converts_to_string() {
+        assert_eq!(Status::Ok.to_string(), "200");
+        assert_eq!(Status::NotFound.to_string(), "404");
+    }
+
+    #[test]
+    fn it_converts_from_code() {
+        let status: Status = 200.into();
+        assert_eq!(status, Status::Ok);
+        assert_eq!(Status::from_code(404), Status::NotFound);
+    }
+}

--- a/azure-functions/src/lib.rs
+++ b/azure-functions/src/lib.rs
@@ -111,6 +111,9 @@ extern crate serde_json;
 extern crate serde_derive;
 extern crate chrono;
 extern crate tokio_threadpool;
+#[cfg(test)]
+#[macro_use(matches)]
+extern crate matches;
 
 #[doc(no_inline)]
 pub use azure_functions_codegen::func;

--- a/azure-functions/src/registry.rs
+++ b/azure-functions/src/registry.rs
@@ -7,7 +7,7 @@ pub struct Registry<'a> {
     registered: HashMap<String, &'a Function>,
 }
 
-impl Registry<'a> {
+impl<'a> Registry<'a> {
     pub fn new(functions: &[&'a Function]) -> Registry<'a> {
         Registry {
             functions: functions
@@ -39,5 +39,83 @@ impl Registry<'a> {
 
     pub fn iter(&self) -> Iter<String, &'a Function> {
         self.functions.iter()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::borrow::Cow;
+
+    #[test]
+    fn it_creates_an_emptry_registry_from_an_empty_slice() {
+        let registry = Registry::new(&[]);
+        assert_eq!(registry.iter().count(), 0);
+    }
+
+    #[test]
+    fn it_creates_a_registry_from_a_list_of_functions() {
+        let registry = Registry::new(&[
+            &Function {
+                name: Cow::Borrowed("function1"),
+                disabled: false,
+                bindings: Cow::Borrowed(&[]),
+                invoker_name: None,
+                invoker: None,
+            },
+            &Function {
+                name: Cow::Borrowed("function2"),
+                disabled: false,
+                bindings: Cow::Borrowed(&[]),
+                invoker_name: None,
+                invoker: None,
+            },
+            &Function {
+                name: Cow::Borrowed("function3"),
+                disabled: false,
+                bindings: Cow::Borrowed(&[]),
+                invoker_name: None,
+                invoker: None,
+            },
+        ]);
+        assert_eq!(registry.iter().count(), 3);
+        assert!(
+            registry
+                .iter()
+                .all(|(k, _)| *k == "function1" || *k == "function2" || *k == "function3")
+        );
+    }
+
+    #[test]
+    fn it_registers_a_function() {
+        let mut registry = Registry::new(&[&Function {
+            name: Cow::Borrowed("function1"),
+            disabled: false,
+            bindings: Cow::Borrowed(&[]),
+            invoker_name: None,
+            invoker: None,
+        }]);
+        assert_eq!(registry.iter().count(), 1);
+
+        let p1 = *registry.iter().nth(0).unwrap().1;
+
+        assert!(registry.register("id", "function1"));
+
+        let p2 = registry.get("id").unwrap();
+        assert_eq!(p1 as *const _, p2 as *const _);
+    }
+
+    #[test]
+    fn it_returns_false_if_function_is_not_present() {
+        let mut registry = Registry::new(&[&Function {
+            name: Cow::Borrowed("function1"),
+            disabled: false,
+            bindings: Cow::Borrowed(&[]),
+            invoker_name: None,
+            invoker: None,
+        }]);
+        assert_eq!(registry.iter().count(), 1);
+
+        assert_eq!(registry.register("id", "not_present"), false);
     }
 }

--- a/azure-functions/src/timer/schedule_status.rs
+++ b/azure-functions/src/timer/schedule_status.rs
@@ -34,3 +34,23 @@ where
         .map_err(|e| Error::custom(format!("{}", e)))
         .map(|dt| dt.with_timezone(&Utc))
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::from_str;
+
+    #[test]
+    fn it_deserializes_from_json() {
+        const JSON: &'static str = r#"{"Last":"0001-01-01T00:00:00","Next":"2018-07-24T23:24:00-07:00","LastUpdated":"2018-07-28T02:00:32+00:00"}"#;
+
+        let status: ScheduleStatus =
+            from_str(JSON).expect("failed to parse schedule status JSON data");
+        assert_eq!(status.last.to_rfc3339(), "0001-01-01T00:00:00+00:00");
+        assert_eq!(status.next.to_rfc3339(), "2018-07-25T06:24:00+00:00");
+        assert_eq!(
+            status.last_updated.to_rfc3339(),
+            "2018-07-28T02:00:32+00:00"
+        );
+    }
+}

--- a/azure-functions/src/util.rs
+++ b/azure-functions/src/util.rs
@@ -40,3 +40,73 @@ where
 
     Err(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_converts_from_string_data() {
+        const DATA: &'static str = "test";
+
+        let mut data = protocol::TypedData::new();
+        data.set_string(DATA.to_string());
+
+        let s: String = convert_from(&data).unwrap();
+        assert_eq!(s, DATA);
+    }
+
+    #[test]
+    fn it_converts_from_json_data() {
+        let mut data = protocol::TypedData::new();
+        data.set_json(r#""hello world""#.to_string());
+
+        let s: String = convert_from(&data).unwrap();
+        assert_eq!(s, "hello world");
+    }
+
+    #[test]
+    fn it_converts_from_bytes_data() {
+        let mut data = protocol::TypedData::new();
+        data.set_bytes(vec![
+            0x68, 0x65, 0x6C, 0x6C, 0x6F, 0x20, 0x77, 0x6F, 0x72, 0x6C, 0x64,
+        ]);
+
+        let s: String = convert_from(&data).unwrap();
+        assert_eq!(s, "hello world");
+    }
+
+    #[test]
+    fn it_converts_from_stream_data() {
+        let mut data = protocol::TypedData::new();
+        data.set_stream(vec![
+            0x68, 0x65, 0x6C, 0x6C, 0x6F, 0x20, 0x77, 0x6F, 0x72, 0x6C, 0x64,
+        ]);
+
+        let s: String = convert_from(&data).unwrap();
+        assert_eq!(s, "hello world");
+    }
+
+    #[test]
+    fn it_converts_from_int_data() {
+        const DATA: i64 = 42;
+
+        let mut data = protocol::TypedData::new();
+        data.set_int(DATA);
+
+        let d: i64 = convert_from(&data).unwrap();
+        assert_eq!(d, DATA);
+    }
+
+    #[test]
+    fn it_converts_from_double_data() {
+        const DATA: f64 = 42.24;
+
+        let mut data = protocol::TypedData::new();
+        data.set_double(DATA);
+
+        let d: f64 = convert_from(&data).unwrap();
+        assert_eq!(d, DATA);
+    }
+
+}

--- a/examples/http/Cargo.toml
+++ b/examples/http/Cargo.toml
@@ -6,4 +6,6 @@ authors = ["Peter Huene <peterhuene@protonmail.com>"]
 [dependencies]
 azure-functions = { version = "0.1.4", path = "../../azure-functions" }
 log = "0.4.2"
+serde = "1.0.66"
 serde_json = "1.0.21"
+serde_derive = "1.0.66"

--- a/examples/http/src/greet_with_json.rs
+++ b/examples/http/src/greet_with_json.rs
@@ -1,0 +1,30 @@
+use azure_functions::bindings::{HttpRequest, HttpResponse};
+use azure_functions::func;
+use azure_functions::http::Status;
+use serde_json::to_value;
+
+#[derive(Deserialize)]
+struct Request {
+    name: String,
+}
+
+#[derive(Serialize)]
+struct Response {
+    message: String,
+}
+
+#[func]
+#[binding(name = "req", auth_level = "anonymous")]
+pub fn greet_with_json(req: &HttpRequest) -> HttpResponse {
+    if let Ok(request) = req.body().from_json::<Request>() {
+        let response = Response {
+            message: format!("Hello from Rust, {}!", request.name),
+        };
+        return to_value(response).unwrap().into();
+    }
+
+    HttpResponse::build()
+        .status(Status::BadRequest)
+        .body("Invalid JSON request.")
+        .into()
+}

--- a/examples/http/src/main.rs
+++ b/examples/http/src/main.rs
@@ -3,9 +3,15 @@
 extern crate azure_functions;
 #[macro_use]
 extern crate log;
+extern crate serde;
+#[macro_use]
+extern crate serde_derive;
+extern crate serde_json;
 
 mod greet;
+mod greet_with_json;
 
 azure_functions::main!{
-    greet::greet
+    greet::greet,
+    greet_with_json::greet_with_json
 }


### PR DESCRIPTION
This commit adds a number of tests to improve test coverage for the
azure-functions crate.

A bug was caught during testing where `HttpResponse` was not properly setting
the status code in the response; this was due to the recent refactoring where
another `From` implementation was added and the existing `From` implementation
(where the status code was being set) was no longer being invoked.

The documentation examples have also been improved with this commit.