### PR TITLE
Use the Rust "slim" image for the stable CI base image.

### DIFF
--- a/docker/ci-stable/Dockerfile
+++ b/docker/ci-stable/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:latest
+FROM rust:slim
 LABEL MAINTAINER Peter Huene <peterhuene@protonmail.com>
 
 RUN    rustup component add rustfmt-preview \


### PR DESCRIPTION
This commit changes the base image for the stable CI to the "slim" Rust image
that saves a substantial amount of space in the resulting CI image.