### PR TITLE
HTTPS Submodule instead of ssh

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ jobs:
           command: cargo build --release --features compile_protobufs
       - run:
           name: Check for stale protobuf files
-          command: git diff-index --quiet HEAD
+          command: git diff --exit-code -- azure-functions-shared/cache
       - run:
           name: Test
           command: cargo test --release

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "azure-functions-shared/protobuf"]
     path = azure-functions-shared/protobuf
-    url = git@github.com:Azure/azure-functions-language-worker-protobuf.git
+    url = https://github.com/Azure/azure-functions-language-worker-protobuf


### PR DESCRIPTION
Change submodules url to use https because cargo only works with https submodules. 