### PR TITLE
Implement logging a backtrace when an Azure Function panics.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,6 +50,7 @@ version = "0.5.2"
 dependencies = [
  "azure-functions-codegen 0.5.2",
  "azure-functions-shared 0.5.2",
+ "backtrace 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.32.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ctrlc 3.1.1 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/azure-functions/Cargo.toml
+++ b/azure-functions/Cargo.toml
@@ -24,6 +24,7 @@ xml-rs = "0.8.0"
 lazy_static = "1.3.0"
 tempfile = "3.0.7"
 ctrlc = "3.1.1"
+backtrace = "0.3.14"
 
 [features]
 unstable = ["azure-functions-codegen/unstable", "azure-functions-shared/unstable"]

--- a/azure-functions/src/backtrace.rs
+++ b/azure-functions/src/backtrace.rs
@@ -1,0 +1,83 @@
+use backtrace::BacktraceFrame;
+use std::env;
+use std::fmt;
+
+pub struct Backtrace {
+    inner: backtrace::Backtrace,
+}
+
+impl Backtrace {
+    pub fn new() -> Backtrace {
+        if !Backtrace::is_enabled() {
+            return Backtrace {
+                inner: Vec::<BacktraceFrame>::new().into(),
+            };
+        }
+
+        let mut found_start = false;
+        let mut found_end = false;
+
+        // This attempts to filter to only the frames relevant to the Azure Function
+        let frames: Vec<BacktraceFrame> = backtrace::Backtrace::new()
+            .frames()
+            .iter()
+            .filter_map(|frame| {
+                if found_end {
+                    return None;
+                }
+
+                for symbol in frame.symbols().iter() {
+                    if let Some(name) = symbol.name() {
+                        let name = format!("{}", name);
+
+                        // Check for the start (i.e. where the panic starts)
+                        if !found_start {
+                            if name.starts_with("std::panicking::begin_panic::")
+                                || name.starts_with("core::panicking::panic::")
+                            {
+                                found_start = true;
+                            }
+                            return None;
+                        }
+
+                        // Check for the end (the invoker frame)
+                        if !found_end && name.contains("::__invoke_") {
+                            found_end = true;
+                            return None;
+                        }
+                    }
+                }
+
+                Some(frame.clone())
+            })
+            .collect();
+
+        Backtrace {
+            inner: frames.into(),
+        }
+    }
+
+    pub fn is_enabled() -> bool {
+        env::var("RUST_BACKTRACE").unwrap_or_else(|_| "0".to_owned()) == "1"
+    }
+}
+
+impl fmt::Display for Backtrace {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        use std::fmt::Debug;
+
+        if !Backtrace::is_enabled() {
+            return write!(
+                f,
+                "\nNote: run with `RUST_BACKTRACE=1` environment variable to display a backtrace."
+            );
+        }
+
+        if self.inner.frames().is_empty() {
+            return Ok(());
+        }
+
+        writeln!(f)?;
+        self.inner.fmt(f)
+    }
+}

--- a/azure-functions/src/lib.rs
+++ b/azure-functions/src/lib.rs
@@ -87,6 +87,7 @@ pub use azure_functions_codegen::func;
 #[doc(hidden)]
 pub use azure_functions_shared::codegen;
 
+mod backtrace;
 mod cli;
 mod logger;
 mod registry;


### PR DESCRIPTION
This commit implements logging a backtrace when an Azure Function panics.

To enable the backtrace, set `RUST_BACKTRACE` to `1` in the environment.

For example, `RUST_BACKTRACE=1 cargo func run`.

Closes #205.