### PR TITLE
Implement table input and output bindings.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -278,6 +278,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "example-table"
+version = "0.1.0"
+dependencies = [
+ "azure-functions 0.1.6",
+ "serde_json 1.0.24 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "example-timer"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,4 +9,5 @@ members = [
     "examples/timer",
     "examples/queue",
     "examples/blob",
+    "examples/table",
 ]

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ The current list of supported bindings:
 | `azure_functions::bindings::HttpResponse` | Output HTTP Response    | out            |
 | `azure_functions::bindings::QueueTrigger` | Queue Trigger           | in             |
 | `azure_functions::bindings::QueueMessage` | Output Queue Message    | out            |
+| `azure_functions::bindings::Table`        | Input and Ouput Table   | in, out        |
 | `azure_functions::bindings::TimerInfo`    | Timer Trigger           | in             |
 | `azure_functions::Context`*               | Invocation Context      | n/a            |
 
@@ -208,6 +209,8 @@ Copy this content to a `Dockerfile` at the root of your source:
 FROM peterhuene/azure-functions-rs-ci:latest AS build-env
 
 COPY . /src
+
+WORKDIR /src
 
 RUN cargo run --release -- init --worker-path /usr/local/bin/rust_worker --script-root /home/site/wwwroot
 

--- a/azure-functions-codegen/src/func/binding.rs
+++ b/azure-functions-codegen/src/func/binding.rs
@@ -1,5 +1,7 @@
 use azure_functions_shared::codegen;
-use func::bindings::{Blob, BlobTrigger, Http, HttpTrigger, Queue, QueueTrigger, TimerTrigger};
+use func::bindings::{
+    Blob, BlobTrigger, Http, HttpTrigger, Queue, QueueTrigger, Table, TimerTrigger,
+};
 use proc_macro::Diagnostic;
 use proc_macro2::TokenStream;
 use quote::ToTokens;
@@ -42,6 +44,10 @@ impl ToTokens for Binding<'_> {
                 let b = Blob(Cow::Borrowed(b));
                 quote!(::azure_functions::codegen::Binding::Blob(#b)).to_tokens(tokens)
             }
+            codegen::Binding::Table(b) => {
+                let b = Table(Cow::Borrowed(b));
+                quote!(::azure_functions::codegen::Binding::Table(#b)).to_tokens(tokens)
+            }
         };
     }
 }
@@ -79,6 +85,11 @@ lazy_static! {
         map.insert("Blob", |args| {
             Ok(codegen::Binding::Blob(Blob::try_from(args)?.0.into_owned()))
         });
+        map.insert("Table", |args| {
+            Ok(codegen::Binding::Table(
+                Table::try_from(args)?.0.into_owned(),
+            ))
+        });
         map
     };
     pub static ref INPUT_OUTPUT_BINDINGS: BindingMap = {
@@ -93,7 +104,6 @@ lazy_static! {
             binding.direction = codegen::Direction::InOut;
             Ok(codegen::Binding::Blob(binding))
         });
-
         map
     };
     pub static ref OUTPUT_BINDINGS: BindingMap = {
@@ -110,6 +120,11 @@ lazy_static! {
             let mut binding = Blob::try_from(args)?.0.into_owned();
             binding.direction = codegen::Direction::Out;
             Ok(codegen::Binding::Blob(binding))
+        });
+        map.insert("Table", |args| {
+            let mut binding = Table::try_from(args)?.0.into_owned();
+            binding.direction = codegen::Direction::Out;
+            Ok(codegen::Binding::Table(binding))
         });
         map
     };

--- a/azure-functions-codegen/src/func/bindings/blob.rs
+++ b/azure-functions-codegen/src/func/bindings/blob.rs
@@ -71,8 +71,8 @@ impl TryFrom<AttributeArguments> for Blob<'_> {
         }
 
         Ok(Blob(Cow::Owned(codegen::bindings::Blob {
-            name: name.expect("expected a name for the Blob binding"),
-            path: path.expect("expected a path for Blob binding"),
+            name: name.expect("expected a name for a blob binding"),
+            path: path.expect("expected a path for a blob binding"),
             connection: connection,
             direction: codegen::Direction::In,
         })))

--- a/azure-functions-codegen/src/func/bindings/blob_trigger.rs
+++ b/azure-functions-codegen/src/func/bindings/blob_trigger.rs
@@ -71,8 +71,8 @@ impl TryFrom<AttributeArguments> for BlobTrigger<'_> {
         }
 
         Ok(BlobTrigger(Cow::Owned(codegen::bindings::BlobTrigger {
-            name: name.expect("expected a name for the BlobTrigger binding"),
-            path: path.expect("expected a path for BlobTrigger binding"),
+            name: name.expect("expected a name for a blob trigger binding"),
+            path: path.expect("expected a path for a blob trigger binding"),
             connection: connection,
             direction: codegen::Direction::In,
         })))

