### PR TITLE
Fix RpcLog messages missing an invocation id.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN if [ -z "$EXAMPLE" ]; then echo "The EXAMPLE argument is required."; exit 1;
     && cd /src/examples/$EXAMPLE \
     && cargo run --release -- init --worker-path /usr/local/bin/rust_worker --script-root /home/site/wwwroot
 
-FROM microsoft/azure-functions-dotnet-core2.0:dev-nightly
+FROM microsoft/azure-functions-dotnet-core2.0:v2.0.11946-alpha
 
 COPY --from=build-env ["/usr/local/bin/rust_worker", "/usr/local/bin/rust_worker"]
 COPY --from=build-env ["/home/site/wwwroot", "/home/site/wwwroot"]


### PR DESCRIPTION
This commit fixes the `RpcLog` messages such that they have an `invocation_id`
populated during the execution of an Azure Function.

With this change, logging macros should now populate messages in Application
Insights for deployed functions on Azure.

Fixes #35.