### PR TITLE
Fix clippy warnings and enable linting in CI.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,9 +13,15 @@ jobs:
       - run:
           name: Check source formatting
           command: |
-            rustfmt --version || true
+            cargo fmt --version || true
             cargo fmt -- --check
             git diff
+      - run:
+          name: Check for linter errors
+          command: |
+            cargo clippy --version || true
+            # TODO: use cargo clippy -- -Dwarnings once this is merged https://github.com/stepancheg/rust-protobuf/pull/332
+            cargo clippy
       - run:
           name: Build
           command: cargo build --release

--- a/azure-functions-codegen/src/func/bindings/blob.rs
+++ b/azure-functions-codegen/src/func/bindings/blob.rs
@@ -73,7 +73,7 @@ impl TryFrom<AttributeArguments> for Blob<'_> {
         Ok(Blob(Cow::Owned(codegen::bindings::Blob {
             name: name.expect("expected a name for a blob binding"),
             path: path.expect("expected a path for a blob binding"),
-            connection: connection,
+            connection,
             direction: codegen::Direction::In,
         })))
     }

--- a/azure-functions-codegen/src/func/bindings/blob_trigger.rs
+++ b/azure-functions-codegen/src/func/bindings/blob_trigger.rs
@@ -73,7 +73,7 @@ impl TryFrom<AttributeArguments> for BlobTrigger<'_> {
         Ok(BlobTrigger(Cow::Owned(codegen::bindings::BlobTrigger {
             name: name.expect("expected a name for a blob trigger binding"),
             path: path.expect("expected a path for a blob trigger binding"),
-            connection: connection,
+            connection,
             direction: codegen::Direction::In,
         })))
     }

--- a/azure-functions-codegen/src/func/bindings/http_trigger.rs
+++ b/azure-functions-codegen/src/func/bindings/http_trigger.rs
@@ -126,10 +126,10 @@ impl TryFrom<AttributeArguments> for HttpTrigger<'_> {
 
         Ok(HttpTrigger(Cow::Owned(codegen::bindings::HttpTrigger {
             name: name.expect("expected a name for a http trigger binding"),
-            auth_level: auth_level,
+            auth_level,
             methods: Cow::Owned(methods),
-            route: route,
-            web_hook_type: web_hook_type,
+            route,
+            web_hook_type,
         })))
     }
 }

--- a/azure-functions-codegen/src/func/bindings/queue.rs
+++ b/azure-functions-codegen/src/func/bindings/queue.rs
@@ -70,7 +70,7 @@ impl TryFrom<AttributeArguments> for Queue<'_> {
         Ok(Queue(Cow::Owned(codegen::bindings::Queue {
             name: name.expect("expected a name for a queue binding"),
             queue_name: queue_name.expect("expected a queue name for a queue binding"),
-            connection: connection,
+            connection,
         })))
     }
 }

--- a/azure-functions-codegen/src/func/bindings/queue_trigger.rs
+++ b/azure-functions-codegen/src/func/bindings/queue_trigger.rs
@@ -70,7 +70,7 @@ impl TryFrom<AttributeArguments> for QueueTrigger<'_> {
         Ok(QueueTrigger(Cow::Owned(codegen::bindings::QueueTrigger {
             name: name.expect("expected a name for a queue trigger binding"),
             queue_name: queue_name.expect("expected a queue name a queue trigger binding"),
-            connection: connection,
+            connection,
         })))
     }
 }

--- a/azure-functions-codegen/src/func/bindings/table.rs
+++ b/azure-functions-codegen/src/func/bindings/table.rs
@@ -119,11 +119,11 @@ impl TryFrom<AttributeArguments> for Table<'_> {
         Ok(Table(Cow::Owned(codegen::bindings::Table {
             name: name.expect("expected a name for a table binding"),
             table_name: table_name.expect("expected a table name for a table binding"),
-            partition_key: partition_key,
-            row_key: row_key,
-            filter: filter,
-            take: take,
-            connection: connection,
+            partition_key,
+            row_key,
+            filter,
+            take,
+            connection,
             direction: codegen::Direction::In,
         })))
     }

