### PR TITLE
Remove `use_extern_macros` feature.

### DIFF
--- a/azure-functions/src/bindings/blob_trigger.rs
+++ b/azure-functions/src/bindings/blob_trigger.rs
@@ -17,7 +17,7 @@ const METADATA_KEY: &'static str = "Metadata";
 /// A function that runs when a blob is created in the `test` container:
 ///
 /// ```rust
-/// # #![feature(use_extern_macros)] extern crate azure_functions;
+/// # extern crate azure_functions;
 /// # #[macro_use] extern crate log;
 /// use azure_functions::bindings::BlobTrigger;
 /// use azure_functions::func;

--- a/azure-functions/src/bindings/http_request.rs
+++ b/azure-functions/src/bindings/http_request.rs
@@ -10,7 +10,7 @@ use std::collections::HashMap;
 /// A function that responds with a friendly greeting:
 ///
 /// ```rust
-/// # #![feature(use_extern_macros)] extern crate azure_functions;
+/// # extern crate azure_functions;
 /// use azure_functions::func;
 /// use azure_functions::bindings::{HttpRequest, HttpResponse};
 ///
@@ -53,7 +53,7 @@ impl HttpRequest {
     /// # Examples
     ///
     /// ```rust
-    /// # #![feature(use_extern_macros)] extern crate azure_functions;
+    /// # extern crate azure_functions;
     /// use azure_functions::func;
     /// use azure_functions::bindings::{HttpRequest, HttpResponse};
     ///
@@ -80,7 +80,7 @@ impl HttpRequest {
     /// # Examples
     ///
     /// ```rust
-    /// # #![feature(use_extern_macros)] extern crate azure_functions;
+    /// # extern crate azure_functions;
     /// use azure_functions::func;
     /// use azure_functions::bindings::{HttpRequest, HttpResponse};
     ///

--- a/azure-functions/src/bindings/queue_trigger.rs
+++ b/azure-functions/src/bindings/queue_trigger.rs
@@ -18,7 +18,7 @@ const POP_RECEIPT_KEY: &'static str = "PopReceipt";
 /// A function that runs when a message is posted to a queue called `example`:
 ///
 /// ```rust
-/// # #![feature(use_extern_macros)] extern crate azure_functions;
+/// # extern crate azure_functions;
 /// # #[macro_use] extern crate log;
 /// use azure_functions::bindings::QueueTrigger;
 /// use azure_functions::func;

--- a/azure-functions/src/bindings/table.rs
+++ b/azure-functions/src/bindings/table.rs
@@ -9,7 +9,7 @@ use std::fmt;
 /// Read a table storage row based on a key posted to the `example` queue:
 ///
 /// ```rust
-/// # #![feature(use_extern_macros)] extern crate azure_functions;
+/// # extern crate azure_functions;
 /// # #[macro_use] extern crate log;
 /// use azure_functions::bindings::{QueueTrigger, Table};
 /// use azure_functions::func;
@@ -24,7 +24,7 @@ use std::fmt;
 /// Run an Azure Storage table query based on a HTTP request:
 ///
 /// ```rust
-/// # #![feature(use_extern_macros)] extern crate azure_functions;
+/// # extern crate azure_functions;
 /// # #[macro_use] extern crate log;
 /// use azure_functions::bindings::{HttpRequest, Table};
 /// use azure_functions::func;

--- a/azure-functions/src/bindings/timer_info.rs
+++ b/azure-functions/src/bindings/timer_info.rs
@@ -11,7 +11,7 @@ use timer::ScheduleStatus;
 /// A function that runs every 5 minutes:
 ///
 /// ```rust
-/// # #![feature(use_extern_macros)] extern crate azure_functions;
+/// # extern crate azure_functions;
 /// # #[macro_use] extern crate log;
 /// use azure_functions::bindings::TimerInfo;
 /// use azure_functions::func;

--- a/azure-functions/src/lib.rs
+++ b/azure-functions/src/lib.rs
@@ -43,7 +43,7 @@
 //! For example, let's create `src/greet.rs` that implements a HTTP triggered function:
 //!
 //! ```rust
-//! # #![feature(use_extern_macros)] extern crate azure_functions;
+//! # extern crate azure_functions;
 //! # #[macro_use] extern crate log;
 //! use azure_functions::func;
 //! use azure_functions::bindings::{HttpRequest, HttpResponse};
@@ -66,8 +66,6 @@
 //! the Azure Functions Host:
 //!
 //! ```rust,ignore
-//! #![feature(use_extern_macros)]
-//!
 //! #[macro_use]
 //! extern crate log;
 //! extern crate azure_functions;

--- a/examples/blob/src/main.rs
+++ b/examples/blob/src/main.rs
@@ -1,5 +1,3 @@
-#![feature(use_extern_macros)]
-
 extern crate azure_functions;
 #[macro_use]
 extern crate log;

--- a/examples/http/src/main.rs
+++ b/examples/http/src/main.rs
@@ -1,5 +1,3 @@
-#![feature(use_extern_macros)]
-
 extern crate azure_functions;
 #[macro_use]
 extern crate log;

--- a/examples/queue/src/main.rs
+++ b/examples/queue/src/main.rs
@@ -1,5 +1,3 @@
-#![feature(use_extern_macros)]
-
 extern crate azure_functions;
 #[macro_use]
 extern crate log;

--- a/examples/table/src/main.rs
+++ b/examples/table/src/main.rs
@@ -1,5 +1,3 @@
-#![feature(use_extern_macros)]
-
 extern crate azure_functions;
 extern crate serde_json;
 

--- a/examples/timer/src/main.rs
+++ b/examples/timer/src/main.rs
@@ -1,5 +1,3 @@
-#![feature(use_extern_macros)]
-
 extern crate azure_functions;
 #[macro_use]
 extern crate log;


### PR DESCRIPTION
The feature has been stabilized and the feature no longer needs to be enabled.

This commit fixes the resulting warnings.