--- a/azure-functions-codegen/src/func/bindings/http.rs
+++ b/azure-functions-codegen/src/func/bindings/http.rs
@@ -41,7 +41,7 @@ impl TryFrom<AttributeArguments> for Http<'_> {
         }
 
         Ok(Http(Cow::Owned(codegen::bindings::Http {
-            name: name.expect("expected a name for the Http binding"),
+            name: name.expect("expected a name for a http binding"),
         })))
     }
 }

--- a/azure-functions-codegen/src/func/bindings/http_trigger.rs
+++ b/azure-functions-codegen/src/func/bindings/http_trigger.rs
@@ -124,7 +124,7 @@ impl TryFrom<AttributeArguments> for HttpTrigger<'_> {
         }
 
         Ok(HttpTrigger(Cow::Owned(codegen::bindings::HttpTrigger {
-            name: name.expect("expected a name for the HttpTrigger binding"),
+            name: name.expect("expected a name for a http trigger binding"),
             auth_level: auth_level,
             methods: Cow::Owned(methods),
             route: route,

--- a/azure-functions-codegen/src/func/bindings/mod.rs
+++ b/azure-functions-codegen/src/func/bindings/mod.rs
@@ -4,6 +4,7 @@ mod http;
 mod http_trigger;
 mod queue;
 mod queue_trigger;
+mod table;
 mod timer_trigger;
 
 pub use self::blob::*;
@@ -12,4 +13,5 @@ pub use self::http::*;
 pub use self::http_trigger::*;
 pub use self::queue::*;
 pub use self::queue_trigger::*;
+pub use self::table::*;
 pub use self::timer_trigger::*;

--- a/azure-functions-codegen/src/func/bindings/queue.rs
+++ b/azure-functions-codegen/src/func/bindings/queue.rs
@@ -68,8 +68,8 @@ impl TryFrom<AttributeArguments> for Queue<'_> {
         }
 
         Ok(Queue(Cow::Owned(codegen::bindings::Queue {
-            name: name.expect("expected a name for the QueueMessage binding"),
-            queue_name: queue_name.expect("expected a queue name for QueueMessage binding"),
+            name: name.expect("expected a name for a queue binding"),
+            queue_name: queue_name.expect("expected a queue name for a queue binding"),
             connection: connection,
         })))
     }

--- a/azure-functions-codegen/src/func/bindings/queue_trigger.rs
+++ b/azure-functions-codegen/src/func/bindings/queue_trigger.rs
@@ -68,8 +68,8 @@ impl TryFrom<AttributeArguments> for QueueTrigger<'_> {
         }
 
         Ok(QueueTrigger(Cow::Owned(codegen::bindings::QueueTrigger {
-            name: name.expect("expected a name for the QueueTrigger binding"),
-            queue_name: queue_name.expect("expected a queue name for QueueTrigger binding"),
+            name: name.expect("expected a name for a queue trigger binding"),
+            queue_name: queue_name.expect("expected a queue name a queue trigger binding"),
             connection: connection,
         })))
     }

