### PR TITLE
Fix the build with latest rust nightly changes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ More bindings will be implemented in the future, including support for retreivin
 Azure Functions for Rust automatically infers the direction of bindings depending on how the binding is used in a function's declaration:
 
 * Parameters passed by immutable reference `&T`, where `T` is a trigger or input binding type, are inferred to be bindings with an `in` direction.
-  
+
   ```rust
   #[func]
   ...
@@ -95,7 +95,7 @@ Azure Functions for Rust automatically infers the direction of bindings dependin
   ```
 
 * Functions that return a type `T`, where `T` is an output binding type, or a tuple of output binding types, are inferred to be bindings with an `out` direction.  Functions may also return `Option<T>` for any output binding type `T`; a `None` value will skip outputting a value.
-  
+
   ```rust
   #[func]
   ...

--- a/azure-functions-codegen/src/func/bindings/blob.rs
+++ b/azure-functions-codegen/src/func/bindings/blob.rs
@@ -91,6 +91,7 @@ impl ToTokens for Blob<'_> {
             path: #path,
             connection: #connection,
             direction: #direction,
-        }).to_tokens(tokens)
+        })
+        .to_tokens(tokens)
     }
 }

--- a/azure-functions-codegen/src/func/bindings/blob_trigger.rs
+++ b/azure-functions-codegen/src/func/bindings/blob_trigger.rs
@@ -91,6 +91,7 @@ impl ToTokens for BlobTrigger<'_> {
             path: #path,
             connection: #connection,
             direction: #direction,
-        }).to_tokens(tokens)
+        })
+        .to_tokens(tokens)
     }
 }

--- a/azure-functions-codegen/src/func/bindings/http_trigger.rs
+++ b/azure-functions-codegen/src/func/bindings/http_trigger.rs
@@ -70,7 +70,8 @@ impl TryFrom<AttributeArguments> for HttpTrigger<'_> {
                                         None
                                     }
                                 }
-                            }).collect();
+                            })
+                            .collect();
 
                         if !invalid.is_empty() {
                             return Err(value.span().unstable().error(format!(
@@ -152,6 +153,7 @@ impl ToTokens for HttpTrigger<'_> {
             methods: ::std::borrow::Cow::Borrowed(&[#(#methods),*]),
             route: #route,
             web_hook_type: #web_hook_type,
-        }).to_tokens(tokens)
+        })
+        .to_tokens(tokens)
     }
 }

--- a/azure-functions-codegen/src/func/bindings/queue.rs
+++ b/azure-functions-codegen/src/func/bindings/queue.rs
@@ -85,6 +85,7 @@ impl ToTokens for Queue<'_> {
             name: #name,
             queue_name: #queue_name,
             connection: #connection,
-        }).to_tokens(tokens)
+        })
+        .to_tokens(tokens)
     }
 }

--- a/azure-functions-codegen/src/func/bindings/queue_trigger.rs
+++ b/azure-functions-codegen/src/func/bindings/queue_trigger.rs
@@ -85,6 +85,7 @@ impl ToTokens for QueueTrigger<'_> {
             name: #name,
             queue_name: #queue_name,
             connection: #connection,
-        }).to_tokens(tokens)
+        })
+        .to_tokens(tokens)
     }
 }

--- a/azure-functions-codegen/src/func/bindings/table.rs
+++ b/azure-functions-codegen/src/func/bindings/table.rs
@@ -154,6 +154,7 @@ impl ToTokens for Table<'_> {
             take: #take,
             connection: #connection,
             direction: #direction,
-        }).to_tokens(tokens)
+        })
+        .to_tokens(tokens)
     }
 }

--- a/azure-functions-codegen/src/func/bindings/timer_trigger.rs
+++ b/azure-functions-codegen/src/func/bindings/timer_trigger.rs
@@ -95,6 +95,7 @@ impl ToTokens for TimerTrigger<'_> {
             schedule: #schedule,
             run_on_startup: #run_on_startup,
             use_monitor: #use_monitor
-        }).to_tokens(tokens)
+        })
+        .to_tokens(tokens)
     }
 }

--- a/azure-functions-codegen/src/func/function.rs
+++ b/azure-functions-codegen/src/func/function.rs
@@ -101,6 +101,7 @@ impl ToTokens for Function<'_> {
             manifest_dir: Some(::std::borrow::Cow::Borrowed(env!("CARGO_MANIFEST_DIR"))),
             file: Some(::std::borrow::Cow::Borrowed(file!())),
         }
-        ).to_tokens(tokens)
+        )
+        .to_tokens(tokens)
     }
 }

--- a/azure-functions-codegen/src/func/invoker.rs
+++ b/azure-functions-codegen/src/func/invoker.rs
@@ -21,7 +21,8 @@ impl Invoker<'a> {
                 }
 
                 Some((name, &*arg_type.elem))
-            }).unzip()
+            })
+            .unzip()
     }
 
     fn get_trigger_arg(&self) -> Option<(&'a Ident, &'a Type)> {

--- a/azure-functions-codegen/src/lib.rs
+++ b/azure-functions-codegen/src/lib.rs
@@ -20,14 +20,14 @@ extern crate syn;
 extern crate quote;
 
 mod func;
-mod main;
+mod register;
 mod util;
 
 use proc_macro::TokenStream;
 
-/// Implements the `main!` macro.
+/// Implements the `register!` macro.
 ///
-/// The `main!` macro is used to register a list of Azure Functions with
+/// The `register!` macro is used to register a list of Azure Functions with
 /// the Azure Functions host.
 ///
 /// This macro expects a comma-separated list of functions that have the
@@ -36,13 +36,13 @@ use proc_macro::TokenStream;
 /// # Examples
 ///
 /// ```rust,ignore
