### PR TITLE
Fix build with latest Rust 2018 Preview.

### DIFF
--- a/azure-functions-codegen/src/lib.rs
+++ b/azure-functions-codegen/src/lib.rs
@@ -2,6 +2,7 @@
 //!
 //! This crate supports the code generation for the `azure-functions` crate.
 #![feature(rust_2018_preview)]
+#![feature(in_band_lifetimes)]
 #![feature(proc_macro_diagnostic)]
 #![feature(drain_filter)]
 #![feature(try_from)]

--- a/azure-functions-shared-codegen/src/lib.rs
+++ b/azure-functions-shared-codegen/src/lib.rs
@@ -2,7 +2,7 @@
 //!
 //! This crate supports code generation for the `azure-functions-shared` crate.
 
-#![deny(unused_extern_crates)]
+#![feature(rust_2018_preview)]
 
 extern crate proc_macro;
 extern crate syn;

--- a/azure-functions-shared/src/lib.rs
+++ b/azure-functions-shared/src/lib.rs
@@ -2,7 +2,7 @@
 //!
 //! This crate shares types between the `azure-functions-codegen` and `azure-functions` crates.
 #![feature(rust_2018_preview)]
-#![feature(use_extern_macros)]
+#![feature(in_band_lifetimes)]
 #![feature(proc_macro_mod)]
 #![feature(proc_macro_gen)]
 #![deny(missing_docs)]

--- a/azure-functions/src/lib.rs
+++ b/azure-functions/src/lib.rs
@@ -100,7 +100,7 @@
 //!
 //! The expected response would be `Hello from Rust, John!`.
 #![feature(rust_2018_preview)]
-#![feature(use_extern_macros)]
+#![feature(in_band_lifetimes)]
 #![feature(proc_macro_mod)]
 #![feature(proc_macro_gen)]
 #![deny(missing_docs)]


### PR DESCRIPTION
This commit fixes the build break that resulted from the latest 2018 preview
removing the inband-liftime feature from the `rust_2018_preview` feature gate.

Also removing unnecessary features that are now gated behind the
`rust_2018_preview` feature gate.