--- a/azure-functions-codegen/src/func/bindings/table.rs
+++ b/azure-functions-codegen/src/func/bindings/table.rs
@@ -1,0 +1,159 @@
+use azure_functions_shared::codegen;
+use proc_macro::Diagnostic;
+use quote::ToTokens;
+use std::borrow::Cow;
+use std::convert::TryFrom;
+use syn::spanned::Spanned;
+use syn::Lit;
+use util::{
+    to_camel_case, AttributeArguments, QuotableBorrowedStr, QuotableDirection, QuotableOption,
+};
+
+pub struct Table<'a>(pub Cow<'a, codegen::bindings::Table>);
+
+impl TryFrom<AttributeArguments> for Table<'_> {
+    type Error = Diagnostic;
+
+    fn try_from(args: AttributeArguments) -> Result<Self, Self::Error> {
+        let mut name = None;
+        let mut table_name = None;
+        let mut partition_key = None;
+        let mut row_key = None;
+        let mut filter = None;
+        let mut take = None;
+        let mut connection = None;
+
+        for (key, value) in args.list.iter() {
+            let key_str = key.to_string();
+
+            match key_str.as_str() {
+                "name" => match value {
+                    Lit::Str(s) => {
+                        name = Some(Cow::Owned(to_camel_case(&s.value())));
+                    }
+                    _ => {
+                        return Err(value
+                            .span()
+                            .unstable()
+                            .error("expected a literal string value for the 'name' argument"));
+                    }
+                },
+                "table_name" => match value {
+                    Lit::Str(s) => {
+                        table_name = Some(Cow::Owned(s.value()));
+                    }
+                    _ => {
+                        return Err(value.span().unstable().error(
+                            "expected a literal string value for the 'table_name' argument",
+                        ));
+                    }
+                },
+                "partition_key" => match value {
+                    Lit::Str(s) => {
+                        partition_key = Some(Cow::Owned(s.value()));
+                    }
+                    _ => {
+                        return Err(value.span().unstable().error(
+                            "expected a literal string value for the 'partition_key' argument",
+                        ));
+                    }
+                },
+                "row_key" => match value {
+                    Lit::Str(s) => {
+                        row_key = Some(Cow::Owned(s.value()));
+                    }
+                    _ => {
+                        return Err(value
+                            .span()
+                            .unstable()
+                            .error("expected a literal string value for the 'row_key' argument"));
+                    }
+                },
+                "filter" => match value {
+                    Lit::Str(s) => {
+                        filter = Some(Cow::Owned(s.value()));
+                    }
+                    _ => {
+                        return Err(value
+                            .span()
+                            .unstable()
+                            .error("expected a literal string value for the 'filter' argument"));
+                    }
+                },
+                "take" => match value {
+                    Lit::Int(i) => {
+                        take = Some(i.value());
+                    }
+                    _ => {
+                        return Err(value
+                            .span()
+                            .unstable()
+                            .error("expected a literal integer value for the 'take' argument"));
+                    }
+                },
+                "connection" => match value {
+                    Lit::Str(s) => {
+                        connection = Some(Cow::Owned(s.value()));
+                    }
+                    _ => {
+                        return Err(value.span().unstable().error(
+                            "expected a literal string value for the 'connection' argument",
+                        ));
+                    }
+                },
+                _ => {
+                    return Err(key.span().unstable().error(format!(
+                        "unsupported binding attribute argument '{}'",
+                        key_str
+                    )));
+                }
+            };
+        }
+
+        if table_name.is_none() {
+            return Err(args
+                .span
+                .error("the 'table_name' argument is required for table bindings."));
+        }
+
+        Ok(Table(Cow::Owned(codegen::bindings::Table {
+            name: name.expect("expected a name for a table binding"),
+            table_name: table_name.expect("expected a table name for a table binding"),
+            partition_key: partition_key,
+            row_key: row_key,
+            filter: filter,
+            take: take,
+            connection: connection,
+            direction: codegen::Direction::In,
+        })))
+    }
+}
+
+impl ToTokens for Table<'_> {
+    fn to_tokens(&self, tokens: &mut ::proc_macro2::TokenStream) {
+        let name = QuotableBorrowedStr(&self.0.name);
+        let table_name = QuotableBorrowedStr(&self.0.table_name);
+        let partition_key = QuotableOption(
+            self.0
+                .partition_key
+                .as_ref()
+                .map(|x| QuotableBorrowedStr(x)),
+        );
+        let row_key = QuotableOption(self.0.row_key.as_ref().map(|x| QuotableBorrowedStr(x)));
+        let filter = QuotableOption(self.0.filter.as_ref().map(|x| QuotableBorrowedStr(x)));
+        let take = QuotableOption(self.0.take.as_ref());
+        let connection = QuotableOption(self.0.connection.as_ref().map(|x| QuotableBorrowedStr(x)));
+        let direction = QuotableDirection(self.0.direction.clone());
+
+        quote!(::azure_functions::codegen::bindings::Table {
+            name: #name,
+            table_name: #table_name,
+            partition_key: #partition_key,
+            row_key: #row_key,
+            filter: #filter,
+            take: #take,
+            connection: #connection,
+            direction: #direction,
+        }).to_tokens(tokens)
+    }
+}

