### PR TITLE
Implement tuple return values.

### DIFF
--- a/examples/blob/src/blob.rs
+++ b/examples/blob/src/blob.rs
@@ -1,8 +1,0 @@
-use azure_functions::bindings::BlobTrigger;
-use azure_functions::func;
-
-#[func]
-#[binding(name = "trigger", path = "test/{name}")]
-pub fn print_blob(trigger: &BlobTrigger) {
-    info!("Blob (as string): {:?}", trigger.blob.as_str());
-}

--- a/examples/blob/src/blob_watcher.rs
+++ b/examples/blob/src/blob_watcher.rs
@@ -1,0 +1,11 @@
+use azure_functions::bindings::BlobTrigger;
+use azure_functions::func;
+
+#[func]
+#[binding(name = "trigger", path = "watching/{name}")]
+pub fn blob_watcher(trigger: &BlobTrigger) {
+    info!(
+        "A blob was created at '{}' with contents: {:?}.",
+        trigger.path, trigger.blob
+    );
+}

--- a/examples/blob/src/copy_blob.rs
+++ b/examples/blob/src/copy_blob.rs
@@ -1,16 +1,14 @@
-use azure_functions::bindings::{Blob, HttpRequest};
+use azure_functions::bindings::{Blob, HttpRequest, HttpResponse};
 use azure_functions::func;
 
 #[func]
 #[binding(
     name = "_req",
     auth_level = "anonymous",
-    web_hook_type = "generic"
+    route = "copy/blob/{container}/{name}"
 )]
-#[binding(name = "blob", path = "copy/{filename}")]
-#[binding(name = "$return", path = "copy/{filename}.copy")]
-pub fn copy_blob(_req: &HttpRequest, blob: &Blob) -> Blob {
-    info!("Blob (as string): {:?}", blob.as_str());
-
-    blob.clone()
+#[binding(name = "blob", path = "{container}/{name}")]
+#[binding(name = "output1", path = "{container}/{name}.copy")]
+pub fn copy_blob(_req: &HttpRequest, blob: &Blob) -> (HttpResponse, Blob) {
+    ("blob has been copied.".into(), blob.clone())
 }

--- a/examples/blob/src/create_blob.rs
+++ b/examples/blob/src/create_blob.rs
@@ -1,0 +1,20 @@
+use azure_functions::bindings::{Blob, HttpRequest, HttpResponse};
+use azure_functions::func;
+use azure_functions::http::Status;
+
+#[func]
+#[binding(
+    name = "req",
+    auth_level = "anonymous",
+    route = "create/blob/{container}/{name}"
+)]
+#[binding(name = "output1", path = "{container}/{name}")]
+pub fn create_blob(req: &HttpRequest) -> (HttpResponse, Blob) {
+    (
+        HttpResponse::build()
+            .status(Status::Created)
+            .body("blob has been created.")
+            .into(),
+        req.body().as_bytes().into(),
+    )
+}

--- a/examples/blob/src/main.rs
+++ b/examples/blob/src/main.rs
@@ -4,10 +4,14 @@ extern crate azure_functions;
 #[macro_use]
 extern crate log;
 
-mod blob;
+mod blob_watcher;
 mod copy_blob;
+mod create_blob;
+mod print_blob;
 
 azure_functions::main!{
-    blob::print_blob,
+    blob_watcher::blob_watcher,
     copy_blob::copy_blob,
+    create_blob::create_blob,
+    print_blob::print_blob,
 }

--- a/examples/blob/src/print_blob.rs
+++ b/examples/blob/src/print_blob.rs
@@ -1,0 +1,13 @@
+use azure_functions::bindings::{Blob, HttpRequest, HttpResponse};
+use azure_functions::func;
+
+#[func]
+#[binding(
+    name = "_req",
+    auth_level = "anonymous",
+    route = "print/blob/{container}/{path}"
+)]
+#[binding(name = "blob", path = "{container}/{path}")]
+pub fn print_blob(_req: &HttpRequest, blob: &Blob) -> HttpResponse {
+    blob.as_bytes().into()
+}

--- a/examples/http/README.md
+++ b/examples/http/README.md
@@ -1,6 +1,6 @@
 # Example HTTP Azure Function
 
-This package is an example of a simple HTTP-triggered Azure Function.
+This project is an example of a simple HTTP-triggered Azure Function.
 
 ## Example function implementations
 

--- a/examples/queue/README.md
+++ b/examples/queue/README.md
@@ -1,6 +1,6 @@
 # Example Queue Triggered Azure Function
 
-This package is an example of a simple queue-triggered Azure Function.
+This project is an example of a simple queue-triggered Azure Function.
 
 ## Example function implementations
 

--- a/examples/timer/README.md
+++ b/examples/timer/README.md
@@ -1,6 +1,6 @@
 # Example Timer Azure Function
 
-This package is an example of a simple timer-triggered Azure Function.
+This project is an example of a simple timer-triggered Azure Function.
 
 ## Example function implementation
 


### PR DESCRIPTION
This commit implements support for tuple return values and output binding in
the `InvocationResponse`.

Fixes #24.
Fixes #30.