### PR TITLE
Implement `sync-extensions` worker command.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,12 +34,15 @@ dependencies = [
  "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
  "grpcio 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.80 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.32 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tempfile 3.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-threadpool 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "xml-rs 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -625,6 +628,11 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
+[[package]]
+name = "xml-rs"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
 [metadata]
 "checksum ansi_term 0.11.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee49baf6cb617b853aa8d93bf420db2383fab46d314482ca2803b40d5fde979b"
 "checksum arrayvec 0.4.7 (registry+https://github.com/rust-lang/crates.io-index)" = "a1e964f9e24d588183fcb43503abda40d288c8657dfc27311516ce2f05675aef"
@@ -694,3 +702,4 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "92c1eb33641e276cfa214a0522acad57be5c56b10cb348b3c5117db75f3ac4b0"
 "checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 "checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+"checksum xml-rs 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "541b12c998c5b56aa2b4e6f18f03664eef9a4fd0a246a55594efae6cc2d964b5"

--- a/azure-functions-shared/src/codegen/binding.rs
+++ b/azure-functions-shared/src/codegen/binding.rs
@@ -1,6 +1,4 @@
-use codegen::bindings::{
-    Blob, BlobTrigger, Http, HttpTrigger, Queue, QueueTrigger, Table, TimerTrigger,
-};
+use codegen::bindings;
 
 #[derive(Serialize, Debug, Clone)]
 #[serde(rename_all = "lowercase")]
@@ -15,14 +13,14 @@ pub enum Direction {
 #[allow(clippy::large_enum_variant)]
 pub enum Binding {
     Context,
-    HttpTrigger(HttpTrigger),
-    Http(Http),
-    TimerTrigger(TimerTrigger),
-    QueueTrigger(QueueTrigger),
-    Queue(Queue),
-    BlobTrigger(BlobTrigger),
-    Blob(Blob),
-    Table(Table),
+    HttpTrigger(bindings::HttpTrigger),
+    Http(bindings::Http),
+    TimerTrigger(bindings::TimerTrigger),
+    QueueTrigger(bindings::QueueTrigger),
+    Queue(bindings::Queue),
+    BlobTrigger(bindings::BlobTrigger),
+    Blob(bindings::Blob),
+    Table(bindings::Table),
 }
 
 impl Binding {
@@ -37,6 +35,20 @@ impl Binding {
             Binding::BlobTrigger(b) => Some(&b.name),
             Binding::Blob(b) => Some(&b.name),
             Binding::Table(b) => Some(&b.name),
+        }
+    }
+
+    pub fn binding_type(&self) -> Option<&str> {
+        match self {
+            Binding::Context => None,
+            Binding::HttpTrigger(_) => Some(bindings::HTTP_TRIGGER_TYPE),
+            Binding::Http(_) => Some(bindings::HTTP_TYPE),
+            Binding::TimerTrigger(_) => Some(bindings::TIMER_TRIGGER_TYPE),
+            Binding::QueueTrigger(_) => Some(bindings::QUEUE_TRIGGER_TYPE),
+            Binding::Queue(_) => Some(bindings::QUEUE_TYPE),
+            Binding::BlobTrigger(_) => Some(bindings::BLOB_TRIGGER_TYPE),
+            Binding::Blob(_) => Some(bindings::BLOB_TYPE),
+            Binding::Table(_) => Some(bindings::TABLE_TYPE),
         }
     }
 

--- a/azure-functions-shared/src/codegen/bindings/blob.rs
+++ b/azure-functions-shared/src/codegen/bindings/blob.rs
@@ -2,6 +2,8 @@ use codegen::Direction;
 use serde::{ser::SerializeMap, Serialize, Serializer};
 use std::borrow::Cow;
 
+pub const BLOB_TYPE: &str = "blob";
+
 #[derive(Debug, Clone)]
 pub struct Blob {
     pub name: Cow<'static, str>,
@@ -20,7 +22,7 @@ impl Serialize for Blob {
         let mut map = serializer.serialize_map(None)?;
 
         map.serialize_entry("name", &self.name)?;
-        map.serialize_entry("type", "blob")?;
+        map.serialize_entry("type", BLOB_TYPE)?;
         map.serialize_entry("direction", &self.direction)?;
         map.serialize_entry("path", &self.path)?;
 

--- a/azure-functions-shared/src/codegen/bindings/blob_trigger.rs
+++ b/azure-functions-shared/src/codegen/bindings/blob_trigger.rs
@@ -2,6 +2,8 @@ use codegen::Direction;
 use serde::{ser::SerializeMap, Serialize, Serializer};
 use std::borrow::Cow;
 
+pub const BLOB_TRIGGER_TYPE: &str = "blobTrigger";
+
 #[derive(Debug, Clone)]
 pub struct BlobTrigger {
     pub name: Cow<'static, str>,
@@ -20,7 +22,7 @@ impl Serialize for BlobTrigger {
         let mut map = serializer.serialize_map(None)?;
 
         map.serialize_entry("name", &self.name)?;
-        map.serialize_entry("type", "blobTrigger")?;
+        map.serialize_entry("type", BLOB_TRIGGER_TYPE)?;
         map.serialize_entry("direction", &self.direction)?;
         map.serialize_entry("path", &self.path)?;
 

--- a/azure-functions-shared/src/codegen/bindings/http.rs
+++ b/azure-functions-shared/src/codegen/bindings/http.rs
@@ -1,6 +1,8 @@
 use serde::{ser::SerializeMap, Serialize, Serializer};
 use std::borrow::Cow;
 
+pub const HTTP_TYPE: &str = "http";
+
 #[derive(Debug, Clone)]
 pub struct Http {
     pub name: Cow<'static, str>,
@@ -16,7 +18,7 @@ impl Serialize for Http {
         let mut map = serializer.serialize_map(None)?;
 
         map.serialize_entry("name", &self.name)?;
-        map.serialize_entry("type", "http")?;
+        map.serialize_entry("type", HTTP_TYPE)?;
         map.serialize_entry("direction", "out")?;
 
         map.end()

--- a/azure-functions-shared/src/codegen/bindings/http_trigger.rs
+++ b/azure-functions-shared/src/codegen/bindings/http_trigger.rs
@@ -1,6 +1,8 @@
 use serde::{ser::SerializeMap, Serialize, Serializer};
 use std::borrow::Cow;
 
+pub const HTTP_TRIGGER_TYPE: &str = "httpTrigger";
+
 #[derive(Debug, Clone)]
 pub struct HttpTrigger {
     pub name: Cow<'static, str>,
@@ -20,7 +22,7 @@ impl Serialize for HttpTrigger {
         let mut map = serializer.serialize_map(None)?;
 
         map.serialize_entry("name", &self.name)?;
-        map.serialize_entry("type", "httpTrigger")?;
+        map.serialize_entry("type", HTTP_TRIGGER_TYPE)?;
         map.serialize_entry("direction", "in")?;
 
         if let Some(auth_level) = self.auth_level.as_ref() {

--- a/azure-functions-shared/src/codegen/bindings/queue.rs
+++ b/azure-functions-shared/src/codegen/bindings/queue.rs
@@ -1,6 +1,8 @@
 use serde::{ser::SerializeMap, Serialize, Serializer};
 use std::borrow::Cow;
 
+pub const QUEUE_TYPE: &str = "queue";
+
 #[derive(Debug, Clone)]
 pub struct Queue {
     pub name: Cow<'static, str>,
@@ -18,7 +20,7 @@ impl Serialize for Queue {
         let mut map = serializer.serialize_map(None)?;
 
         map.serialize_entry("name", &self.name)?;
-        map.serialize_entry("type", "queue")?;
+        map.serialize_entry("type", QUEUE_TYPE)?;
         map.serialize_entry("direction", "out")?;
         map.serialize_entry("queueName", &self.queue_name)?;
 

--- a/azure-functions-shared/src/codegen/bindings/queue_trigger.rs
+++ b/azure-functions-shared/src/codegen/bindings/queue_trigger.rs
@@ -1,6 +1,8 @@
 use serde::{ser::SerializeMap, Serialize, Serializer};
 use std::borrow::Cow;
 
+pub const QUEUE_TRIGGER_TYPE: &str = "queueTrigger";
+
 #[derive(Debug, Clone)]
 pub struct QueueTrigger {
     pub name: Cow<'static, str>,
@@ -18,7 +20,7 @@ impl Serialize for QueueTrigger {
         let mut map = serializer.serialize_map(None)?;
 
         map.serialize_entry("name", &self.name)?;
-        map.serialize_entry("type", "queueTrigger")?;
+        map.serialize_entry("type", QUEUE_TRIGGER_TYPE)?;
         map.serialize_entry("direction", "in")?;
         map.serialize_entry("queueName", &self.queue_name)?;
 

--- a/azure-functions-shared/src/codegen/bindings/table.rs
+++ b/azure-functions-shared/src/codegen/bindings/table.rs
@@ -2,6 +2,8 @@ use codegen::Direction;
 use serde::{ser::SerializeMap, Serialize, Serializer};
 use std::borrow::Cow;
 
+pub const TABLE_TYPE: &str = "table";
+
 #[derive(Debug, Clone)]
 pub struct Table {
     pub name: Cow<'static, str>,
@@ -24,7 +26,7 @@ impl Serialize for Table {
         let mut map = serializer.serialize_map(None)?;
 
         map.serialize_entry("name", &self.name)?;
-        map.serialize_entry("type", "table")?;
+        map.serialize_entry("type", TABLE_TYPE)?;
         map.serialize_entry("direction", &self.direction)?;
         map.serialize_entry("tableName", &self.table_name)?;
 

--- a/azure-functions-shared/src/codegen/bindings/timer_trigger.rs
+++ b/azure-functions-shared/src/codegen/bindings/timer_trigger.rs
@@ -1,6 +1,8 @@
 use serde::{ser::SerializeMap, Serialize, Serializer};
 use std::borrow::Cow;
 
+pub const TIMER_TRIGGER_TYPE: &str = "timerTrigger";
+
 #[derive(Debug, Clone)]
 pub struct TimerTrigger {
     pub name: Cow<'static, str>,
@@ -19,7 +21,7 @@ impl Serialize for TimerTrigger {
         let mut map = serializer.serialize_map(None)?;
 
         map.serialize_entry("name", &self.name)?;
-        map.serialize_entry("type", "timerTrigger")?;
+        map.serialize_entry("type", TIMER_TRIGGER_TYPE)?;
         map.serialize_entry("direction", "in")?;
 
         if let Some(schedule) = self.schedule.as_ref() {

--- a/azure-functions/Cargo.toml
+++ b/azure-functions/Cargo.toml
@@ -18,6 +18,9 @@ serde = "1.0.79"
 serde_json = "1.0.31"
 serde_derive = "1.0.79"
 chrono = { version = "0.4.6", features = ["serde"] }
+xml-rs = "0.8.0"
+lazy_static = "1.2.0"
+tempfile = "3.0.4"
 
 [dev-dependencies]
 matches = "0.1.8"

--- a/azure-functions/src/bindings/blob.rs
+++ b/azure-functions/src/bindings/blob.rs
@@ -216,7 +216,7 @@ mod tests {
         let blob: Blob = BLOB.into();
 
         let mut s = String::new();
-        write!(s, "{}", blob);
+        write!(s, "{}", blob).unwrap();
 
         assert_eq!(s, BLOB);
     }

--- a/azure-functions/src/bindings/queue_message.rs
+++ b/azure-functions/src/bindings/queue_message.rs
@@ -216,7 +216,7 @@ mod tests {
         let message: QueueMessage = MESSAGE.into();
 
         let mut s = String::new();
-        write!(s, "{}", message);
+        write!(s, "{}", message).unwrap();
 
         assert_eq!(s, MESSAGE);
     }

--- a/azure-functions/src/bindings/table.rs
+++ b/azure-functions/src/bindings/table.rs
@@ -237,7 +237,7 @@ mod tests {
             row.insert("data".to_string(), Value::String("value".to_string()));
         }
         let mut s = String::new();
-        write!(s, "{}", table);
+        write!(s, "{}", table).unwrap();
 
         assert_eq!(
             s,

--- a/azure-functions/src/cli.rs
+++ b/azure-functions/src/cli.rs
@@ -23,6 +23,17 @@ pub fn create_app() -> App<'a, 'b> {
                 )
         )
         .subcommand(
+            SubCommand::with_name("sync-extensions")
+                .about("Synchronizes the Azure Function binding extensions used by the worker.")
+                .arg(
+                    Arg::with_name("script_root")
+                        .long("script-root")
+                        .value_name("SCRIPT_ROOT")
+                        .help("The script root to synchronize the binding extensions for.")
+                        .required(true),
+                )
+        )
+        .subcommand(
             SubCommand::with_name("run")
                 .about("Runs the Rust language worker.")
                  .arg(

--- a/azure-functions/src/http/body.rs
+++ b/azure-functions/src/http/body.rs
@@ -268,7 +268,7 @@ mod tests {
         let body: Body = BODY.into();
 
         let mut s = String::new();
-        write!(s, "{}", body);
+        write!(s, "{}", body).unwrap();
 
         assert_eq!(s, BODY);
     }


### PR DESCRIPTION
This commit implements a `sync-extensions` command for the language worker.
The command is responsible for generating a .NET Core project file that can be
used to restore and publish the required Azure Functions binding extensions.

Currently, only one binding extension is supported, which is for storage.  If
you use storage bindings the `sync-extensions` command will automatically
restore the binding extensions for the Azure Functions storage bindings.

Fixes #53.