--- a/azure-functions-codegen/src/func/bindings/timer_trigger.rs
+++ b/azure-functions-codegen/src/func/bindings/timer_trigger.rs
@@ -75,7 +75,7 @@ impl TryFrom<AttributeArguments> for TimerTrigger<'_> {
         }
 
         Ok(TimerTrigger(Cow::Owned(codegen::bindings::TimerTrigger {
-            name: name.expect("expected a name for the TimerTrigger binding"),
+            name: name.expect("expected a name for a timer trigger binding"),
             schedule: schedule,
             run_on_startup: run_on_startup,
             use_monitor: use_monitor,

--- a/azure-functions-codegen/src/util.rs
+++ b/azure-functions-codegen/src/util.rs
@@ -90,7 +90,8 @@ impl TryFrom<Attribute> for AttributeArguments {
             }
         };
 
-        let mut args = AttributeArguments::try_from(stream)?;
+        let mut args = AttributeArguments::try_from(stream)
+            .map_err(|_| span.unstable().error("failed to parse attribute"))?;
         args.span = span.unstable();
         Ok(args)
     }

--- a/azure-functions-shared/src/codegen/binding.rs
+++ b/azure-functions-shared/src/codegen/binding.rs
@@ -1,4 +1,6 @@
-use codegen::bindings::{Blob, BlobTrigger, Http, HttpTrigger, Queue, QueueTrigger, TimerTrigger};
+use codegen::bindings::{
+    Blob, BlobTrigger, Http, HttpTrigger, Queue, QueueTrigger, Table, TimerTrigger,
+};
 
 #[derive(Serialize, Debug, Clone)]
 #[serde(rename_all = "lowercase")]
@@ -19,6 +21,7 @@ pub enum Binding {
     Queue(Queue),
     BlobTrigger(BlobTrigger),
     Blob(Blob),
+    Table(Table),
 }
 
 impl Binding {
@@ -32,6 +35,7 @@ impl Binding {
             Binding::Queue(b) => Some(&b.name),
             Binding::BlobTrigger(b) => Some(&b.name),
             Binding::Blob(b) => Some(&b.name),
+            Binding::Table(b) => Some(&b.name),
         }
     }
 
@@ -48,7 +52,11 @@ impl Binding {
             | Binding::TimerTrigger(_)
             | Binding::QueueTrigger(_)
             | Binding::BlobTrigger(_) => true,
-            Binding::Context | Binding::Http(_) | Binding::Queue(_) | Binding::Blob(_) => false,
+            Binding::Context
+            | Binding::Http(_)
+            | Binding::Queue(_)
+            | Binding::Blob(_)
+            | Binding::Table(_) => false,
         }
     }
 }

--- a/azure-functions-shared/src/codegen/bindings/mod.rs
+++ b/azure-functions-shared/src/codegen/bindings/mod.rs
@@ -4,6 +4,7 @@ mod http;
 mod http_trigger;
 mod queue;
 mod queue_trigger;
+mod table;
 mod timer_trigger;
 
 pub use self::blob::*;
@@ -12,4 +13,5 @@ pub use self::http::*;
 pub use self::http_trigger::*;
 pub use self::queue::*;
 pub use self::queue_trigger::*;
+pub use self::table::*;
 pub use self::timer_trigger::*;

--- a/azure-functions-shared/src/codegen/bindings/table.rs
+++ b/azure-functions-shared/src/codegen/bindings/table.rs
@@ -1,0 +1,53 @@
+use codegen::Direction;
+use serde::{ser::SerializeMap, Serialize, Serializer};
+use std::borrow::Cow;
+
+#[derive(Debug, Clone)]
+pub struct Table {
+    pub name: Cow<'static, str>,
+    pub direction: Direction,
+    pub table_name: Cow<'static, str>,
+    pub partition_key: Option<Cow<'static, str>>,
+    pub row_key: Option<Cow<'static, str>>,
+    pub filter: Option<Cow<'static, str>>,
+    pub take: Option<u64>,
+    pub connection: Option<Cow<'static, str>>,
+}
+
+// TODO: when https://github.com/serde-rs/serde/issues/760 is resolved, remove implementation in favor of custom Serialize derive
+// The fix would allow us to set the constant `type` entry rather than having to emit it manually.
+impl Serialize for Table {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let mut map = serializer.serialize_map(None)?;
+
+        map.serialize_entry("name", &self.name)?;
+        map.serialize_entry("type", "table")?;
+        map.serialize_entry("direction", &self.direction)?;
+        map.serialize_entry("tableName", &self.table_name)?;
+
+        if let Some(partition_key) = self.partition_key.as_ref() {
+            map.serialize_entry("partitionKey", partition_key)?;
+        }
+
+        if let Some(row_key) = self.row_key.as_ref() {
+            map.serialize_entry("rowKey", row_key)?;
+        }
+
+        if let Some(filter) = self.filter.as_ref() {
+            map.serialize_entry("filter", filter)?;
+        }
+
+        if let Some(take) = self.take.as_ref() {
+            map.serialize_entry("take", take)?;
+        }
+
+        if let Some(connection) = self.connection.as_ref() {
+            map.serialize_entry("connection", connection)?;
+        }
+
+        map.end()
+    }
+}

--- a/azure-functions/src/bindings/blob.rs
+++ b/azure-functions/src/bindings/blob.rs
@@ -117,6 +117,14 @@ impl From<String> for Blob {
     }
 }
 
