### PR TITLE
Disable compiling protobufs except for CI.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,10 @@ jobs:
             cargo clippy
       - run:
           name: Build
-          command: cargo build --release
+          command: cargo build --release --features compile_protobufs
+      - run:
+          name: Check for stale protobuf files
+          command: git diff-index --quiet HEAD
       - run:
           name: Test
           command: cargo test --release

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -61,7 +61,6 @@ dependencies = [
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "grpcio 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "protobuf 2.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "protoc 2.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "protoc-grpcio 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/azure-functions-shared/Cargo.toml
+++ b/azure-functions-shared/Cargo.toml
@@ -17,4 +17,7 @@ serde_derive = "1.0.79"
 
 [build-dependencies]
 protoc-grpcio = "0.3.0"
-protoc = "2.1.4"
+
+[features]
+default = []
+compile_protobufs = []

--- a/azure-functions-shared/build.rs
+++ b/azure-functions-shared/build.rs
@@ -1,7 +1,5 @@
-extern crate protoc;
 extern crate protoc_grpcio;
 
-use protoc::Protoc;
 use std::env;
 use std::fs;
 use std::path::PathBuf;
@@ -53,7 +51,7 @@ fn main() {
 
     fs::create_dir_all(&cache_dir).expect("failed to create cache directory");
 
-    if Protoc::from_env_path().check().is_ok() {
+    if cfg!(feature = "compile_protobufs") {
         compile_protobufs(&out_dir, &cache_dir);
     } else {
         use_cached_files(&out_dir, &cache_dir);


### PR DESCRIPTION
This commit disables compiling protobufs except for the nightly CI.

This should allow both documentation generation for docs.rs and packaging when
protoc is installed.