### PR TITLE
Implement Option<T> output bindings.

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Azure Functions for Rust automatically infers the direction of bindings dependin
   }
   ```
 
-* Functions that return a type `T`, where `T` is an output binding type, or a tuple of output binding types, are inferred to be bindings with an `out` direction.
+* Functions that return a type `T`, where `T` is an output binding type, or a tuple of output binding types, are inferred to be bindings with an `out` direction.  Functions may also return `Option<T>` for any output binding type `T`; a `None` value will skip outputting a value.
   
   ```rust
   #[func]
@@ -106,7 +106,15 @@ Azure Functions for Rust automatically infers the direction of bindings dependin
   ```rust
   #[func]
   ...
-  pub fn example(...) -> (HttpResponse, Blob) {
+  pub fn example(...) -> Option<Blob> {
+      ...
+  }
+  ```
+
+  ```rust
+  #[func]
+  ...
+  pub fn example(...) -> (HttpResponse, Option<Blob>) {
       ...
   }
   ```
@@ -128,7 +136,7 @@ Azure Functions for Rust automatically infers the direction of bindings dependin
   }
   ```
 
-  With the above, there is no `$return` binding and the Azure Function "returns" no value.  Instead, a single output binding named `output1` is used.
+  For the above example, there is no `$return` binding and the Azure Function "returns" no value.  Instead, a single output binding named `output1` is used.
 
 # Development
 

--- a/azure-functions-codegen/src/util.rs
+++ b/azure-functions-codegen/src/util.rs
@@ -7,7 +7,7 @@ use syn::buffer::TokenBuffer;
 use syn::punctuated::Punctuated;
 use syn::spanned::Spanned;
 use syn::synom::Synom;
-use syn::{parse, parse2, Attribute, Ident, Lit, LitStr, Path};
+use syn::{parse, parse2, Attribute, Ident, Lit, LitStr, Path, PathSegment};
 
 pub fn to_camel_case(input: &str) -> String {
     let mut result = String::new();
@@ -211,11 +211,9 @@ pub fn path_to_string(path: &Path) -> String {
     s
 }
 
-pub fn last_ident_in_path(path: &Path) -> String {
+pub fn last_segment_in_path(path: &Path) -> &PathSegment {
     path.segments
         .iter()
         .last()
         .expect("expected at least one segment in path")
-        .ident
-        .to_string()
 }


### PR DESCRIPTION
This commit implements `Option<T>` for output bindings.

A returned `None` value skips the output to the Azure Functions Host.

Additionally, this commit adds support for "paren" types in the AST, which are
basically single-element tuple types.  Thus, `(T)` is treated as `T`.

Fixes #29.