### PR TITLE
Implement nightly and stable builds for CI.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,16 @@
-version: 2
+version: 2.1
 jobs:
   build:
+    parameters:
+      image:
+        description: "The CI image to use."
+        type: string
+      cargo-features:
+        description: "The additional cargo features to enable for the build."
+        type: string
+        default: ""
     docker:
-      - image: peterhuene/azure-functions-rs-ci
+      - image: "<< parameters.image >>"
     steps:
       - checkout
       - restore_cache:
@@ -16,16 +24,15 @@ jobs:
             cargo fmt --version || true
             cargo fmt -- --check
             git diff
-      # Disabling lint check until the component shows up again in nightly
-      # - run:
-      #     name: Check for linter errors
-      #     command: |
-      #       cargo clippy --version || true
-      #       # TODO: use cargo clippy -- -Dwarnings once this is merged https://github.com/stepancheg/rust-protobuf/pull/332
-      #       cargo clippy
+      - run:
+          name: Check for linter errors
+          command: |
+            cargo clippy --version || true
+            # TODO: use cargo clippy -- -Dwarnings once this is merged https://github.com/stepancheg/rust-protobuf/pull/332
+            cargo clippy
       - run:
           name: Build
-          command: cargo build --release --features compile_protobufs
+          command: "cargo build --release --features 'compile_protobufs << parameters.cargo-features >>'"
       - run:
           name: Check for stale protobuf files
           command: git diff --exit-code -- azure-functions-shared/cache
@@ -38,6 +45,13 @@ jobs:
             - "~/.cargo"
             - "./target"
   build-ci-image:
+    parameters:
+      image:
+        description: "The CI image to build."
+        type: string
+      directory:
+        description: "The directory containing the Dockerfile."
+        type: string
     docker:
       - image: docker:stable-git
     steps:
@@ -50,20 +64,28 @@ jobs:
       - run:
           name: Build CI Docker image
           command: |
-            cd docker/ci
-            docker build -t peterhuene/azure-functions-rs-ci:latest .
+            "cd << parameters.directory >>"
+            "docker build --pull -t << parameters.image >> ."
       - run:
           name: Push CI Docker image
-          command: docker push peterhuene/azure-functions-rs-ci:latest
+          command: "docker push << parameters.image >>"
 workflows:
-  version: 2
-  commit:
+  commit-stable:
     jobs:
       - build:
+          image: peterhuene/azure-functions-rs-ci:stable
           filters:
             branches:
               ignore: gh-pages
-  nightly:
+  commit-nightly:
+    jobs:
+      - build:
+          image: peterhuene/azure-functions-rs-ci:nightly
+          cargo-features: unstable
+          filters:
+            branches:
+              ignore: gh-pages
+  build-stable:
     triggers:
       - schedule:
           cron: "0 0 * * *"
@@ -72,5 +94,27 @@ workflows:
               only:
                 - master
     jobs:
-      - build-ci-image
-      - build
+      - build-ci-image:
+          directory: docker/ci-stable
+          image: peterhuene/azure-functions-rs-ci:stable
+      - build:
+          requires:
+            - build-ci-image
+          image: peterhuene/azure-functions-rs-ci:stable
+  build-nightly:
+      triggers:
+        - schedule:
+            cron: "0 0 * * *"
+            filters:
+              branches:
+                only:
+                  - master
+      jobs:
+        - build-ci-image:
+            directory: docker/ci-nightly
+            image: peterhuene/azure-functions-rs-ci:nightly
+        - build:
+            requires:
+              - build-ci-image
+            image: peterhuene/azure-functions-rs-ci:nightly
+            cargo-features: unstable

--- a/docker/ci-nightly/Dockerfile
+++ b/docker/ci-nightly/Dockerfile
@@ -1,0 +1,20 @@
+FROM rustlang/rust:nightly-slim
+LABEL MAINTAINER Peter Huene <peterhuene@protonmail.com>
+
+RUN    rustup component add rustfmt-preview --toolchain nightly \
+    && rustup component add clippy --toolchain nightly \
+    && apt-get update \
+    && apt-get upgrade -y \
+    && apt-get install -y wget unzip \
+    && wget https://github.com/google/protobuf/releases/download/v3.6.1/protoc-3.6.1-linux-x86_64.zip \
+    && unzip protoc-3.6.1-linux-x86_64.zip -d /usr \
+    && rm protoc-3.6.1-linux-x86_64.zip \
+    && apt-get install -y g++ cmake libssl-dev git \
+    && apt-get remove -y --purge wget unzip \
+    && apt-get autoremove -y;
+
+ENV PATH "$PATH:/root/.cargo/bin"
+
+WORKDIR /root
+
+CMD ["/bin/true"]

--- a/docker/ci-stable/Dockerfile
+++ b/docker/ci-stable/Dockerfile
@@ -1,13 +1,14 @@
-FROM rustlang/rust:nightly-slim
+FROM rust:latest
 LABEL MAINTAINER Peter Huene <peterhuene@protonmail.com>
 
-RUN    rustup component add rustfmt-preview --toolchain nightly \
+RUN    rustup component add rustfmt-preview \
+    && rustup component add clippy \
     && apt-get update \
     && apt-get upgrade -y \
     && apt-get install -y wget unzip \
-    && wget https://github.com/google/protobuf/releases/download/v3.6.0/protoc-3.6.0-linux-x86_64.zip \
-    && unzip protoc-3.6.0-linux-x86_64.zip -d /usr \
-    && rm protoc-3.6.0-linux-x86_64.zip \
+    && wget https://github.com/google/protobuf/releases/download/v3.6.1/protoc-3.6.1-linux-x86_64.zip \
+    && unzip protoc-3.6.1-linux-x86_64.zip -d /usr \
+    && rm protoc-3.6.1-linux-x86_64.zip \
     && apt-get install -y g++ cmake libssl-dev git \
     && apt-get remove -y --purge wget unzip \
     && apt-get autoremove -y;

--- a/docker/sdk/Dockerfile
+++ b/docker/sdk/Dockerfile
@@ -1,4 +1,5 @@
 FROM rustlang/rust:nightly-slim AS builder
+LABEL MAINTAINER Peter Huene <peterhuene@protonmail.com>
 
 ENV DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1
 


### PR DESCRIPTION
This commit implements definitions for building nightly and stable CI images
for the nightly builds and turns on a commit-triggered build for both stable
and nightly.

Clippy is also re-enabled now that it is back in the nightly builds.