### PR TITLE
Add back support for passing input bindings by reference.

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,23 +221,31 @@ More bindings will be implemented in the future, including support for retreivin
 
 Azure Functions for Rust automatically infers the direction of bindings depending on how the binding is used in a function's declaration:
 
-* Parameters passed by value `T`, where `T` is a trigger or input binding type, are inferred to be bindings with an `in` direction.
+* Parameters of type `T` or `&T`, where `T` is a trigger or input binding type, are inferred to be bindings with an `in` direction.
 
   ```rust
   #[func]
   ...
-  pub fn example(blob: Blob) {
+  pub fn example(..., blob: Blob) {
       ...
   }
   ```
 
-* Parameters passed by mutable reference `&mut T`, where `T` is a trigger or input binding type that supports the `inout` direction, are inferred to be bindings with an `inout` direction.
+  ```rust
+  #[func]
+  ...
+  pub fn example(..., blob: &Blob) {
+      ...
+  }
+  ```
+
+* Parameters of type `&mut T`, where `T` is a trigger or input binding type that supports the `inout` direction, are inferred to be bindings with an `inout` direction.
 **Note: `inout` direction bindings are currently not implemented for languages other than C#.  See [this issue](https://github.com/Azure/azure-functions-host/issues/49) regarding this problem with the Azure Functions Host.**
 
   ```rust
   #[func]
   ...
-  pub fn example(blob: &mut Blob) {
+  pub fn example(..., blob: &mut Blob) {
       ...
   }
   ```

--- a/azure-functions-codegen/src/func.rs
+++ b/azure-functions-codegen/src/func.rs
@@ -77,6 +77,12 @@ fn bind_input_type(
     let type_name = last_segment_in_path(&tp.path).ident.to_string();
 
     if type_name == CONTEXT_TYPE_NAME {
+        if let Some(m) = mutability {
+            macro_panic(
+                m.span(),
+                "context bindings cannot be passed by mutable reference",
+            );
+        }
         return Binding::Context;
     }
 
@@ -125,12 +131,6 @@ fn bind_argument(
         FnArg::Captured(arg) => match &arg.ty {
             Type::Reference(tr) => match &*tr.elem {
                 Type::Path(tp) => {
-                    if tr.mutability.is_none() {
-                        macro_panic(
-                            arg.ty.span(),
-                            "bindings cannot be passed by immutable reference",
-                        )
-                    }
                     bind_input_type(&arg.pat, tp, tr.mutability, has_trigger, binding_args)
                 }
                 _ => macro_panic(

--- a/azure-functions-codegen/src/func/output_bindings.rs
+++ b/azure-functions-codegen/src/func/output_bindings.rs
@@ -59,7 +59,9 @@ impl<'a> OutputBindings<'a> {
     fn iter_mut_args(&self) -> impl Iterator<Item = (&'a Ident, &'a Type)> {
         self.0.decl.inputs.iter().filter_map(|x| match x {
             FnArg::Captured(arg) => {
-                if let Type::Reference(_) = &arg.ty {
+                if let Type::Reference(tr) = &arg.ty {
+                    tr.mutability?;
+
                     let name = match &arg.pat {
                         Pat::Ident(name) => &name.ident,
                         _ => panic!("expected ident argument pattern"),


### PR DESCRIPTION
This commit adds back support for passing trigger and input bindings by
reference.

This will prevent existing code from breaking when it doesn't need a moved
input binding type.