### PR TITLE
Fix the Dockerfile template for `cargo func new-app`.

### DIFF
--- a/azure-functions-sdk/src/templates/new-app/Dockerfile.hbs
+++ b/azure-functions-sdk/src/templates/new-app/Dockerfile.hbs
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile-upstream:experimental
 
-FROM peterhuene/azure-functions-rs-build:{{crate_version}} AS builder
+FROM peterhuene/azure-functions-rs-build:{{crate_version}} AS build-image
 
 WORKDIR /src
 COPY . /src
@@ -11,14 +11,27 @@ RUN --mount=type=cache,target=/src/target \
     --mount=type=cache,target=/usr/local/cargo/registry \
     ["cargo", "run", "--release", "--", "init", "--worker-path", "/usr/local/bin/rust_worker", "--script-root", "/home/site/wwwroot", "--sync"]
 
-FROM microsoft/azure-functions-dotnet-core2.0:2.0
+FROM mcr.microsoft.com/azure-functions/base:2.0 as runtime-image
 
-# Copy the worker from the build image
-COPY --from=builder ["/usr/local/bin/rust_worker", "/usr/local/bin/rust_worker"]
+FROM microsoft/dotnet:2.2-aspnetcore-runtime
 
-# Copy configuration to the Azure Functions Host
-COPY --from=builder ["/src/appsettings.json", "/azure-functions-host/appsettings.json"]
+ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
+    HOME=/home \
+    FUNCTIONS_WORKER_RUNTIME=Rust
+
+# Copy the Azure Functions host from the runtime image
+COPY --from=runtime-image [ "/azure-functions-host", "/azure-functions-host" ]
+
+# Create the Rust worker config
 ADD ["https://raw.githubusercontent.com/peterhuene/azure-functions-rs/v{{crate_version}}/azure-functions/worker.config.json", "/azure-functions-host/workers/rust/worker.config.json"]
 
+# Copy the worker from the build image
+COPY --from=build-image [ "/usr/local/bin/rust_worker", "/usr/local/bin/rust_worker" ]
+
+# Copy configuration to the Azure Functions Host
+COPY --from=build-image ["/src/appsettings.json", "/azure-functions-host/appsettings.json"]
+
 # Copy the script root contents from the build image
-COPY --from=builder ["/home/site/wwwroot", "/home/site/wwwroot"]
+COPY --from=build-image ["/home/site/wwwroot", "/home/site/wwwroot"]
+
+CMD [ "dotnet", "/azure-functions-host/Microsoft.Azure.WebJobs.Script.WebHost.dll" ]


### PR DESCRIPTION
This commit fixes the Dockerfile template for the `cargo func new-app` command
so that the correct base image is used and the `FUNCTIONS_WORKER_RUNTIME`
environment variable is set.