--- a/azure-functions-codegen/src/func/bindings/timer_trigger.rs
+++ b/azure-functions-codegen/src/func/bindings/timer_trigger.rs
@@ -76,9 +76,9 @@ impl TryFrom<AttributeArguments> for TimerTrigger<'_> {
 
         Ok(TimerTrigger(Cow::Owned(codegen::bindings::TimerTrigger {
             name: name.expect("expected a name for a timer trigger binding"),
-            schedule: schedule,
-            run_on_startup: run_on_startup,
-            use_monitor: use_monitor,
+            schedule,
+            run_on_startup,
+            use_monitor,
         })))
     }
 }
@@ -87,8 +87,8 @@ impl ToTokens for TimerTrigger<'_> {
     fn to_tokens(&self, tokens: &mut TokenStream) {
         let name = QuotableBorrowedStr(&self.0.name);
         let schedule = QuotableOption(self.0.schedule.as_ref().map(|x| QuotableBorrowedStr(x)));
-        let run_on_startup = QuotableOption(self.0.run_on_startup.clone());
-        let use_monitor = QuotableOption(self.0.use_monitor.clone());
+        let run_on_startup = QuotableOption(self.0.run_on_startup);
+        let use_monitor = QuotableOption(self.0.use_monitor);
 
         quote!(::azure_functions::codegen::bindings::TimerTrigger {
             name: #name,

--- a/azure-functions-codegen/src/func/invoker.rs
+++ b/azure-functions-codegen/src/func/invoker.rs
@@ -4,7 +4,7 @@ use quote::ToTokens;
 use syn::{FnArg, Ident, ItemFn, Pat, Type, TypeReference};
 use util::{last_segment_in_path, to_camel_case};
 
-const INVOKER_PREFIX: &'static str = "__invoke_";
+const INVOKER_PREFIX: &str = "__invoke_";
 
 pub struct Invoker<'a>(pub &'a ItemFn);
 
@@ -65,7 +65,7 @@ impl Invoker<'a> {
 
     fn is_context_type(ty: &Type) -> bool {
         match ty {
-            Type::Path(tp) => last_segment_in_path(&tp.path).ident.to_string() == CONTEXT_TYPE_NAME,
+            Type::Path(tp) => last_segment_in_path(&tp.path).ident == CONTEXT_TYPE_NAME,
             Type::Paren(tp) => Invoker::is_context_type(&tp.elem),
             _ => false,
         }

--- a/azure-functions-codegen/src/func/output_bindings.rs
+++ b/azure-functions-codegen/src/func/output_bindings.rs
@@ -65,9 +65,7 @@ impl OutputBindings<'a> {
 
                 let arg_type = match &arg.ty {
                     Type::Reference(tr) => {
-                        if tr.mutability.is_none() {
-                            return None;
-                        }
+                        tr.mutability?;
                         tr
                     }
                     _ => panic!("expected a type reference"),
@@ -83,7 +81,7 @@ impl OutputBindings<'a> {
         match t {
             Type::Path(tp) => {
                 let last = last_segment_in_path(&tp.path);
-                if last.ident.to_string() != "Option" {
+                if last.ident != "Option" {
                     return false;
                 }
 
@@ -107,7 +105,7 @@ impl OutputBindings<'a> {
 
     fn is_unit_tuple(t: &Type) -> bool {
         match t {
-            Type::Tuple(tuple) => tuple.elems.len() == 0,
+            Type::Tuple(tuple) => tuple.elems.is_empty(),
             _ => false,
         }
     }

--- a/azure-functions-codegen/src/util.rs
+++ b/azure-functions-codegen/src/util.rs
@@ -17,9 +17,10 @@ pub fn to_camel_case(input: &str) -> String {
         if ch == '_' {
             capitalize = true;
         } else {
-            result.push(match capitalize && !first {
-                true => ch.to_ascii_uppercase(),
-                false => ch,
+            result.push(if capitalize && !first {
+                ch.to_ascii_uppercase()
+            } else {
+                ch
             });
             first = false;
             capitalize = false;
@@ -37,10 +38,7 @@ impl AttributeArguments {
     pub fn with_name(name: &str, span: ::proc_macro2::Span) -> Self {
         AttributeArguments {
             span: span.unstable(),
-            list: vec![(
-                Ident::new("name", span.clone()),
-                Lit::Str(LitStr::new(name, span)),
-            )],
+            list: vec![(Ident::new("name", span), Lit::Str(LitStr::new(name, span)))],
         }
     }
 }

--- a/azure-functions-shared-codegen/src/lib.rs
+++ b/azure-functions-shared-codegen/src/lib.rs
@@ -31,7 +31,7 @@ use syn::{parse, ItemMod};
 /// ```
 #[proc_macro_attribute]
 pub fn generated_mod(_: TokenStream, input: TokenStream) -> TokenStream {
-    let m = parse::<ItemMod>(input.clone()).unwrap();
+    let m = parse::<ItemMod>(input).unwrap();
 
     let ident = &m.ident;
 

--- a/azure-functions-shared/src/codegen/binding.rs
+++ b/azure-functions-shared/src/codegen/binding.rs
@@ -12,6 +12,7 @@ pub enum Direction {
 
 #[derive(Serialize, Debug, Clone)]
 #[serde(untagged, rename_all = "camelCase")]
+#[allow(clippy::large_enum_variant)]
 pub enum Binding {
     Context,
     HttpTrigger(HttpTrigger),

--- a/azure-functions-shared/src/context.rs
+++ b/azure-functions-shared/src/context.rs
@@ -13,9 +13,9 @@ impl Context<'a> {
     /// Creates a new function invocation context.
     pub fn new(invocation_id: &'a str, function_id: &'a str, name: &'a str) -> Self {
         Context {
-            invocation_id: invocation_id,
-            function_id: function_id,
-            name: name,
+            invocation_id,
+            function_id,
+            name,
         }
     }
 

--- a/azure-functions/src/bindings/blob.rs
+++ b/azure-functions/src/bindings/blob.rs
@@ -84,7 +84,7 @@ impl Blob {
     }
 
     /// Deserializes the blob as JSON to the requested type.
-    pub fn from_json<T>(&'b self) -> Result<T>
+    pub fn as_json<T>(&'b self) -> Result<T>
     where
         T: Deserialize<'b>,
     {
@@ -192,7 +192,7 @@ mod tests {
         };
 
         let blob: Blob = ::serde_json::to_value(data).unwrap().into();
-        assert_eq!(blob.from_json::<Data>().unwrap().message, MESSAGE);
+        assert_eq!(blob.as_json::<Data>().unwrap().message, MESSAGE);
 
         let data: protocol::TypedData = blob.into();
         assert_eq!(data.get_json(), r#"{"message":"test"}"#);

--- a/azure-functions/src/bindings/blob_trigger.rs
+++ b/azure-functions/src/bindings/blob_trigger.rs
@@ -5,10 +5,10 @@ use serde_json::from_str;
 use std::collections::HashMap;
 use util::convert_from;
 
-const PATH_KEY: &'static str = "BlobTrigger";
-const URI_KEY: &'static str = "Uri";
-const PROPERTIES_KEY: &'static str = "Properties";
-const METADATA_KEY: &'static str = "Metadata";
+const PATH_KEY: &str = "BlobTrigger";
+const URI_KEY: &str = "Uri";
+const PROPERTIES_KEY: &str = "Properties";
+const METADATA_KEY: &str = "Metadata";
 
 /// Represents an Azure Storage blob trigger binding.
 ///
@@ -66,8 +66,8 @@ impl Trigger for BlobTrigger {
             self.path = path.take_string();
         }
         if let Some(uri) = metadata.get(URI_KEY) {
-            self.uri =
-                convert_from(uri).expect(&format!("failed to read '{}' from metadata", URI_KEY));
+            self.uri = convert_from(uri)
+                .unwrap_or_else(|| panic!("failed to read '{}' from metadata", URI_KEY));
         }
         if let Some(properties) = metadata.get(PROPERTIES_KEY) {
             self.properties =

--- a/azure-functions/src/bindings/http_response.rs
+++ b/azure-functions/src/bindings/http_response.rs
@@ -103,7 +103,7 @@ use std::collections::HashMap;
 ///     body
 /// );
 /// ```
-#[derive(Debug)]
+#[derive(Default, Debug)]
 pub struct HttpResponse {
     pub(crate) data: protocol::RpcHttp,
     pub(crate) status: Status,
@@ -266,10 +266,7 @@ mod tests {
             response.headers().get("Content-Type").unwrap(),
             "application/json"
         );
-        assert_eq!(
-            response.body().from_json::<Data>().unwrap().message,
-            MESSAGE
-        );
+        assert_eq!(response.body().as_json::<Data>().unwrap().message, MESSAGE);
     }
 
     #[test]

--- a/azure-functions/src/bindings/queue_message.rs
+++ b/azure-functions/src/bindings/queue_message.rs
@@ -84,7 +84,7 @@ impl QueueMessage {
     }
 
     /// Deserializes the blob as JSON to the requested type.
-    pub fn from_json<T>(&'b self) -> Result<T>
+    pub fn as_json<T>(&'b self) -> Result<T>
     where
         T: Deserialize<'b>,
     {
@@ -192,7 +192,7 @@ mod tests {
         };
 
         let message: QueueMessage = ::serde_json::to_value(data).unwrap().into();
-        assert_eq!(message.from_json::<Data>().unwrap().message, MESSAGE);
+        assert_eq!(message.as_json::<Data>().unwrap().message, MESSAGE);
 
         let data: protocol::TypedData = message.into();
         assert_eq!(data.get_json(), r#"{"message":"test"}"#);

--- a/azure-functions/src/bindings/queue_trigger.rs
+++ b/azure-functions/src/bindings/queue_trigger.rs
@@ -4,12 +4,12 @@ use rpc::protocol;
 use std::collections::HashMap;
 use util::convert_from;
 
-const ID_KEY: &'static str = "Id";
-const DEQUEUE_COUNT_KEY: &'static str = "DequeueCount";
-const EXPIRATION_TIME_KEY: &'static str = "ExpirationTime";
-const INSERTION_TIME_KEY: &'static str = "InsertionTime";
-const NEXT_VISIBLE_TIME_KEY: &'static str = "NextVisibleTime";
-const POP_RECEIPT_KEY: &'static str = "PopReceipt";
+const ID_KEY: &str = "Id";
+const DEQUEUE_COUNT_KEY: &str = "DequeueCount";
+const EXPIRATION_TIME_KEY: &str = "ExpirationTime";
+const INSERTION_TIME_KEY: &str = "InsertionTime";
+const NEXT_VISIBLE_TIME_KEY: &str = "NextVisibleTime";
+const POP_RECEIPT_KEY: &str = "PopReceipt";
 
 /// Represents a queue trigger binding.
 ///
@@ -67,28 +67,23 @@ impl Trigger for QueueTrigger {
             self.id = id.take_string();
         }
         if let Some(count) = metadata.get(DEQUEUE_COUNT_KEY) {
-            self.dequeue_count = convert_from(count).expect(&format!(
-                "failed to read '{}' from metadata",
-                DEQUEUE_COUNT_KEY
-            ));
+            self.dequeue_count = convert_from(count)
+                .unwrap_or_else(|| panic!("failed to read '{}' from metadata", DEQUEUE_COUNT_KEY));
         }
         if let Some(time) = metadata.get(EXPIRATION_TIME_KEY) {
-            self.expiration_time = convert_from(time).map(|t| Some(t)).expect(&format!(
-                "failed to read '{}' from metadata",
-                EXPIRATION_TIME_KEY
-            ));
+            self.expiration_time = Some(convert_from(time).unwrap_or_else(|| {
+                panic!("failed to read '{}' from metadata", EXPIRATION_TIME_KEY)
+            }));
         }
         if let Some(time) = metadata.get(INSERTION_TIME_KEY) {
-            self.insertion_time = convert_from(time).map(|t| Some(t)).expect(&format!(
-                "failed to read '{}' from metadata",
-                INSERTION_TIME_KEY
-            ));
+            self.insertion_time = Some(convert_from(time).unwrap_or_else(|| {
+                panic!("failed to read '{}' from metadata", INSERTION_TIME_KEY)
+            }));
         }
         if let Some(time) = metadata.get(NEXT_VISIBLE_TIME_KEY) {
-            self.next_visible_time = convert_from(time).map(|t| Some(t)).expect(&format!(
-                "failed to read '{}' from metadata",
-                NEXT_VISIBLE_TIME_KEY
-            ));
+            self.next_visible_time = Some(convert_from(time).unwrap_or_else(|| {
+                panic!("failed to read '{}' from metadata", NEXT_VISIBLE_TIME_KEY)
+            }));
         }
         if let Some(receipt) = metadata.get_mut(POP_RECEIPT_KEY) {
             self.pop_receipt = receipt.take_string();

--- a/azure-functions/src/bindings/table.rs
+++ b/azure-functions/src/bindings/table.rs
@@ -37,7 +37,7 @@ use std::fmt;
 ///         info!("Row: {:?}", row);
 ///     }
 /// }
-#[derive(Debug, Clone)]
+#[derive(Default, Debug, Clone)]
 pub struct Table(Value);
 
 /// Represents the data of an Azure Storage table row.
@@ -100,7 +100,7 @@ impl Table {
     }
 
     /// Converts the table binding to a JSON value.
-    pub fn to_value(self) -> Value {
+    pub fn into_value(self) -> Value {
         self.0
     }
 }
@@ -224,7 +224,7 @@ mod tests {
         table.add_row("partition1", "row1");
 
         assert_eq!(
-            table.to_value().to_string(),
+            table.into_value().to_string(),
             r#"[{"PartitionKey":"partition1","RowKey":"row1"}]"#
         );
     }

--- a/azure-functions/src/http/body.rs
+++ b/azure-functions/src/http/body.rs
@@ -104,10 +104,10 @@ impl Body<'_> {
     /// }
     ///
     /// let body = Body::String(Cow::Borrowed(r#"{ "message": "hello" }"#));
-    /// let data = body.from_json::<Data>().unwrap();
+    /// let data = body.as_json::<Data>().unwrap();
     /// assert_eq!(data.message, "hello");
     /// ```
-    pub fn from_json<T>(&'b self) -> Result<T>
+    pub fn as_json<T>(&'b self) -> Result<T>
     where
         T: Deserialize<'b>,
     {
@@ -244,7 +244,7 @@ mod tests {
         };
 
         let body: Body = ::serde_json::to_value(data).unwrap().into();
-        assert_eq!(body.from_json::<Data>().unwrap().message, MESSAGE);
+        assert_eq!(body.as_json::<Data>().unwrap().message, MESSAGE);
 
         let data: protocol::TypedData = body.into();
         assert_eq!(data.get_json(), r#"{"message":"test"}"#);

--- a/azure-functions/src/http/response_builder.rs
+++ b/azure-functions/src/http/response_builder.rs
@@ -2,7 +2,7 @@ use bindings::HttpResponse;
 use http::{Body, Status};
 
 /// Represents a builder for HTTP responses.
-#[derive(Debug)]
+#[derive(Default, Debug)]
 pub struct ResponseBuilder(pub(crate) HttpResponse);
 
 impl ResponseBuilder {
@@ -84,13 +84,10 @@ impl ResponseBuilder {
         B: Into<Body<'a>>,
     {
         let body = body.into();
-        match &body {
-            Body::Empty => {
-                self.0.data.clear_body();
-                return self;
-            }
-            _ => {}
-        };
+        if let Body::Empty = &body {
+            self.0.data.clear_body();
+            return self;
+        }
 
         if !self.0.headers().contains_key("Content-Type") {
             self.0.data.mut_headers().insert(

--- a/azure-functions/src/http/status.rs
+++ b/azure-functions/src/http/status.rs
@@ -1,5 +1,5 @@
 /// Represents a HTTP status code.
-#[derive(Debug, Clone, Copy, Hash, PartialEq, Eq)]
+#[derive(Default, Debug, Clone, Copy, Hash, PartialEq, Eq)]
 pub struct Status(u16);
 
 macro_rules! statuses {

--- a/azure-functions/src/logger.rs
+++ b/azure-functions/src/logger.rs
@@ -12,10 +12,7 @@ pub struct Logger {
 
 impl Logger {
     pub fn new(level: Level, sender: Sender) -> Logger {
-        Logger {
-            level: level,
-            sender: sender,
-        }
+        Logger { level, sender }
     }
 }
 

--- a/azure-functions/src/registry.rs
+++ b/azure-functions/src/registry.rs
@@ -34,7 +34,7 @@ impl<'a> Registry<'a> {
     }
 
     pub fn get(&self, id: &str) -> Option<&'a Function> {
-        self.registered.get(id).map(|x| *x)
+        self.registered.get(id).cloned()
     }
 
     pub fn iter(&self) -> Iter<String, &'a Function> {

--- a/azure-functions/src/util.rs
+++ b/azure-functions/src/util.rs
@@ -17,14 +17,14 @@ where
     }
 
     if data.has_bytes() {
-        if let Some(s) = from_utf8(data.get_bytes()).ok() {
+        if let Ok(s) = from_utf8(data.get_bytes()) {
             return s.parse::<T>().ok();
         }
         return None;
     }
 
     if data.has_stream() {
-        if let Some(s) = from_utf8(data.get_stream()).ok() {
+        if let Ok(s) = from_utf8(data.get_stream()) {
             return s.parse::<T>().ok();
         }
         return None;

--- a/docker/ci/Dockerfile
+++ b/docker/ci/Dockerfile
@@ -2,6 +2,7 @@ FROM rustlang/rust:nightly-slim
 LABEL MAINTAINER Peter Huene <peterhuene@protonmail.com>
 
 RUN    rustup component add rustfmt-preview --toolchain nightly \
+    && rustup component add clippy-preview --toolchain nightly \
     && apt-get update \
     && apt-get upgrade -y \
     && apt-get install -y wget unzip \

--- a/examples/http/README.md
+++ b/examples/http/README.md
@@ -43,7 +43,7 @@ struct Response {
 #[func]
 #[binding(name = "req", auth_level = "anonymous")]
 pub fn greet_with_json(req: &HttpRequest) -> HttpResponse {
-    if let Ok(request) = req.body().from_json::<Request>() {
+    if let Ok(request) = req.body().as_json::<Request>() {
         let response = Response {
             message: format!("Hello from Rust, {}!", request.name),
         };

--- a/examples/http/src/greet_with_json.rs
+++ b/examples/http/src/greet_with_json.rs
@@ -16,7 +16,7 @@ struct Response {
 #[func]
 #[binding(name = "req", auth_level = "anonymous")]
 pub fn greet_with_json(req: &HttpRequest) -> HttpResponse {
-    if let Ok(request) = req.body().from_json::<Request>() {
+    if let Ok(request) = req.body().as_json::<Request>() {
         let response = Response {
             message: format!("Hello from Rust, {}!", request.name),
         };


### PR DESCRIPTION
This commit fixes all clippy warnings (except for two; see
https://github.com/stepancheg/rust-protobuf/pull/332).

Additionally, clippy is added to the CI image and enabled in the CircleCI build
definition.