### PR TITLE
Fix formatting with recent rust-fmt.

### DIFF
--- a/azure-functions-codegen/src/export.rs
+++ b/azure-functions-codegen/src/export.rs
@@ -38,7 +38,7 @@ pub fn attr_impl(input: TokenStream) -> TokenStream {
         })
         .collect();
 
-    let expanded = quote!{
+    let expanded = quote! {
         &[#(&#funcs),*]
     };
 

--- a/azure-functions-codegen/src/func/mod.rs
+++ b/azure-functions-codegen/src/func/mod.rs
@@ -462,7 +462,7 @@ pub fn attr_impl(args: TokenStream, input: TokenStream) -> TokenStream {
 
     let func = Function(Cow::Borrowed(&func));
 
-    let expanded = quote!{
+    let expanded = quote! {
         #target
 
         #invoker

--- a/examples/blob/src/main.rs
+++ b/examples/blob/src/main.rs
@@ -12,7 +12,7 @@ mod print_blob;
 pub fn main() {
     azure_functions::worker_main(
         ::std::env::args(),
-        azure_functions::export!{
+        azure_functions::export! {
             blob_watcher::blob_watcher,
             copy_blob::copy_blob,
             create_blob::create_blob,

--- a/examples/http/src/main.rs
+++ b/examples/http/src/main.rs
@@ -14,7 +14,7 @@ mod greet_with_json;
 pub fn main() {
     azure_functions::worker_main(
         ::std::env::args(),
-        azure_functions::export!{
+        azure_functions::export! {
             greet::greet,
             greet_with_json::greet_with_json
         },

--- a/examples/queue/src/main.rs
+++ b/examples/queue/src/main.rs
@@ -10,7 +10,7 @@ mod queue_with_output;
 pub fn main() {
     azure_functions::worker_main(
         ::std::env::args(),
-        azure_functions::export!{
+        azure_functions::export! {
             queue::queue,
             queue_with_output::queue_with_output
         },

--- a/examples/table/src/main.rs
+++ b/examples/table/src/main.rs
@@ -9,7 +9,7 @@ mod read_row;
 pub fn main() {
     azure_functions::worker_main(
         ::std::env::args(),
-        azure_functions::export!{
+        azure_functions::export! {
             create_row::create_row,
             read_row::read_row,
         },

--- a/examples/timer/src/main.rs
+++ b/examples/timer/src/main.rs
@@ -9,7 +9,7 @@ mod timer;
 pub fn main() {
     azure_functions::worker_main(
         ::std::env::args(),
-        azure_functions::export!{
+        azure_functions::export! {
             timer::timer,
         },
     );


### PR DESCRIPTION
This commit fixes the formatting changes resulting from the latest rust-fmt.