### PR TITLE
Implement Vec<T> input and output bindings.

### DIFF
--- a/azure-functions-codegen/src/func/output_bindings.rs
+++ b/azure-functions-codegen/src/func/output_bindings.rs
@@ -1,13 +1,13 @@
+use crate::func::get_generic_argument_type;
 use azure_functions_shared::{codegen::last_segment_in_path, util::to_camel_case};
-use quote::quote;
-use quote::ToTokens;
-use syn::ItemFn;
-use syn::{FnArg, GenericArgument, Ident, Pat, PathArguments, ReturnType, Type};
+use proc_macro2::TokenStream;
+use quote::{quote, ToTokens};
+use syn::{FnArg, Ident, ItemFn, Pat, ReturnType, Type};
 
 pub struct OutputBindings<'a>(pub &'a ItemFn);
 
 impl<'a> OutputBindings<'a> {
-    fn get_output_bindings(&self) -> Vec<::proc_macro2::TokenStream> {
+    fn get_output_argument_bindings(&self) -> Vec<TokenStream> {
         self.iter_mut_args()
             .map(|(name, _)| {
                 let name_str = to_camel_case(&name.to_string());
@@ -21,38 +21,65 @@ impl<'a> OutputBindings<'a> {
             .collect()
     }
 
-    pub fn iter_output_return_bindings(&self) -> Vec<::proc_macro2::TokenStream> {
+    fn get_output_return_binding(ty: &Type, index: usize) -> Option<TokenStream> {
+        if OutputBindings::is_unit_tuple(ty) {
+            return None;
+        }
+
+        let name = format!("{}{}", crate::func::OUTPUT_BINDING_PREFIX, index);
+
+        match OutputBindings::get_generic_argument_type(ty, "Option") {
+            Some(inner) => {
+                let conversion = OutputBindings::get_binding_conversion(inner, None);
+                Some(quote!(
+                    if let Some(__ret) = __ret.#index {
+                        let mut __output_binding = ::azure_functions::rpc::protocol::ParameterBinding::new();
+                        __output_binding.set_name(#name.to_string());
+                        __output_binding.set_data(#conversion);
+                        __output_data.push(__output_binding);
+                    }
+                ))
+            }
+            None => {
+                let conversion = OutputBindings::get_binding_conversion(ty, Some(index));
+                Some(quote!(
+                    let mut __output_binding = ::azure_functions::rpc::protocol::ParameterBinding::new();
+                    __output_binding.set_name(#name.to_string());
+                    __output_binding.set_data(#conversion);
+                    __output_data.push(__output_binding);
+                ))
+            }
+        }
+    }
+
+    fn get_binding_conversion(ty: &Type, index: Option<usize>) -> TokenStream {
+        match OutputBindings::get_generic_argument_type(ty, "Vec") {
+            Some(_) => match index {
+                Some(index) => {
+                    quote!(::azure_functions::rpc::protocol::TypedData::from_vec(__ret.#index))
+                }
+                None => quote!(::azure_functions::rpc::protocol::TypedData::from_vec(__ret)),
+            },
+            None => match index {
+                Some(index) => quote!(__ret.#index.into()),
+                None => quote!(__ret.into()),
+            },
+        }
+    }
+
+    fn iter_output_return_bindings(&self) -> Vec<TokenStream> {
         match &self.0.decl.output {
             ReturnType::Default => vec![],
-            ReturnType::Type(_, ty) => {
-                match &**ty {
-                    Type::Tuple(tuple) => tuple.elems.iter().enumerate().skip(1).filter_map(|(i, ty)| {
-                        if OutputBindings::is_unit_tuple(ty) {
-                            return None;
-                        }
-                        let name = format!("{}{}", crate::func::OUTPUT_BINDING_PREFIX, i);
-
-                        if OutputBindings::is_option_type(ty) {
-                            Some(quote!(
-                                if let Some(__ret) = __ret.#i {
-                                    let mut __output_binding = ::azure_functions::rpc::protocol::ParameterBinding::new();
-                                    __output_binding.set_name(#name.to_string());
-                                    __output_binding.set_data(__ret.into());
-                                    __output_data.push(__output_binding);
-                                }
-                            ))
-                        } else {
-                            Some(quote!(
-                                let mut __output_binding = ::azure_functions::rpc::protocol::ParameterBinding::new();
-                                __output_binding.set_name(#name.to_string());
-                                __output_binding.set_data(__ret.#i.into());
-                                __output_data.push(__output_binding);
-                            ))
-                        }
-                    }).collect(),
-                    _ => vec![],
-                }
-            }
+            ReturnType::Type(_, ty) => match &**ty {
+                Type::Tuple(tuple) => tuple
+                    .elems
+                    .iter()
+                    .enumerate()
+                    .skip(1)
+                    .filter_map(|(i, ty)| OutputBindings::get_output_return_binding(ty, i))
+                    .collect(),
+                _ => vec![],
+            },
         }
     }
 
@@ -75,29 +102,15 @@ impl<'a> OutputBindings<'a> {
         })
     }
 
-    fn is_option_type(t: &Type) -> bool {
-        match t {
+    fn get_generic_argument_type(ty: &'a Type, generic_type_name: &str) -> Option<&'a Type> {
+        match ty {
             Type::Path(tp) => {
-                let last = last_segment_in_path(&tp.path);
-                if last.ident != "Option" {
-                    return false;
-                }
-
-                match &last.arguments {
-                    PathArguments::AngleBracketed(gen_args) => {
-                        if gen_args.args.len() != 1 {
-                            return false;
-                        }
-                        match gen_args.args.iter().nth(0) {
-                            Some(GenericArgument::Type(_)) => true,
-                            _ => false,
-                        }
-                    }
-                    _ => false,
-                }
+                get_generic_argument_type(last_segment_in_path(&tp.path), generic_type_name)
             }
-            Type::Paren(tp) => OutputBindings::is_option_type(&tp.elem),
-            _ => false,
+            Type::Paren(tp) => {
+                OutputBindings::get_generic_argument_type(&tp.elem, generic_type_name)
+            }
+            _ => None,
         }
     }
 
@@ -107,11 +120,56 @@ impl<'a> OutputBindings<'a> {
             _ => false,
         }
     }
+
+    fn get_return_binding(ty: &Type, in_tuple: bool) -> Option<TokenStream> {
+        if OutputBindings::is_unit_tuple(ty) {
+            return None;
+        }
+
+        if in_tuple {
+            match OutputBindings::get_generic_argument_type(ty, "Option") {
+                Some(inner) => {
+                    let conversion = OutputBindings::get_binding_conversion(inner, None);
+                    Some(quote!(
+                        if let Some(__ret) = __ret.0 {
+                            __res.set_return_value(#conversion);
+                        }
+                    ))
+                }
+                None => {
+                    let conversion = OutputBindings::get_binding_conversion(ty, Some(0));
+                    Some(quote!(__res.set_return_value(#conversion);))
+                }
+            }
+        } else {
+            if let Type::Tuple(tuple) = &*ty {
+                if let Some(first) = tuple.elems.iter().nth(0) {
+                    return OutputBindings::get_return_binding(first, true);
+                }
+                return None;
+            }
+
+            match OutputBindings::get_generic_argument_type(ty, "Option") {
+                Some(inner) => {
+                    let conversion = OutputBindings::get_binding_conversion(inner, None);
+                    Some(quote!(
+                        if let Some(__ret) = __ret {
+                            __res.set_return_value(#conversion);
+                        }
+                    ))
+                }
+                None => {
+                    let conversion = OutputBindings::get_binding_conversion(ty, None);
+                    Some(quote!(__res.set_return_value(#conversion);))
+                }
+            }
+        }
+    }
 }
 
 impl ToTokens for OutputBindings<'_> {
-    fn to_tokens(&self, tokens: &mut ::proc_macro2::TokenStream) {
-        let mut output_bindings = self.get_output_bindings();
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        let mut output_bindings = self.get_output_argument_bindings();
         output_bindings.append(&mut self.iter_output_return_bindings());
 
         if !output_bindings.is_empty() {
@@ -127,28 +185,8 @@ impl ToTokens for OutputBindings<'_> {
         match &self.0.decl.output {
             ReturnType::Default => {}
             ReturnType::Type(_, ty) => {
-                if let Type::Tuple(tuple) = &**ty {
-                    if let Some(first) = tuple.elems.iter().nth(0) {
-                        if !OutputBindings::is_unit_tuple(first) {
-                            if OutputBindings::is_option_type(first) {
-                                quote!(if let Some(__ret) = __ret.0 {
-                                    __res.set_return_value(__ret.into());
-                                })
-                                .to_tokens(tokens);
-                            } else {
-                                quote!(__res.set_return_value(__ret.0.into());).to_tokens(tokens);
-                            }
-                        }
-                    }
-                } else if !OutputBindings::is_unit_tuple(ty) {
-                    if OutputBindings::is_option_type(ty) {
-                        quote!(if let Some(__ret) = __ret {
-                            __res.set_return_value(__ret.into());
-                        })
-                        .to_tokens(tokens);
-                    } else {
-                        quote!(__res.set_return_value(__ret.into());).to_tokens(tokens);
-                    }
+                if let Some(binding) = OutputBindings::get_return_binding(ty, false) {
+                    binding.to_tokens(tokens);
                 }
             }
         }

--- a/azure-functions-shared/build.rs
+++ b/azure-functions-shared/build.rs
@@ -1,5 +1,3 @@
-extern crate protoc_grpcio;
-
 use std::env;
 use std::fs;
 use std::path::PathBuf;

--- a/azure-functions-shared/src/codegen/bindings.rs
+++ b/azure-functions-shared/src/codegen/bindings.rs
@@ -33,7 +33,8 @@ pub use self::timer_trigger::*;
 use lazy_static::lazy_static;
 use proc_macro2::{Span, TokenStream};
 use quote::{quote, ToTokens};
-use std::collections::HashMap;
+use serde_derive::Serialize;
+use std::collections::{HashMap, HashSet};
 use syn::AttributeArgs;
 
 #[derive(Serialize, Debug, Clone, Copy, PartialEq)]
@@ -294,6 +295,20 @@ lazy_static! {
             Binding::SignalR(SignalR::from((args, span)))
         });
         map
+    };
+    pub static ref VEC_INPUT_BINDINGS: HashSet<&'static str> = {
+        let mut set = HashSet::new();
+        set.insert("CosmosDbDocument");
+        set
+    };
+    pub static ref VEC_OUTPUT_BINDINGS: HashSet<&'static str> = {
+        let mut set = HashSet::new();
+        set.insert("CosmosDbDocument");
+        set.insert("EventHubMessage");
+        set.insert("QueueMessage");
+        set.insert("SignalRMessage");
+        set.insert("SignalRGroupAction");
+        set
     };
 }
 

--- a/azure-functions-shared/src/lib.rs
+++ b/azure-functions-shared/src/lib.rs
@@ -6,9 +6,6 @@
 #![deny(missing_docs)]
 #![deny(unused_extern_crates)]
 
-#[macro_use]
-extern crate serde_derive;
-
 #[doc(hidden)]
 pub mod codegen;
 mod context;

--- a/azure-functions/src/bindings/blob.rs
+++ b/azure-functions/src/bindings/blob.rs
@@ -14,35 +14,41 @@ use std::str::from_utf8;
 /// Creating a blob from a string:
 ///
 /// ```rust
-/// use azure_functions::bindings::Blob;
+/// use azure_functions::bindings::{HttpRequest, Blob};
+/// use azure_functions::func;
 ///
-/// let blob: Blob = "hello world!".into();
-/// assert_eq!(blob.as_str().unwrap(), "hello world!");
+/// #[func]
+/// #[binding(name = "output1", path = "example")]
+/// pub fn create_blob(_req: HttpRequest) -> ((), Blob) {
+///     ((), "Hello world!".into())
+/// }
 /// ```
 ///
 /// Creating a blob from a JSON value (see the [json! macro](https://docs.serde.rs/serde_json/macro.json.html) from the `serde_json` crate):
 ///
 /// ```rust
-/// # #[macro_use] extern crate serde_json;
-/// # extern crate azure_functions;
-/// use azure_functions::bindings::Blob;
+/// use azure_functions::bindings::{HttpRequest, Blob};
+/// use azure_functions::func;
+/// use serde_json::json;
 ///
-/// let blob: Blob = json!({ "hello": "world!" }).into();
-///
-/// assert_eq!(blob.as_str().unwrap(), r#"{"hello":"world!"}"#);
+/// #[func]
+/// #[binding(name = "output1", path = "example")]
+/// pub fn create_blob(_req: HttpRequest) -> ((), Blob) {
+///     ((), json!({ "hello": "world!" }).into())
+/// }
 /// ```
 ///
 /// Creating a blob from a sequence of bytes:
 ///
 /// ```rust
-/// use azure_functions::bindings::Blob;
+/// use azure_functions::bindings::{HttpRequest, Blob};
+/// use azure_functions::func;
 ///
-/// let blob: Blob = [1, 2, 3][..].into();
-///
-/// assert_eq!(
-///     blob.as_bytes(),
-///     [1, 2, 3]
-/// );
+/// #[func]
+/// #[binding(name = "output1", path = "example")]
+/// pub fn create_blob(_req: HttpRequest) -> ((), Blob) {
+///     ((), [1, 2, 3][..].into())
+/// }
 /// ```
 #[derive(Debug, Clone)]
 pub struct Blob(protocol::TypedData);
@@ -236,6 +242,8 @@ impl Into<protocol::TypedData> for Blob {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use serde::Serialize;
+    use serde_json::json;
     use serde_json::to_value;
     use std::fmt::Write;
 

--- a/azure-functions/src/bindings/blob_trigger.rs
+++ b/azure-functions/src/bindings/blob_trigger.rs
@@ -17,15 +17,14 @@ const METADATA_KEY: &str = "Metadata";
 /// A function that runs when a blob is created in the `test` container:
 ///
 /// ```rust
-/// # extern crate azure_functions;
-/// # #[macro_use] extern crate log;
 /// use azure_functions::bindings::BlobTrigger;
 /// use azure_functions::func;
+/// use log::info;
 ///
 /// #[func]
-/// #[binding(name = "trigger", path = "test/{name}")]
+/// #[binding(name = "trigger", path = "example/")]
 /// pub fn print_blob(trigger: BlobTrigger) {
-///     info!("Blob (as string): {:?}", trigger.blob.as_str());
+///     info!("Blob (as string): {}", trigger.blob.as_str().unwrap());
 /// }
 /// ```
 #[derive(Debug)]
@@ -74,7 +73,8 @@ mod tests {
     use super::*;
     use crate::blob::*;
     use chrono::Utc;
-    use serde_json::to_string;
+    use matches::matches;
+    use serde_json::{json, to_string};
 
     #[test]
     fn it_constructs() {

--- a/azure-functions/src/bindings/cosmos_db_trigger.rs
+++ b/azure-functions/src/bindings/cosmos_db_trigger.rs
@@ -10,12 +10,11 @@ use std::collections::HashMap;
 /// An example of logging all Cosmos DB documents that triggered the function:
 ///
 /// ```rust
-/// # extern crate azure_functions;
-/// # #[macro_use] extern crate log;
 /// use azure_functions::{
 ///     bindings::CosmosDbTrigger,
 ///     func,
 /// };
+/// use log::warn;
 ///
 /// #[func]
 /// #[binding(

--- a/azure-functions/src/bindings/event_grid_event.rs
+++ b/azure-functions/src/bindings/event_grid_event.rs
@@ -1,6 +1,7 @@
 use crate::rpc::protocol;
 use crate::util::deserialize_datetime;
 use chrono::{DateTime, Utc};
+use serde_derive::Deserialize;
 use serde_json::from_str;
 use std::collections::HashMap;
 
@@ -9,12 +10,11 @@ use std::collections::HashMap;
 /// # Examples
 ///
 /// ```rust
-/// # extern crate azure_functions;
-/// # #[macro_use] extern crate log;
 /// use azure_functions::{
 ///     bindings::EventGridEvent,
 ///     func,
 /// };
+/// use log::warn;
 ///
 /// #[func]
 /// pub fn log_event(event: EventGridEvent) {

--- a/azure-functions/src/bindings/event_hub_trigger.rs
+++ b/azure-functions/src/bindings/event_hub_trigger.rs
@@ -18,12 +18,11 @@ const SYSTEM_PROPERTIES_KEY: &str = "SystemProperties";
 /// # Examples
 ///
 /// ```rust
-/// # extern crate azure_functions;
-/// # #[macro_use] extern crate log;
 /// use azure_functions::{
 ///     bindings::EventHubTrigger,
 ///     func,
 /// };
+/// use log::warn;
 ///
 /// #[func]
 /// #[binding(name = "trigger", connection = "my_connection")]
@@ -102,6 +101,7 @@ impl EventHubTrigger {
 mod tests {
     use super::*;
     use crate::event_hub::RuntimeInformation;
+    use serde_json::json;
     use std::str::FromStr;
 
     #[test]

--- a/azure-functions/src/bindings/http_request.rs
+++ b/azure-functions/src/bindings/http_request.rs
@@ -9,7 +9,6 @@ use std::collections::HashMap;
 /// A function that responds with a friendly greeting:
 ///
 /// ```rust
-/// # extern crate azure_functions;
 /// use azure_functions::{
 ///     bindings::{HttpRequest, HttpResponse},
 ///     func,
@@ -53,7 +52,6 @@ impl HttpRequest {
     /// # Examples
     ///
     /// ```rust
-    /// # extern crate azure_functions;
     /// use azure_functions::func;
     /// use azure_functions::bindings::{HttpRequest, HttpResponse};
     ///
@@ -80,7 +78,6 @@ impl HttpRequest {
     /// # Examples
     ///
     /// ```rust
-    /// # extern crate azure_functions;
     /// use azure_functions::func;
     /// use azure_functions::bindings::{HttpRequest, HttpResponse};
     ///
@@ -122,6 +119,7 @@ impl HttpRequest {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use matches::matches;
     use std::borrow::Cow;
 
     #[test]

--- a/azure-functions/src/bindings/http_response.rs
+++ b/azure-functions/src/bindings/http_response.rs
@@ -11,97 +11,55 @@ use std::collections::HashMap;
 /// Creating a response from a string:
 ///
 /// ```rust
-/// use azure_functions::bindings::HttpResponse;
-/// use azure_functions::http::{Body, Status};
+/// use azure_functions::bindings::{HttpRequest, HttpResponse};
+/// use azure_functions::func;
 ///
-/// let response: HttpResponse = "hello world".into();
-///
-/// assert_eq!(response.status(), Status::Ok);
-/// assert_eq!(
-///     response
-///         .headers()
-///         .get("Content-Type")
-///         .unwrap(),
-///     "text/plain");
-/// assert_eq!(
-///     response.body().as_str().unwrap(),
-///     "hello world"
-/// );
+/// #[func]
+/// pub fn example(_req: HttpRequest) -> HttpResponse {
+///     "Hello world!".into()
+/// }
 /// ```
 ///
 /// Creating a response from a JSON value (see the [json! macro](https://docs.serde.rs/serde_json/macro.json.html) from the `serde_json` crate):
 ///
 /// ```rust
-/// # #[macro_use] extern crate serde_json;
-/// # extern crate azure_functions;
-/// use azure_functions::bindings::HttpResponse;
-/// use azure_functions::http::{Body, Status};
+/// use azure_functions::bindings::{HttpRequest, HttpResponse};
+/// use azure_functions::func;
+/// use serde_json::json;
 ///
-/// let response: HttpResponse = json!({ "hello": "world!" }).into();
-///
-/// assert_eq!(response.status(), Status::Ok);
-/// assert_eq!(
-///     response
-///         .headers()
-///         .get("Content-Type")
-///         .unwrap(),
-///     "application/json"
-/// );
-/// assert_eq!(
-///     response.body().as_str().unwrap(),
-///     "{\"hello\":\"world!\"}"
-/// );
+/// #[func]
+/// pub fn example(_req: HttpRequest) -> HttpResponse {
+///     json!({ "hello": "world" }).into()
+/// }
 /// ```
 ///
 /// Creating a response from a sequence of bytes:
 ///
 /// ```rust
-/// use azure_functions::bindings::HttpResponse;
-/// use azure_functions::http::{Body, Status};
+/// use azure_functions::bindings::{HttpRequest, HttpResponse};
+/// use azure_functions::func;
 ///
-/// let response: HttpResponse = [1, 2, 3][..].into();
-///
-/// assert_eq!(response.status(), Status::Ok);
-/// assert_eq!(
-///     response
-///         .headers()
-///         .get("Content-Type")
-///         .unwrap(),
-///     "application/octet-stream"
-/// );
-/// assert_eq!(
-///     response.body().as_bytes(),
-///     [1, 2, 3]
-/// );
+/// #[func]
+/// pub fn example(_req: HttpRequest) -> HttpResponse {
+///     [1, 2, 3][..].into()
+/// }
 /// ```
 ///
 /// Building a custom response:
 ///
 /// ```rust
-/// use azure_functions::bindings::HttpResponse;
-/// use azure_functions::http::{Body, Status};
+/// use azure_functions::bindings::{HttpRequest, HttpResponse};
+/// use azure_functions::func;
+/// use azure_functions::http::Status;
 ///
-/// let url = "http://example.com";
-/// let body = format!("The requested resource has moved to: {}", url);
-///
-/// let response: HttpResponse = HttpResponse::build()
-///     .status(Status::MovedPermanently)
-///     .header("Location", url)
-///     .body(body.as_str())
-///     .into();
-///
-/// assert_eq!(response.status(), Status::MovedPermanently);
-/// assert_eq!(
-///     response
-///         .headers()
-///         .get("Location")
-///         .unwrap(),
-///     url
-/// );
-/// assert_eq!(
-///     response.body().as_str().unwrap(),
-///     body
-/// );
+/// #[func]
+/// pub fn example(_req: HttpRequest) -> HttpResponse {
+///     HttpResponse::build()
+///         .status(Status::MovedPermanently)
+///         .header("Location", "http://example.com")
+///         .body("The requested resource has moved to: http://example.com")
+///         .into()
+/// }
 /// ```
 #[derive(Default, Debug)]
 pub struct HttpResponse {
@@ -209,6 +167,8 @@ impl Into<protocol::TypedData> for HttpResponse {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use matches::matches;
+    use serde::{Deserialize, Serialize};
 
     #[test]
     fn it_is_empty_by_default() {

--- a/azure-functions/src/bindings/queue_trigger.rs
+++ b/azure-functions/src/bindings/queue_trigger.rs
@@ -18,15 +18,14 @@ const POP_RECEIPT_KEY: &str = "PopReceipt";
 /// A function that runs when a message is posted to a queue called `example`:
 ///
 /// ```rust
-/// # extern crate azure_functions;
-/// # #[macro_use] extern crate log;
 /// use azure_functions::bindings::QueueTrigger;
 /// use azure_functions::func;
+/// use log::warn;
 ///
 /// #[func]
 /// #[binding(name = "trigger", queue_name = "example")]
 /// pub fn run_on_message(trigger: QueueTrigger) {
-///     info!("Rust function ran due to queue message: {}", trigger.message);
+///     warn!("Rust function ran due to queue message: {}", trigger.message);
 /// }
 /// ```
 #[derive(Debug)]

--- a/azure-functions/src/bindings/signalr_group_action.rs
+++ b/azure-functions/src/bindings/signalr_group_action.rs
@@ -1,7 +1,6 @@
-use crate::rpc::protocol;
-use crate::signalr::GroupAction;
+use crate::{rpc::protocol, signalr::GroupAction, FromVec};
 use serde_derive::{Deserialize, Serialize};
-use serde_json::to_string;
+use serde_json::{to_string, to_value, Value};
 
 /// Represents the SignalR group action output binding.
 ///
@@ -46,6 +45,17 @@ impl Into<protocol::TypedData> for SignalRGroupAction {
             to_string(&self).expect("failed to convert SignalR group action to JSON string"),
         );
 
+        data
+    }
+}
+
+#[doc(hidden)]
+impl FromVec<SignalRGroupAction> for protocol::TypedData {
+    fn from_vec(vec: Vec<SignalRGroupAction>) -> Self {
+        let mut data = protocol::TypedData::new();
+        data.set_json(
+            Value::Array(vec.into_iter().map(|a| to_value(a).unwrap()).collect()).to_string(),
+        );
         data
     }
 }

--- a/azure-functions/src/bindings/signalr_message.rs
+++ b/azure-functions/src/bindings/signalr_message.rs
@@ -1,6 +1,6 @@
-use crate::rpc::protocol;
+use crate::{rpc::protocol, FromVec};
 use serde_derive::{Deserialize, Serialize};
-use serde_json::{to_string, Value};
+use serde_json::{to_string, to_value, Value};
 
 /// Represents the SignalR message output binding.
 ///
@@ -45,6 +45,17 @@ impl Into<protocol::TypedData> for SignalRMessage {
     fn into(self) -> protocol::TypedData {
         let mut data = protocol::TypedData::new();
         data.set_json(to_string(&self).expect("failed to convert SignalR message to JSON string"));
+        data
+    }
+}
+
+#[doc(hidden)]
+impl FromVec<SignalRMessage> for protocol::TypedData {
+    fn from_vec(vec: Vec<SignalRMessage>) -> Self {
+        let mut data = protocol::TypedData::new();
+        data.set_json(
+            Value::Array(vec.into_iter().map(|m| to_value(m).unwrap()).collect()).to_string(),
+        );
         data
     }
 }

--- a/azure-functions/src/bindings/table.rs
+++ b/azure-functions/src/bindings/table.rs
@@ -1,6 +1,6 @@
 use crate::http::Body;
 use crate::rpc::protocol;
-use serde_json::{from_str, Map, Value};
+use serde_json::{from_str, json, Map, Value};
 use std::fmt;
 
 /// Represents an Azure Storage table input or output binding.
@@ -10,31 +10,29 @@ use std::fmt;
 /// Read a table storage row based on a key posted to the `example` queue:
 ///
 /// ```rust
-/// # extern crate azure_functions;
-/// # #[macro_use] extern crate log;
 /// use azure_functions::bindings::{QueueTrigger, Table};
 /// use azure_functions::func;
+/// use log::warn;
 ///
 /// #[func]
 /// #[binding(name = "trigger", queue_name = "example")]
 /// #[binding(name = "table", table_name = "MyTable", partition_key = "MyPartition", row_key = "{queueTrigger}")]
 /// pub fn log_row(trigger: QueueTrigger, table: Table) {
-///     info!("Row: {:?}", table.rows().nth(0));
+///     warn!("Row: {:?}", table.rows().nth(0));
 /// }
 /// ```
 /// Run an Azure Storage table query based on a HTTP request:
 ///
 /// ```rust
-/// # extern crate azure_functions;
-/// # #[macro_use] extern crate log;
 /// use azure_functions::bindings::{HttpRequest, Table};
 /// use azure_functions::func;
+/// use log::warn;
 ///
 /// #[func]
 /// #[binding(name = "table", table_name = "MyTable", filter = "{filter}")]
 /// pub fn log_rows(req: HttpRequest, table: Table) {
 ///     for row in table.rows() {
-///         info!("Row: {:?}", row);
+///         warn!("Row: {:?}", row);
 ///     }
 /// }
 #[derive(Default, Debug, Clone)]

--- a/azure-functions/src/bindings/timer_info.rs
+++ b/azure-functions/src/bindings/timer_info.rs
@@ -1,5 +1,6 @@
 use crate::rpc::protocol;
 use crate::timer::ScheduleStatus;
+use serde_derive::Deserialize;
 use serde_json::from_str;
 use std::collections::HashMap;
 
@@ -10,15 +11,14 @@ use std::collections::HashMap;
 /// A function that runs every 5 minutes:
 ///
 /// ```rust
-/// # extern crate azure_functions;
-/// # #[macro_use] extern crate log;
 /// use azure_functions::bindings::TimerInfo;
 /// use azure_functions::func;
+/// use log::warn;
 ///
 /// #[func]
 /// #[binding(name = "_info", schedule = "0 */5 * * * *")]
 /// pub fn timer(_info: TimerInfo) {
-///     info!("Rust Azure function ran!");
+///     warn!("Rust Azure function ran!");
 /// }
 /// ```
 #[derive(Debug, Deserialize)]

--- a/azure-functions/src/blob/properties.rs
+++ b/azure-functions/src/blob/properties.rs
@@ -143,7 +143,7 @@ impl Default for StandardBlobTier {
 }
 
 /// Represents the properties of an Azure Storage blob.
-#[derive(Default, Debug, Deserialize)]
+#[derive(Default, Debug, serde_derive::Deserialize)]
 #[serde(rename_all = "PascalCase")]
 pub struct Properties {
     /// The number of committed blocks, if the blob is an append blob.
@@ -320,7 +320,8 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use serde_json::from_value;
+    use matches::matches;
+    use serde_json::{from_value, json};
 
     #[test]
     fn it_deserializes_from_json() {

--- a/azure-functions/src/event_hub/partition_context.rs
+++ b/azure-functions/src/event_hub/partition_context.rs
@@ -1,4 +1,5 @@
 use crate::event_hub::RuntimeInformation;
+use serde_derive::{Deserialize, Serialize};
 
 /// Encapsulates information related to an Event Hubs partition.
 #[derive(Debug, Serialize, Deserialize)]

--- a/azure-functions/src/event_hub/runtime_information.rs
+++ b/azure-functions/src/event_hub/runtime_information.rs
@@ -1,5 +1,6 @@
 use crate::util::deserialize_datetime;
 use chrono::{DateTime, Utc};
+use serde_derive::{Deserialize, Serialize};
 
 /// Represents the approximate receiver runtime information for a logical partition of an Event Hub.
 #[derive(Debug, Serialize, Deserialize)]

--- a/azure-functions/src/event_hub/system_properties.rs
+++ b/azure-functions/src/event_hub/system_properties.rs
@@ -1,5 +1,6 @@
 use crate::util::deserialize_datetime;
 use chrono::{DateTime, Utc};
+use serde_derive::{Deserialize, Serialize};
 
 /// Represents properties that are set by the Event Hubs service.
 #[derive(Debug, Serialize, Deserialize)]

--- a/azure-functions/src/http/body.rs
+++ b/azure-functions/src/http/body.rs
@@ -92,11 +92,9 @@ impl Body<'_> {
     /// # Examples
     ///
     /// ```rust
-    /// # #[macro_use] extern crate serde_derive;
-    /// # extern crate serde;
-    /// # extern crate azure_functions;
     /// use azure_functions::http::Body;
     /// use std::borrow::Cow;
+    /// use serde_derive::Deserialize;
     ///
     /// #[derive(Deserialize)]
     /// struct Data {
@@ -203,6 +201,8 @@ impl Into<protocol::TypedData> for Body<'_> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use matches::matches;
+    use serde_derive::{Deserialize, Serialize};
     use serde_json::to_value;
     use std::fmt::Write;
 

--- a/azure-functions/src/http/status.rs
+++ b/azure-functions/src/http/status.rs
@@ -19,7 +19,6 @@ macro_rules! statuses {
         /// Create a `Status` from a status code `code`:
         ///
         /// ```rust
-        /// # extern crate azure_functions;
         /// use azure_functions::http::Status;
         ///
         /// assert_eq!(Status::from_code(404), Status::NotFound);

--- a/azure-functions/src/lib.rs
+++ b/azure-functions/src/lib.rs
@@ -81,16 +81,6 @@
 #![deny(missing_docs)]
 #![cfg_attr(test, recursion_limit = "128")]
 
-#[macro_use]
-extern crate serde_json;
-#[macro_use]
-extern crate serde_derive;
-#[cfg(test)]
-#[macro_use(matches)]
-extern crate matches;
-#[macro_use]
-extern crate lazy_static;
-
 #[doc(no_inline)]
 pub use azure_functions_codegen::func;
 
@@ -117,7 +107,7 @@ pub use azure_functions_shared::Context;
 use crate::registry::Registry;
 use futures::Future;
 use serde::Serialize;
-use serde_json::{to_string_pretty, Serializer};
+use serde_json::{json, to_string_pretty, Serializer};
 use std::env::{current_dir, current_exe};
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -125,6 +115,16 @@ use std::process::Command;
 use tempfile::TempDir;
 use xml::writer::XmlEvent;
 use xml::EmitterConfig;
+
+#[doc(hidden)]
+pub trait IntoVec<T> {
+    fn into_vec(self) -> Vec<T>;
+}
+
+#[doc(hidden)]
+pub trait FromVec<T> {
+    fn from_vec(vec: Vec<T>) -> Self;
+}
 
 // This is a workaround to the issue that `file!` expands to be workspace-relative
 // and cargo does not have an environment variable for the workspace directory.

--- a/azure-functions/src/registry.rs
+++ b/azure-functions/src/registry.rs
@@ -1,4 +1,5 @@
 use crate::codegen::{bindings, Function};
+use lazy_static::lazy_static;
 use std::collections::hash_map::Iter;
 use std::collections::HashMap;
 

--- a/azure-functions/src/timer/schedule_status.rs
+++ b/azure-functions/src/timer/schedule_status.rs
@@ -1,5 +1,6 @@
 use crate::util::deserialize_datetime;
 use chrono::{DateTime, Utc};
+use serde_derive::Deserialize;
 
 /// Represents a timer binding schedule status.
 #[derive(Debug, Deserialize)]

--- a/examples/cosmosdb/src/functions/mod.rs
+++ b/examples/cosmosdb/src/functions/mod.rs
@@ -4,6 +4,7 @@
 // Export the modules that define Azure Functions here.
 azure_functions::export! {
     create_document,
+    query_documents,
     log_documents,
     read_document
 }

--- a/examples/cosmosdb/src/functions/query_documents.rs
+++ b/examples/cosmosdb/src/functions/query_documents.rs
@@ -1,0 +1,18 @@
+use azure_functions::{
+    bindings::{CosmosDbDocument, HttpRequest, HttpResponse},
+    func,
+};
+
+#[func]
+#[binding(name = "_req", route = "query/{name}")]
+#[binding(
+    name = "documents",
+    connection = "connection",
+    database_name = "exampledb",
+    collection_name = "documents",
+    sql_query="select * from documents d where contains(d.name, {name})",
+    create_collection = true,
+)]
+pub fn query_documents(_req: HttpRequest, documents: Vec<CosmosDbDocument>) -> HttpResponse {
+    documents.into()
+}

--- a/examples/event-hub/src/functions/create_event.rs
+++ b/examples/event-hub/src/functions/create_event.rs
@@ -1,13 +1,17 @@
 use azure_functions::{
-    bindings::{HttpRequest, HttpResponse, EventHubMessage},
+    bindings::{EventHubMessage, HttpRequest, HttpResponse},
     func,
 };
 
 #[func]
-#[binding(name = "output1", connection = "connection", event_hub_name = "example")]
+#[binding(
+    name = "output1",
+    connection = "connection",
+    event_hub_name = "example"
+)]
 pub fn create_event(_req: HttpRequest) -> (HttpResponse, EventHubMessage) {
     (
         "Created Event Hub message.".into(),
-        "Hello from Rust!".into()
+        "Hello from Rust!".into(),
     )
 }


### PR DESCRIPTION
This commit implements `Vec<T>` input and output bindings.

By accepting `Vec<T>` as a parameter, it allows certain input bindings to have
multiple items (e.g. Cosmos DB documents from a query).

By returning `Vec<T>` as a return value, it allows certain output bindings to
create multiple items (e.g. storage queue messages).

This commit also removes any unnecessary `extern crate` declarations and
changes all binding documentation to use Azure Function examples.

Closes #207.