-/// azure_functions::main!{
+/// azure_functions::register!{
 ///     module::my_azure_function
 /// }
 /// ```
 #[proc_macro]
-pub fn main(input: TokenStream) -> TokenStream {
-    main::attr_impl(input)
+pub fn register(input: TokenStream) -> TokenStream {
+    register::attr_impl(input)
 }
 
 /// Implements the `func` attribute.

--- a/azure-functions-codegen/src/register.rs
+++ b/azure-functions-codegen/src/register.rs
@@ -29,12 +29,14 @@ pub fn attr_impl(input: TokenStream) -> TokenStream {
                         &mut expr,
                         "__{}_FUNCTION",
                         segment.ident.to_string().to_uppercase()
-                    ).unwrap();
+                    )
+                    .unwrap();
                 }
             }
 
             parse_str::<Expr>(&expr).unwrap()
-        }).collect();
+        })
+        .collect();
 
     let expanded = quote!{
         pub fn main() {

--- a/azure-functions-codegen/src/util.rs
+++ b/azure-functions-codegen/src/util.rs
@@ -145,7 +145,8 @@ impl<T: ToTokens> ToTokens for QuotableOption<T> {
         match &self.0 {
             Some(inner) => quote!(Some(#inner)),
             None => quote!(None),
-        }.to_tokens(tokens);
+        }
+        .to_tokens(tokens);
     }
 }
 

--- a/azure-functions-shared-codegen/src/lib.rs
+++ b/azure-functions-shared-codegen/src/lib.rs
@@ -44,5 +44,6 @@ pub fn generated_mod(_: TokenStream, input: TokenStream) -> TokenStream {
     quote!(
         #[path = #path]
         mod #ident;
-    ).into()
+    )
+    .into()
 }

--- a/azure-functions-shared/build.rs
+++ b/azure-functions-shared/build.rs
@@ -54,7 +54,8 @@ fn compile_protobufs() {
     fs::copy(
         out_dir.join(RUST_PROTOBUF_FILE),
         cache_dir.join(RUST_PROTOBUF_FILE),
-    ).expect(&format!("can't update cache file '{}'", RUST_PROTOBUF_FILE));
+    )
+    .expect(&format!("can't update cache file '{}'", RUST_PROTOBUF_FILE));
     fs::copy(out_dir.join(RUST_GRPC_FILE), cache_dir.join(RUST_GRPC_FILE))
         .expect(&format!("can't update cache file '{}'", RUST_GRPC_FILE));
 }

--- a/azure-functions/src/lib.rs
+++ b/azure-functions/src/lib.rs
@@ -72,9 +72,9 @@
 //!
 //! mod greet;
 //!
-//! // The main! macro generates an entrypoint for the binary
+//! // The register! macro generates an entrypoint for the binary
 //! // Expects a list of Azure Functions to register with the Azure Functions host
-//! azure_functions::main!{
+//! azure_functions::register!{
 //!     greet::greet
 //! }
 //! ```
@@ -140,7 +140,7 @@ pub mod http;
 pub mod rpc;
 pub mod timer;
 #[doc(no_inline)]
