### PR TITLE
Pass trigger and input bindings by value.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ use azure_functions::bindings::{HttpRequest, HttpResponse};
 use azure_functions::func;
 
 #[func]
-pub fn greet(req: &HttpRequest) -> HttpResponse {
+pub fn greet(req: HttpRequest) -> HttpResponse {
     // Log the message with the Azure Functions Host
     info!("Request: {:?}", req);
 
@@ -221,12 +221,12 @@ More bindings will be implemented in the future, including support for retreivin
 
 Azure Functions for Rust automatically infers the direction of bindings depending on how the binding is used in a function's declaration:
 
-* Parameters passed by immutable reference `&T`, where `T` is a trigger or input binding type, are inferred to be bindings with an `in` direction.
+* Parameters passed by value `T`, where `T` is a trigger or input binding type, are inferred to be bindings with an `in` direction.
 
   ```rust
   #[func]
   ...
-  pub fn example(..., blob: &Blob) {
+  pub fn example(blob: Blob) {
       ...
   }
   ```
@@ -237,7 +237,7 @@ Azure Functions for Rust automatically infers the direction of bindings dependin
   ```rust
   #[func]
   ...
-  pub fn example(..., blob: &mut Blob) {
+  pub fn example(blob: &mut Blob) {
       ...
   }
   ```

--- a/azure-functions-codegen/src/lib.rs
+++ b/azure-functions-codegen/src/lib.rs
@@ -75,7 +75,7 @@ pub fn export(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
 /// use azure_functions::bindings::HttpRequest;
 ///
 /// #[func]
-/// pub fn example(req: &HttpRequest) {
+/// pub fn example(req: HttpRequest) {
 /// }
 /// ```
 #[proc_macro_attribute]

--- a/azure-functions-sdk/src/main.rs
+++ b/azure-functions-sdk/src/main.rs
@@ -29,7 +29,7 @@
 //! };
 //!
 //! #[func]
-//! pub fn hello(req: &HttpRequest) -> HttpResponse {
+//! pub fn hello(req: HttpRequest) -> HttpResponse {
 //!     "Hello from Rust!".into()
 //! }
 //! ```

--- a/azure-functions-sdk/src/templates/new/blob.rs.hbs
+++ b/azure-functions-sdk/src/templates/new/blob.rs.hbs
@@ -5,7 +5,7 @@ use azure_functions::{
 
 #[func]
 #[binding(name = "trigger", path = "{{path}}")]
-pub fn {{name}}(trigger: &BlobTrigger) {
+pub fn {{name}}(trigger: BlobTrigger) {
     // trigger.path has the path to the blob that triggered the function
     // trigger.blob has the contents of the blob
 }

--- a/azure-functions-sdk/src/templates/new/eventgrid.rs.hbs
+++ b/azure-functions-sdk/src/templates/new/eventgrid.rs.hbs
@@ -4,6 +4,6 @@ use azure_functions::{
 };
 
 #[func]
-pub fn {{name}}(event: &EventGridEvent) {
+pub fn {{name}}(event: EventGridEvent) {
     // event.data has the event data JSON
 }

--- a/azure-functions-sdk/src/templates/new/eventhub.rs.hbs
+++ b/azure-functions-sdk/src/templates/new/eventhub.rs.hbs
@@ -9,6 +9,6 @@ use azure_functions::{
 {{else~}}
 #[binding(name = "trigger", connection = "{{connection}}")]
 {{/if~}}
-pub fn {{name}}(trigger: &EventHubTrigger) {
+pub fn {{name}}(trigger: EventHubTrigger) {
     // trigger.message contains the message posted to the Event Hub
 }

--- a/azure-functions-sdk/src/templates/new/http.rs.hbs
+++ b/azure-functions-sdk/src/templates/new/http.rs.hbs
@@ -7,6 +7,6 @@ use azure_functions::{
 {{#if auth_level~}}
 #[binding(name = "req", auth_level = "{{auth_level}}")]
 {{/if~}}
-pub fn {{name}}(req: &HttpRequest) -> HttpResponse {
+pub fn {{name}}(req: HttpRequest) -> HttpResponse {
     "Hello from Rust!".into()
 }

--- a/azure-functions-sdk/src/templates/new/queue.rs.hbs
+++ b/azure-functions-sdk/src/templates/new/queue.rs.hbs
@@ -5,6 +5,6 @@ use azure_functions::{
 
 #[func]
 #[binding(name = "trigger", queue_name = "{{queue_name}}")]
-pub fn {{name}}(trigger: &QueueTrigger) {
+pub fn {{name}}(trigger: QueueTrigger) {
     // trigger.message contains the message posted to the queue
 }

--- a/azure-functions-sdk/src/templates/new/timer.rs.hbs
+++ b/azure-functions-sdk/src/templates/new/timer.rs.hbs
@@ -5,6 +5,6 @@ use azure_functions::{
 
 #[func]
 #[binding(name = "trigger", schedule = "{{schedule}}")]
-pub fn {{name}}(trigger: &TimerInfo) {
+pub fn {{name}}(trigger: TimerInfo) {
     // function will execute at the scheduled interval
 }

--- a/azure-functions-shared/src/context.rs
+++ b/azure-functions-shared/src/context.rs
@@ -2,7 +2,7 @@ use std::env;
 use std::path::PathBuf;
 
 /// Represents context about an Azure Function invocation.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Context<'a> {
     invocation_id: &'a str,
     function_id: &'a str,

--- a/azure-functions/src/bindings/blob_trigger.rs
+++ b/azure-functions/src/bindings/blob_trigger.rs
@@ -24,7 +24,7 @@ const METADATA_KEY: &str = "Metadata";
 ///
 /// #[func]
 /// #[binding(name = "trigger", path = "test/{name}")]
-/// pub fn print_blob(trigger: &BlobTrigger) {
+/// pub fn print_blob(trigger: BlobTrigger) {
 ///     info!("Blob (as string): {:?}", trigger.blob.as_str());
 /// }
 /// ```
@@ -66,13 +66,6 @@ impl BlobTrigger {
                 from_str(x.get_json()).expect("failed to deserialize blob metadata")
             }),
         }
-    }
-}
-
-#[doc(hidden)]
-impl Into<protocol::TypedData> for BlobTrigger {
-    fn into(self) -> protocol::TypedData {
-        self.blob.into()
     }
 }
 

--- a/azure-functions/src/bindings/event_grid_event.rs
+++ b/azure-functions/src/bindings/event_grid_event.rs
@@ -17,7 +17,7 @@ use std::collections::HashMap;
 /// };
 ///
 /// #[func]
-/// pub fn log_event(event: &EventGridEvent) {
+/// pub fn log_event(event: EventGridEvent) {
 ///     log::warn!("Event Data: {}", event.data);
 /// }
 /// ```

--- a/azure-functions/src/bindings/event_hub_trigger.rs
+++ b/azure-functions/src/bindings/event_hub_trigger.rs
@@ -27,7 +27,7 @@ const SYSTEM_PROPERTIES_KEY: &str = "SystemProperties";
 ///
 /// #[func]
 /// #[binding(name = "trigger", connection = "my_connection")]
-/// pub fn log_event(trigger: &EventHubTrigger) {
+/// pub fn log_event(trigger: EventHubTrigger) {
 ///     log::warn!("{:?}", trigger);
 /// }
 /// ```

--- a/azure-functions/src/bindings/http_request.rs
+++ b/azure-functions/src/bindings/http_request.rs
@@ -16,7 +16,7 @@ use std::collections::HashMap;
 /// };
 ///
 /// #[func]
-/// pub fn greet(request: &HttpRequest) -> HttpResponse {
+/// pub fn greet(request: HttpRequest) -> HttpResponse {
 ///     format!(
 ///         "Hello, {}!",
 ///         request.query_params().get("name").map_or("stranger", |x| x)
@@ -59,7 +59,7 @@ impl HttpRequest {
     ///
     /// #[func]
     /// #[binding(name = "request", route = "users/{id:int}")]
-    /// pub fn users(request: &HttpRequest) -> HttpResponse {
+    /// pub fn users(request: HttpRequest) -> HttpResponse {
     ///     format!(
     ///         "User ID requested: {}",
     ///         request.route_params().get("id").unwrap()
@@ -85,7 +85,7 @@ impl HttpRequest {
     /// use azure_functions::bindings::{HttpRequest, HttpResponse};
     ///
     /// #[func]
-    /// pub fn users(request: &HttpRequest) -> HttpResponse {
+    /// pub fn users(request: HttpRequest) -> HttpResponse {
     ///     format!(
     ///         "The 'name' query parameter is: {}",
     ///         request.query_params().get("name").map_or("undefined", |x| x)

--- a/azure-functions/src/bindings/queue_trigger.rs
+++ b/azure-functions/src/bindings/queue_trigger.rs
@@ -25,7 +25,7 @@ const POP_RECEIPT_KEY: &str = "PopReceipt";
 ///
 /// #[func]
 /// #[binding(name = "trigger", queue_name = "example")]
-/// pub fn run_on_message(trigger: &QueueTrigger) {
+/// pub fn run_on_message(trigger: QueueTrigger) {
 ///     info!("Rust function ran due to queue message: {}", trigger.message);
 /// }
 /// ```

--- a/azure-functions/src/bindings/table.rs
+++ b/azure-functions/src/bindings/table.rs
@@ -17,7 +17,7 @@ use std::fmt;
 /// #[func]
 /// #[binding(name = "trigger", queue_name = "example")]
 /// #[binding(name = "table", table_name = "MyTable", partition_key = "MyPartition", row_key = "{queueTrigger}")]
-/// pub fn log_row(trigger: &QueueTrigger, table: &Table) {
+/// pub fn log_row(trigger: QueueTrigger, table: Table) {
 ///     info!("Row: {:?}", table.rows().nth(0));
 /// }
 /// ```
@@ -31,7 +31,7 @@ use std::fmt;
 ///
 /// #[func]
 /// #[binding(name = "table", table_name = "MyTable", filter = "{filter}")]
-/// pub fn log_rows(req: &HttpRequest, table: &Table) {
+/// pub fn log_rows(req: HttpRequest, table: Table) {
 ///     for row in table.rows() {
 ///         info!("Row: {:?}", row);
 ///     }

--- a/azure-functions/src/bindings/timer_info.rs
+++ b/azure-functions/src/bindings/timer_info.rs
@@ -17,7 +17,7 @@ use std::collections::HashMap;
 ///
 /// #[func]
 /// #[binding(name = "_info", schedule = "0 */5 * * * *")]
-/// pub fn timer(_info: &TimerInfo) {
+/// pub fn timer(_info: TimerInfo) {
 ///     info!("Rust Azure function ran!");
 /// }
 /// ```

--- a/azure-functions/src/lib.rs
+++ b/azure-functions/src/lib.rs
@@ -55,7 +55,7 @@
 //! };
 //!
 //! #[func]
-//! pub fn hello(req: &HttpRequest) -> HttpResponse {
+//! pub fn hello(req: HttpRequest) -> HttpResponse {
 //!     "Hello from Rust!".into()
 //! }
 //! ```

--- a/examples/blob/README.md
+++ b/examples/blob/README.md
@@ -12,7 +12,7 @@ use azure_functions::{bindings::BlobTrigger, func};
 
 #[func]
 #[binding(name = "trigger", path = "watching/{name}")]
-pub fn blob_watcher(trigger: &BlobTrigger) {
+pub fn blob_watcher(trigger: BlobTrigger) {
     log::info!(
         "A blob was created at '{}' with contents: {:?}.",
         trigger.path,
@@ -33,7 +33,7 @@ use azure_functions::{
 #[func]
 #[binding(name = "req", route = "create/blob/{container}/{name}")]
 #[binding(name = "output1", path = "{container}/{name}")]
-pub fn create_blob(req: &HttpRequest) -> (HttpResponse, Blob) {
+pub fn create_blob(req: HttpRequest) -> (HttpResponse, Blob) {
     (
         HttpResponse::build()
             .status(Status::Created)
@@ -56,7 +56,7 @@ use azure_functions::{
 #[binding(name = "_req", route = "copy/blob/{container}/{name}")]
 #[binding(name = "blob", path = "{container}/{name}")]
 #[binding(name = "output1", path = "{container}/{name}.copy")]
-pub fn copy_blob(_req: &HttpRequest, blob: &Blob) -> (HttpResponse, Blob) {
+pub fn copy_blob(_req: HttpRequest, blob: Blob) -> (HttpResponse, Blob) {
     ("blob has been copied.".into(), blob.clone())
 }
 ```
@@ -72,7 +72,7 @@ use azure_functions::{
 #[func]
 #[binding(name = "_req", route = "print/blob/{container}/{path}")]
 #[binding(name = "blob", path = "{container}/{path}")]
-pub fn print_blob(_req: &HttpRequest, blob: &Blob) -> HttpResponse {
+pub fn print_blob(_req: HttpRequest, blob: Blob) -> HttpResponse {
     blob.as_bytes().into()
 }
 ```

--- a/examples/blob/src/functions/blob_watcher.rs
+++ b/examples/blob/src/functions/blob_watcher.rs
@@ -2,8 +2,8 @@ use azure_functions::{bindings::BlobTrigger, func};
 
 #[func]
 #[binding(name = "trigger", path = "watching/{name}")]
-pub fn blob_watcher(trigger: &BlobTrigger) {
-    log::info!(
+pub fn blob_watcher(trigger: BlobTrigger) {
+    log::warn!(
         "A blob was created at '{}' with contents: {:?}.",
         trigger.path,
         trigger.blob

--- a/examples/blob/src/functions/copy_blob.rs
+++ b/examples/blob/src/functions/copy_blob.rs
@@ -7,6 +7,6 @@ use azure_functions::{
 #[binding(name = "_req", route = "copy/blob/{container}/{name}")]
 #[binding(name = "blob", path = "{container}/{name}")]
 #[binding(name = "output1", path = "{container}/{name}.copy")]
-pub fn copy_blob(_req: &HttpRequest, blob: &Blob) -> (HttpResponse, Blob) {
-    ("blob has been copied.".into(), blob.clone())
+pub fn copy_blob(_req: HttpRequest, blob: Blob) -> (HttpResponse, Blob) {
+    ("blob has been copied.".into(), blob)
 }

--- a/examples/blob/src/functions/create_blob.rs
+++ b/examples/blob/src/functions/create_blob.rs
@@ -7,7 +7,7 @@ use azure_functions::{
 #[func]
 #[binding(name = "req", route = "create/blob/{container}/{name}")]
 #[binding(name = "output1", path = "{container}/{name}")]
-pub fn create_blob(req: &HttpRequest) -> (HttpResponse, Blob) {
+pub fn create_blob(req: HttpRequest) -> (HttpResponse, Blob) {
     (
         HttpResponse::build()
             .status(Status::Created)

--- a/examples/blob/src/functions/print_blob.rs
+++ b/examples/blob/src/functions/print_blob.rs
@@ -6,6 +6,7 @@ use azure_functions::{
 #[func]
 #[binding(name = "_req", route = "print/blob/{container}/{path}")]
 #[binding(name = "blob", path = "{container}/{path}")]
-pub fn print_blob(_req: &HttpRequest, blob: &Blob) -> HttpResponse {
-    blob.as_bytes().into()
+pub fn print_blob(_req: HttpRequest, blob: Blob) -> HttpResponse {
+    let response: String = blob.into();
+    response.into()
 }

--- a/examples/event-grid/README.md
+++ b/examples/event-grid/README.md
@@ -10,7 +10,7 @@ An example Event Grid triggered Azure Function that runs when a new event is pos
 use azure_functions::{bindings::EventGridEvent, func};
 
 #[func]
-pub fn log_event(event: &EventGridEvent) {
+pub fn log_event(event: EventGridEvent) {
     log::warn!("Event Data: {}", event.data);
 }
 ```

--- a/examples/event-grid/src/functions/log_event.rs
+++ b/examples/event-grid/src/functions/log_event.rs
@@ -1,6 +1,6 @@
 use azure_functions::{bindings::EventGridEvent, func};
 
 #[func]
-pub fn log_event(event: &EventGridEvent) {
+pub fn log_event(event: EventGridEvent) {
     log::warn!("Event Data: {}", event.data);
 }

--- a/examples/event-hub/README.md
+++ b/examples/event-hub/README.md
@@ -15,7 +15,7 @@ use azure_functions::{
 
 #[func]
 #[binding(name = "trigger", connection = "connection", event_hub_name = "example")]
-pub fn log_event(trigger: &EventHubTrigger) {
+pub fn log_event(trigger: EventHubTrigger) {
     log::warn!("Event hub message: {}", trigger.message.as_str().unwrap());
 }
 ```
@@ -30,7 +30,7 @@ use azure_functions::{
 
 #[func]
 #[binding(name = "output1", connection = "connection", event_hub_name = "example")]
-pub fn create_event(_req: &HttpRequest) -> (HttpResponse, EventHubMessage) {
+pub fn create_event(_req: HttpRequest) -> (HttpResponse, EventHubMessage) {
     (
         "Created Event Hub message.".into(),
         "Hello from Rust!".into()

--- a/examples/event-hub/src/functions/create_event.rs
+++ b/examples/event-hub/src/functions/create_event.rs
@@ -5,7 +5,7 @@ use azure_functions::{
 
 #[func]
 #[binding(name = "output1", connection = "connection", event_hub_name = "example")]
-pub fn create_event(_req: &HttpRequest) -> (HttpResponse, EventHubMessage) {
+pub fn create_event(_req: HttpRequest) -> (HttpResponse, EventHubMessage) {
     (
         "Created Event Hub message.".into(),
         "Hello from Rust!".into()

--- a/examples/event-hub/src/functions/log_event.rs
+++ b/examples/event-hub/src/functions/log_event.rs
@@ -5,6 +5,6 @@ use azure_functions::{
 
 #[func]
 #[binding(name = "trigger", connection = "connection", event_hub_name = "example")]
-pub fn log_event(trigger: &EventHubTrigger) {
+pub fn log_event(trigger: EventHubTrigger) {
     log::warn!("Event hub message: {}", trigger.message.as_str().unwrap());
 }

--- a/examples/http/README.md
+++ b/examples/http/README.md
@@ -13,7 +13,7 @@ use azure_functions::{
 };
 
 #[func]
-pub fn greet(context: &Context, req: &HttpRequest) -> HttpResponse {
+pub fn greet(context: Context, req: HttpRequest) -> HttpResponse {
     log::info!("Context: {:?}, Request: {:?}", context, req);
 
     format!(
@@ -46,7 +46,7 @@ struct Response {
 }
 
 #[func]
-pub fn greet_with_json(req: &HttpRequest) -> HttpResponse {
+pub fn greet_with_json(req: HttpRequest) -> HttpResponse {
     if let Ok(request) = req.body().as_json::<Request>() {
         let response = Response {
             message: format!("Hello from Rust, {}!", request.name),

--- a/examples/http/src/functions/greet.rs
+++ b/examples/http/src/functions/greet.rs
@@ -4,7 +4,7 @@ use azure_functions::{
 };
 
 #[func]
-pub fn greet(context: &Context, req: &HttpRequest) -> HttpResponse {
+pub fn greet(context: Context, req: HttpRequest) -> HttpResponse {
     log::info!("Context: {:?}, Request: {:?}", context, req);
 
     format!(

--- a/examples/http/src/functions/greet_with_json.rs
+++ b/examples/http/src/functions/greet_with_json.rs
@@ -17,7 +17,7 @@ struct Response {
 }
 
 #[func]
-pub fn greet_with_json(req: &HttpRequest) -> HttpResponse {
+pub fn greet_with_json(req: HttpRequest) -> HttpResponse {
     if let Ok(request) = req.body().as_json::<Request>() {
         let response = Response {
             message: format!("Hello from Rust, {}!", request.name),

--- a/examples/queue/README.md
+++ b/examples/queue/README.md
@@ -12,7 +12,7 @@ use azure_functions::{bindings::QueueTrigger, func};
 
 #[func]
 #[binding(name = "trigger", queue_name = "test")]
-pub fn queue(trigger: &QueueTrigger) {
+pub fn queue(trigger: QueueTrigger) {
     log::info!("Message: {}", trigger.message);
 }
 ```
@@ -28,7 +28,7 @@ use azure_functions::{
 #[func]
 #[binding(name = "trigger", queue_name = "echo-in")]
 #[binding(name = "$return", queue_name = "echo-out")]
-pub fn queue_with_output(trigger: &QueueTrigger) -> QueueMessage {
+pub fn queue_with_output(trigger: QueueTrigger) -> QueueMessage {
     log::info!("Message: {}", trigger.message);
 
     trigger.message.clone()

--- a/examples/queue/src/functions/queue.rs
+++ b/examples/queue/src/functions/queue.rs
@@ -2,6 +2,6 @@ use azure_functions::{bindings::QueueTrigger, func};
 
 #[func]
 #[binding(name = "trigger", queue_name = "test")]
-pub fn queue(trigger: &QueueTrigger) {
+pub fn queue(trigger: QueueTrigger) {
     log::info!("Message: {}", trigger.message);
 }

--- a/examples/queue/src/functions/queue_with_output.rs
+++ b/examples/queue/src/functions/queue_with_output.rs
@@ -6,7 +6,7 @@ use azure_functions::{
 #[func]
 #[binding(name = "trigger", queue_name = "echo-in")]
 #[binding(name = "$return", queue_name = "echo-out")]
-pub fn queue_with_output(trigger: &QueueTrigger) -> QueueMessage {
+pub fn queue_with_output(trigger: QueueTrigger) -> QueueMessage {
     log::info!("Message: {}", trigger.message);
 
     trigger.message.clone()

--- a/examples/table/README.md
+++ b/examples/table/README.md
@@ -16,7 +16,7 @@ use serde_json::Value;
 #[func]
 #[binding(name = "req", route = "create/{table}/{partition}/{row}")]
 #[binding(name = "output1", table_name = "{table}")]
-pub fn create_row(req: &HttpRequest) -> ((), Table) {
+pub fn create_row(req: HttpRequest) -> ((), Table) {
     let mut table = Table::new();
     {
         let row = table.add_row(
@@ -50,7 +50,7 @@ use serde_json::Value;
     partition_key = "{partition}",
     row_key = "{row}"
 )]
-pub fn read_row(_req: &HttpRequest, table: &Table) -> HttpResponse {
+pub fn read_row(_req: HttpRequest, table: Table) -> HttpResponse {
     table.as_value().get(0).unwrap_or(&Value::Null).into()
 }
 ```

--- a/examples/table/src/functions/create_row.rs
+++ b/examples/table/src/functions/create_row.rs
@@ -7,7 +7,7 @@ use serde_json::Value;
 #[func]
 #[binding(name = "req", route = "create/{table}/{partition}/{row}")]
 #[binding(name = "output1", table_name = "{table}")]
-pub fn create_row(req: &HttpRequest) -> ((), Table) {
+pub fn create_row(req: HttpRequest) -> ((), Table) {
     let mut table = Table::new();
     {
         let row = table.add_row(

--- a/examples/table/src/functions/read_row.rs
+++ b/examples/table/src/functions/read_row.rs
@@ -12,6 +12,6 @@ use serde_json::Value;
     partition_key = "{partition}",
     row_key = "{row}"
 )]
-pub fn read_row(_req: &HttpRequest, table: &Table) -> HttpResponse {
+pub fn read_row(_req: HttpRequest, table: Table) -> HttpResponse {
     table.as_value().get(0).unwrap_or(&Value::Null).into()
 }

--- a/examples/timer/README.md
+++ b/examples/timer/README.md
@@ -11,7 +11,7 @@ use azure_functions::{bindings::TimerInfo, func};
 
 #[func]
 #[binding(name = "info", schedule = "0 */1 * * * *")]
-pub fn timer(info: &TimerInfo) {
+pub fn timer(info: TimerInfo) {
     log::info!("Hello from Rust!");
     log::info!("Timer information: {:?}", info);
 }

--- a/examples/timer/src/functions/timer.rs
+++ b/examples/timer/src/functions/timer.rs
@@ -2,7 +2,7 @@ use azure_functions::{bindings::TimerInfo, func};
 
 #[func]
 #[binding(name = "info", schedule = "0 */1 * * * *")]
-pub fn timer(info: &TimerInfo) {
+pub fn timer(info: TimerInfo) {
     log::info!("Hello from Rust!");
     log::info!("Timer information: {:?}", info);
 }


### PR DESCRIPTION
This commit changes the way trigger and input bindings are passed to Azure
Functions.

Previously, trigger and input bindings were passed by immutable reference.
However, if the function wanted to output the input data, it would have to
clone the input data, creating an unnecessary copy.

Now both trigger and input bindings are passed by value.  The input data can
now be moved to the output data as necessary.