### PR TITLE
Implement copying original source files into Functions App.

### DIFF
--- a/azure-functions-codegen/src/func/function.rs
+++ b/azure-functions-codegen/src/func/function.rs
@@ -64,6 +64,8 @@ impl TryFrom<TokenStream> for Function<'_> {
             bindings: Cow::Owned(Vec::new()),
             invoker_name: None,
             invoker: None,
+            manifest_dir: None,
+            file: None,
         })))
     }
 }
@@ -96,6 +98,8 @@ impl ToTokens for Function<'_> {
             bindings: ::std::borrow::Cow::Borrowed(&[#(#bindings),*]),
             invoker_name: #invoker_name,
             invoker: Some(#invoker),
+            manifest_dir: Some(::std::borrow::Cow::Borrowed(env!("CARGO_MANIFEST_DIR"))),
+            file: Some(::std::borrow::Cow::Borrowed(file!())),
         }
         ).to_tokens(tokens)
     }

--- a/azure-functions-shared/src/codegen/function.rs
+++ b/azure-functions-shared/src/codegen/function.rs
@@ -11,6 +11,8 @@ pub struct Function {
     pub bindings: Cow<'static, [Binding]>,
     pub invoker_name: Option<Cow<'static, str>>,
     pub invoker: Option<fn(&str, &mut protocol::InvocationRequest) -> protocol::InvocationResponse>,
+    pub manifest_dir: Option<Cow<'static, str>>,
+    pub file: Option<Cow<'static, str>>,
 }
 
 // TODO: when https://github.com/serde-rs/serde/issues/760 is resolved, remove implementation in favor of custom Serialize derive

--- a/azure-functions/src/registry.rs
+++ b/azure-functions/src/registry.rs
@@ -15,7 +15,7 @@ impl<'a> Registry<'a> {
                 .by_ref()
                 .fold(HashMap::new(), |mut map, func| {
                     if map.insert(func.name.clone().into_owned(), func).is_some() {
-                        panic!("Azure Function '{}' has already been registered; make sure all functions have unique names.", func.name);
+                        panic!("Azure Function '{}' has already been registered; ensure all functions have unique names.", func.name);
                     }
                     map
                 }),
@@ -62,6 +62,8 @@ mod tests {
                 bindings: Cow::Borrowed(&[]),
                 invoker_name: None,
                 invoker: None,
+                manifest_dir: None,
+                file: None,
             },
             &Function {
                 name: Cow::Borrowed("function2"),
@@ -69,6 +71,8 @@ mod tests {
                 bindings: Cow::Borrowed(&[]),
                 invoker_name: None,
                 invoker: None,
+                manifest_dir: None,
+                file: None,
             },
             &Function {
                 name: Cow::Borrowed("function3"),
@@ -76,6 +80,8 @@ mod tests {
                 bindings: Cow::Borrowed(&[]),
                 invoker_name: None,
                 invoker: None,
+                manifest_dir: None,
+                file: None,
             },
         ]);
         assert_eq!(registry.iter().count(), 3);
@@ -94,6 +100,8 @@ mod tests {
             bindings: Cow::Borrowed(&[]),
             invoker_name: None,
             invoker: None,
+            manifest_dir: None,
+            file: None,
         }]);
         assert_eq!(registry.iter().count(), 1);
 
@@ -113,6 +121,8 @@ mod tests {
             bindings: Cow::Borrowed(&[]),
             invoker_name: None,
             invoker: None,
+            manifest_dir: None,
+            file: None,
         }]);
         assert_eq!(registry.iter().count(), 1);
 


### PR DESCRIPTION
This commit implements copying the original source file containing an Azure
Function into the Azure Functions application.

If the application is not initialized from where the original source code is
inaccessible, a comment-only source file is still created.

Fixes #37.