-pub use azure_functions_codegen::main;
+pub use azure_functions_codegen::register;
 pub use azure_functions_shared::Context;
 
 use futures::Future;
@@ -175,13 +175,13 @@ fn has_rust_files(directory: &Path) -> bool {
         .expect(&format!(
             "failed to read directory '{}'",
             directory.display()
-        )).any(|p| {
-            if let Ok(p) = p {
+        ))
+        .any(|p| match p {
+            Ok(p) => {
                 let p = p.path();
                 p.is_file() && p.extension().map(|x| x == "rs").unwrap_or(false)
-            } else {
-                false
             }
+            _ => false,
         })
 }
 
@@ -230,7 +230,8 @@ fn initialize_app(worker_path: &str, script_root: &str, registry: Arc<Mutex<Regi
     fs::copy(
         current_exe().expect("Failed to determine the path to the current executable"),
         worker_path,
-    ).expect("Failed to copy worker executable");
+    )
+    .expect("Failed to copy worker executable");
 
     for entry in fs::read_dir(&script_root).expect("failed to read script root directory") {
         let path = script_root.join(entry.expect("failed to read script root entry").path());
@@ -339,7 +340,8 @@ fn run_worker(
             );
 
             client.process_all_messages(registry)
-        }).wait()
+        })
+        .wait()
         .unwrap();
 }
 

--- a/azure-functions/src/rpc/client.rs
+++ b/azure-functions/src/rpc/client.rs
@@ -63,7 +63,8 @@ impl Client {
             .client
             .get_or_insert(protocol::FunctionRpcClient::new(
                 channel.connect(&format!("{}:{}", host, port)),
-            )).event_stream()
+            ))
+            .event_stream()
             .unwrap();
 
         let (tx, rx) = mpsc::channel(1);
@@ -154,7 +155,8 @@ impl Client {
         log::set_boxed_logger(Box::new(logger::Logger::new(
             log::Level::Trace,
             self.sender.clone().unwrap(),
-        ))).expect("Failed to set the global logger instance");
+        )))
+        .expect("Failed to set the global logger instance");
 
         // At this point, translate any panics to error! macros to log with the host
         panic::set_hook(Box::new(|info| match info.location() {

--- a/examples/blob/src/main.rs
+++ b/examples/blob/src/main.rs
@@ -7,7 +7,7 @@ mod copy_blob;
 mod create_blob;
 mod print_blob;
 
-azure_functions::main!{
+azure_functions::register!{
     blob_watcher::blob_watcher,
     copy_blob::copy_blob,
     create_blob::create_blob,

--- a/examples/http/src/greet.rs
+++ b/examples/http/src/greet.rs
@@ -9,5 +9,6 @@ pub fn greet(context: &Context, req: &HttpRequest) -> HttpResponse {
     format!(
         "Hello from Rust, {}!\n",
         req.query_params().get("name").map_or("stranger", |x| x)
-    ).into()
+    )
+    .into()
 }

--- a/examples/http/src/main.rs
+++ b/examples/http/src/main.rs
@@ -9,7 +9,7 @@ extern crate serde_json;
 mod greet;
 mod greet_with_json;
 
-azure_functions::main!{
+azure_functions::register!{
     greet::greet,
     greet_with_json::greet_with_json
 }

--- a/examples/queue/src/main.rs
+++ b/examples/queue/src/main.rs
@@ -5,7 +5,7 @@ extern crate log;
 mod queue;
 mod queue_with_output;
 
-azure_functions::main!{
+azure_functions::register!{
     queue::queue,
     queue_with_output::queue_with_output
 }

--- a/examples/table/src/main.rs
+++ b/examples/table/src/main.rs
@@ -4,7 +4,7 @@ extern crate serde_json;
 mod create_row;
 mod read_row;
 
-azure_functions::main!{
+azure_functions::register!{
     create_row::create_row,
     read_row::read_row,
 }

--- a/examples/timer/src/main.rs
+++ b/examples/timer/src/main.rs
@@ -4,6 +4,6 @@ extern crate log;
 
 mod timer;
 
-azure_functions::main!{
+azure_functions::register!{
     timer::timer,
 }


### PR DESCRIPTION
This commit fixes the build so that the `main!` procedural macro is no longer
ambiguous with the main function. It has been renamed to `register!`.

Also fixes are formatting changes resulting from using the latest rustfmt.