### PR TITLE
Fix the nightly build of CI images.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,8 +64,8 @@ jobs:
       - run:
           name: Build CI Docker image
           command: |
-            "cd << parameters.directory >>"
-            "docker build --pull -t << parameters.image >> ."
+            cd << parameters.directory >>
+            docker build --pull -t << parameters.image >> .
       - run:
           name: Push CI Docker image
           command: "docker push << parameters.image >>"


### PR DESCRIPTION
This commit fixes the unnecessary quotes around the command to build the
CI image that runs nightly.