+impl From<&Value> for Blob {
+    fn from(content: &Value) -> Self {
+        let mut data = protocol::TypedData::new();
+        data.set_json(content.to_string());
+        Blob(data)
+    }
+}
+
 impl From<Value> for Blob {
     fn from(content: Value) -> Self {
         let mut data = protocol::TypedData::new();
@@ -241,6 +249,17 @@ mod tests {
     fn it_converts_from_u8_vec() {
         let blob: Blob = vec![0, 1, 2].into();
         assert_eq!(blob.as_bytes(), [0, 1, 2]);
+    }
+
+    #[test]
+    fn it_converts_from_typed_data() {
+        const BLOB: &'static str = "hello world!";
+
+        let mut data = protocol::TypedData::new();
+        data.set_string(BLOB.to_string());
+
+        let blob: Blob = data.into();
+        assert_eq!(blob.as_str().unwrap(), BLOB);
     }
 
     #[test]

--- a/azure-functions/src/bindings/mod.rs
+++ b/azure-functions/src/bindings/mod.rs
@@ -9,6 +9,7 @@ mod http_request;
 mod http_response;
 mod queue_message;
 mod queue_trigger;
+mod table;
 mod timer_info;
 
 pub use self::blob::*;
@@ -17,6 +18,7 @@ pub use self::http_request::*;
 pub use self::http_response::*;
 pub use self::queue_message::*;
 pub use self::queue_trigger::*;
+pub use self::table::*;
 pub use self::timer_info::*;
 
 #[doc(hidden)]

--- a/azure-functions/src/bindings/queue_message.rs
+++ b/azure-functions/src/bindings/queue_message.rs
@@ -117,6 +117,14 @@ impl From<String> for QueueMessage {
     }
 }
 
+impl From<&Value> for QueueMessage {
+    fn from(content: &Value) -> Self {
+        let mut data = protocol::TypedData::new();
+        data.set_json(content.to_string());
+        QueueMessage(data)
+    }
+}
+
 impl From<Value> for QueueMessage {
     fn from(content: Value) -> Self {
         let mut data = protocol::TypedData::new();

--- a/azure-functions/src/bindings/table.rs
+++ b/azure-functions/src/bindings/table.rs
@@ -1,0 +1,282 @@
+use rpc::protocol;
+use serde_json::{from_str, Map, Value};
+use std::fmt;
+
+/// Represents an Azure Storage table input or output binding.
+///
+/// # Examples
+///
+/// Read a table storage row based on a key posted to the `example` queue:
+///
+/// ```rust
+/// # #![feature(use_extern_macros)] extern crate azure_functions;
+/// # #[macro_use] extern crate log;
+/// use azure_functions::bindings::{QueueTrigger, Table};
+/// use azure_functions::func;
+///
+/// #[func]
+/// #[binding(name = "trigger", queue_name = "example")]
+/// #[binding(name = "table", table_name = "MyTable", partition_key = "MyPartition", row_key = "{queueTrigger}")]
+/// pub fn log_row(trigger: &QueueTrigger, table: &Table) {
+///     info!("Row: {:?}", table.rows().nth(0));
+/// }
+/// ```
+/// Run an Azure Storage table query based on a HTTP request:
+///
+/// ```rust
+/// # #![feature(use_extern_macros)] extern crate azure_functions;
+/// # #[macro_use] extern crate log;
+/// use azure_functions::bindings::{HttpRequest, Table};
+/// use azure_functions::func;
+///
+/// #[func]
+/// #[binding(name = "req", auth_level = "anonymous", web_hook_type="generic")]
+/// #[binding(name = "table", table_name = "MyTable", filter = "{filter}")]
+/// pub fn log_rows(req: &HttpRequest, table: &Table) {
+///     for row in table.rows() {
+///         info!("Row: {:?}", row);
+///     }
+/// }
+#[derive(Debug, Clone)]
+pub struct Table(Value);
+
+/// Represents the data of an Azure Storage table row.
+pub type Row = Map<String, Value>;
+
+impl Table {
+    /// Creates a new table binding.
+    ///
+    /// The new table binding can be used for output.
+    pub fn new() -> Table {
+        Table(Value::Array(Vec::new()))
+    }
+
+    /// Gets whether or not the table binding is empty (no rows).
+    pub fn is_empty(&self) -> bool {
+        self.0.as_array().unwrap().is_empty()
+    }
+
+    /// Gets the current length of the rows stored in the table binding.
+    pub fn len(&self) -> usize {
+        self.0.as_array().unwrap().len()
+    }
+
+    /// Gets the iterator over the rows stored in the table binding.
+    ///
+    /// For input bindings, this will be the rows returned from either a single entity lookup
+    /// or a filter query.
+    ///
+    /// For output bindings, this will be the rows that have been added to the table binding.
+    pub fn rows(&self) -> impl Iterator<Item = &Row> {
+        self.0
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|x| x.as_object().unwrap())
+    }
+
+    /// Adds a new row to the table binding with the specified partition and row keys.
+    pub fn add_row(&mut self, partition_key: &str, row_key: &str) -> &mut Row {
+        let array = self.0.as_array_mut().unwrap();
+
+        array.push(json!({
+            "PartitionKey": partition_key,
+            "RowKey": row_key
+        }));
+
+        array.last_mut().unwrap().as_object_mut().unwrap()
+    }
+
+    /// Adds a row as a value to the table.
+    pub fn add_row_value(&mut self, value: Value) {
+        let array = self.0.as_array_mut().unwrap();
+
+        array.push(value);
+    }
+
+    /// Gets the table as a JSON value.
+    pub fn as_value(&self) -> &Value {
+        &self.0
+    }
+
+    /// Converts the table binding to a JSON value.
+    pub fn to_value(self) -> Value {
+        self.0
+    }
+}
+
+impl fmt::Display for Table {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl From<protocol::TypedData> for Table {
+    fn from(data: protocol::TypedData) -> Self {
+        if data.has_json() {
+            let mut rows: Value =
+                from_str(data.get_json()).expect("expected valid JSON data for table binding");
+
+            if rows.is_object() {
+                rows = Value::Array(vec![rows]);
+            }
+
+            if !rows.is_array() {
+                panic!("expected an object or array for table binding data");
+            }
+
+            Table(rows)
+        } else {
+            Table::new()
+        }
+    }
+}
+
+impl Into<protocol::TypedData> for Table {
+    fn into(self) -> protocol::TypedData {
+        let mut data = protocol::TypedData::new();
+        data.set_json(self.0.to_string());
+        data
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fmt::Write;
+
+    #[test]
+    fn it_constructs_an_empty_table() {
+        let table = Table::new();
+        assert_eq!(table.len(), 0);
+        assert_eq!(table.rows().count(), 0);
+        assert!(table.is_empty());
+    }
+
+    #[test]
+    fn it_is_not_empty_when_rows_are_present() {
+        let mut table = Table::new();
+        table.add_row("partition1", "row1");
+        assert!(!table.is_empty());
+    }
+
+    #[test]
+    fn it_has_a_length_equal_to_number_of_rows() {
+        let mut table = Table::new();
+        assert_eq!(table.len(), 0);
+        table.add_row("partition1", "row1");
+        table.add_row("partition2", "row2");
+        table.add_row("partition3", "row3");
+        assert_eq!(table.len(), 3);
+    }
+
+    #[test]
+    fn it_iterates_rows() {
+        let mut table = Table::new();
+        assert_eq!(table.len(), 0);
+        table.add_row("partition1", "row1");
+        table.add_row("partition2", "row2");
+        table.add_row("partition3", "row3");
+        assert_eq!(table.len(), 3);
+
+        for (i, row) in table.rows().enumerate() {
+            assert_eq!(
+                row.get("PartitionKey").unwrap().as_str().unwrap(),
+                format!("partition{}", i + 1)
+            );
+            assert_eq!(
+                row.get("RowKey").unwrap().as_str().unwrap(),
+                format!("row{}", i + 1)
+            );
+        }
+    }
+
+    #[test]
+    fn it_adds_row_value() {
+        let mut table = Table::new();
+        assert_eq!(table.len(), 0);
+        table.add_row_value(json!({
+            "PartitionKey": "partition1",
+            "RowKey": "row1",
+            "data": "hello world"
+        }));
+
+        assert_eq!(
+            table.to_string(),
+            r#"[{"PartitionKey":"partition1","RowKey":"row1","data":"hello world"}]"#
+        );
+    }
+
+    #[test]
+    fn it_casts_to_value_reference() {
+        let mut table = Table::new();
+        table.add_row("partition1", "row1");
+
+        assert_eq!(
+            table.as_value().to_string(),
+            r#"[{"PartitionKey":"partition1","RowKey":"row1"}]"#
+        );
+    }
+
+    #[test]
+    fn it_converts_to_value() {
+        let mut table = Table::new();
+        table.add_row("partition1", "row1");
+
+        assert_eq!(
+            table.to_value().to_string(),
+            r#"[{"PartitionKey":"partition1","RowKey":"row1"}]"#
+        );
+    }
+
+    #[test]
+    fn it_displays_as_a_string() {
+        let mut table = Table::new();
+        {
+            let row = table.add_row("partition1", "row1");
+            row.insert("data".to_string(), Value::String("value".to_string()));
+        }
+        let mut s = String::new();
+        write!(s, "{}", table);
+
+        assert_eq!(
+            s,
+            r#"[{"PartitionKey":"partition1","RowKey":"row1","data":"value"}]"#
+        );
+    }
+
+    #[test]
+    fn it_converts_from_typed_data() {
+        const TABLE: &'static str =
+            r#"[{"PartitionKey":"partition1","RowKey":"row1","data":"value"}]"#;
+
+        let mut data = protocol::TypedData::new();
+        data.set_json(TABLE.to_string());
+
+        let table: Table = data.into();
+        assert_eq!(table.len(), 1);
+        assert_eq!(table.to_string(), TABLE);
+
+        let mut data = protocol::TypedData::new();
+        data.set_string("".to_string());
+
+        let table: Table = data.into();
+        assert_eq!(table.len(), 0);
+        assert!(table.is_empty());
+    }
+
+    #[test]
+    fn it_converts_to_typed_data() {
+        let mut table = Table::new();
+        {
+            let row = table.add_row("partition1", "row1");
+            row.insert("data".to_string(), Value::String("value".to_string()));
+        }
+        let data: protocol::TypedData = table.into();
+        assert!(data.has_json());
+        assert_eq!(
+            data.get_json(),
+            r#"[{"PartitionKey":"partition1","RowKey":"row1","data":"value"}]"#
+        );
+    }
+}

--- a/azure-functions/src/http/body.rs
+++ b/azure-functions/src/http/body.rs
@@ -159,6 +159,12 @@ impl From<String> for Body<'_> {
     }
 }
 
+impl From<&Value> for Body<'_> {
+    fn from(data: &Value) -> Self {
+        Body::Json(Cow::Owned(data.to_string()))
+    }
+}
+
 impl From<Value> for Body<'_> {
     fn from(data: Value) -> Self {
         Body::Json(Cow::Owned(data.to_string()))

--- a/azure-functions/src/lib.rs
+++ b/azure-functions/src/lib.rs
@@ -4,6 +4,7 @@
 //!
 //! The following Azure Functions trigger bindings are supported:
 //!
+//! * [Blob triggers](bindings/struct.BlobTrigger.html)
 //! * [HTTP triggers](bindings/struct.HttpRequest.html)
 //! * [Queue triggers](bindings/struct.QueueTrigger.html)
 //! * [Timer triggers](bindings/struct.TimerInfo.html)
@@ -11,12 +12,14 @@
 //! The following Azure Functions input bindings are supported:
 //!
 //! * [Blob input](bindings/struct.Blob.html)
+//! * [Table input](bindings/struct.Table.html)
 //!
 //! The following Azure Functions output bindings are supported:
 //!
 //! * [Blob output](bindings/struct.Blob.html)
 //! * [HTTP output](bindings/struct.HttpResponse.html)
 //! * [Queue message output](bindings/struct.QueueMessage.html)
+//! * [Table output](bindings/struct.Table.html)
 //!
 //! Eventually more bindings will be implemented, including custom binding data.
 //!
@@ -111,7 +114,7 @@ extern crate futures;
 extern crate grpcio;
 extern crate log;
 extern crate serde;
-#[cfg_attr(test, macro_use)]
+#[macro_use]
 extern crate serde_json;
 #[macro_use]
 extern crate serde_derive;

--- a/examples/table/Cargo.toml
+++ b/examples/table/Cargo.toml
@@ -1,11 +1,8 @@
 [package]
-name = "example-http"
+name = "example-table"
 version = "0.1.0"
 authors = ["Peter Huene <peterhuene@protonmail.com>"]
 
 [dependencies]
 azure-functions = { version = "0.1.6", path = "../../azure-functions" }
-log = "0.4.2"
-serde = "1.0.66"
 serde_json = "1.0.21"
-serde_derive = "1.0.66"

--- a/examples/table/README.md
+++ b/examples/table/README.md
@@ -1,0 +1,148 @@
+# Example Table Azure Functions
+
+This project is an example of simple table-related Azure Functions.
+
+## Example function implementations
+
+An example function that creates a row in an Azure Storage using an output table binding:
+
+```rust
+use azure_functions::bindings::{HttpRequest, Table};
+use azure_functions::func;
+use serde_json::Value;
+
+#[func]
+#[binding(
+    name = "req",
+    auth_level = "anonymous",
+    route = "create/{table}/{partition}/{row}"
+)]
+#[binding(name = "output1", table_name = "{table}")]
+pub fn create_row(req: &HttpRequest) -> ((), Table) {
+    let mut table = Table::new();
+    {
+        let row = table.add_row(
+            req.route_params().get("partition").unwrap(),
+            req.route_params().get("row").unwrap(),
+        );
+
+        row.insert(
+            "body".to_string(),
+            Value::String(req.body().as_str().unwrap().to_owned()),
+        );
+    }
+    ((), table)
+}
+```
+
+An example function that reads a row using an input table binding:
+
+```rust
+use azure_functions::bindings::{HttpRequest, HttpResponse, Table};
+use azure_functions::func;
+use serde_json::Value;
+
+#[func]
+#[binding(
+    name = "_req",
+    auth_level = "anonymous",
+    route = "read/{table}/{partition}/{row}"
+)]
+#[binding(
+    name = "table",
+    table_name = "{table}",
+    partition_key = "{partition}",
+    row_key = "{row}"
+)]
+pub fn read_row(_req: &HttpRequest, table: &Table) -> HttpResponse {
+    table.as_value().get(0).unwrap_or(&Value::Null).into()
+}
+```
+
+# Running the example locally
+
+## Prerequisites
+
+### Nightly Rust compiler
+
+This example requires the use of a nightly Rust compiler due the use of the experimental procedural macros feature.
+
+Use [rustup](https://github.com/rust-lang-nursery/rustup.rs) to install a nightly compiler:
+
+```
+rustup install nightly
+rustup default nightly
+```
+
+### .NET Core SDK
+
+The Azure Functions Host is implemented with .NET Core, so download and install a [.NET Core SDK](https://www.microsoft.com/net/download).
+
+### Azure Functions Host
+
+Clone the Azure Functions Host from GitHub:
+
+```
+git clone git@github.com:azure/azure-functions-host.git
+```
+
+Use `dotnet` to build the Azure Functions Host:
+
+```
+cd azure-functions-host/src/WebJobs.Script.WebHost
+dotnet build
+```
+
+## Register the Rust language worker
+
+The Azure Functions Host uses JSON configuration files to register language workers.
+
+Create the configuration file to register the Rust language worker:
+
+```
+mkdir azure-functions-host/src/WebJobs.Script.WebHost/bin/Debug/netcoreapp2.1/workers/rust
+cp azure-functions-rs/azure-functions/worker.config.json azure-functions-host/src/WebJobs.Script.WebHost/bin/Debug/netcoreapp2.1/workers/rust
+```
+
+## Initialize the example application
+
+Run the following command to build and initialize the Rust Azure Functions application:
+
+```
+cd azure-functions-rs/examples/table
+cargo run --release -- init --worker-path /tmp/table-example/rust_worker --script-root /tmp/table-example/root
+```
+
+## Start the Azure Functions Host
+
+Run the following commands to start the Azure Functions Host:
+
+```
+cd azure-functions-host/src/WebJobs.Script.WebHost
+PATH=/tmp/table-example:$PATH AzureWebJobsScriptRoot=/tmp/table-example/root AzureWebJobsStorage=$CONNECTION_STRING dotnet run
+```
+
+Where `$CONNECTION_STRING` is the Azure Storage connection string the Azure Functions host should use.
+
+_Note: the syntax above works on macOS and Linux; on Windows, set the environment variables before running `dotnet run`._
+
+## Invoke the `create_row` function
+
+To create a row in a table named `test` with partition key `partition1` and row key `row1`,
+use curl to invoke the `create_row` function:
+
+```
+curl -d "hello world!" http://localhost:5000/api/create/test/partition1/row1 -v
+```
+
+With any luck, this should return a `204 No Content` response.
+
+## Invoke the `read_row` function
+
+To read a row from a table named `test` with partition key `partition1` and row key `row1`:
+
+```
+curl http://localhost:5000/api/read/test/partition1/row1
+```
+
+With any luck, the entity should be printed by `curl`.

--- a/examples/table/src/create_row.rs
+++ b/examples/table/src/create_row.rs
@@ -1,0 +1,26 @@
+use azure_functions::bindings::{HttpRequest, Table};
+use azure_functions::func;
+use serde_json::Value;
+
+#[func]
+#[binding(
+    name = "req",
+    auth_level = "anonymous",
+    route = "create/{table}/{partition}/{row}"
+)]
+#[binding(name = "output1", table_name = "{table}")]
+pub fn create_row(req: &HttpRequest) -> ((), Table) {
+    let mut table = Table::new();
+    {
+        let row = table.add_row(
+            req.route_params().get("partition").unwrap(),
+            req.route_params().get("row").unwrap(),
+        );
+
+        row.insert(
+            "body".to_string(),
+            Value::String(req.body().as_str().unwrap().to_owned()),
+        );
+    }
+    ((), table)
+}

--- a/examples/table/src/main.rs
+++ b/examples/table/src/main.rs
@@ -1,0 +1,12 @@
+#![feature(use_extern_macros)]
+
+extern crate azure_functions;
+extern crate serde_json;
+
+mod create_row;
+mod read_row;
+
+azure_functions::main!{
+    create_row::create_row,
+    read_row::read_row,
+}

--- a/examples/table/src/read_row.rs
+++ b/examples/table/src/read_row.rs
@@ -1,0 +1,19 @@
+use azure_functions::bindings::{HttpRequest, HttpResponse, Table};
+use azure_functions::func;
+use serde_json::Value;
+
+#[func]
+#[binding(
+    name = "_req",
+    auth_level = "anonymous",
+    route = "read/{table}/{partition}/{row}"
+)]
+#[binding(
+    name = "table",
+    table_name = "{table}",
+    partition_key = "{partition}",
+    row_key = "{row}"
+)]
+pub fn read_row(_req: &HttpRequest, table: &Table) -> HttpResponse {
+    table.as_value().get(0).unwrap_or(&Value::Null).into()
+}


### PR DESCRIPTION
This commit implements table input and output bindings through the `Table`
binding type.

Fixes #17.