### PR TITLE
Replace tower-grpc with grpc-rs. 

### DIFF
--- a/.azure/azure-pipelines.yml
+++ b/.azure/azure-pipelines.yml
@@ -43,8 +43,10 @@ steps:
   - bash: |
       set -e
       curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain $(toolchain)
-      echo "##vso[task.prependpath]$HOME/.cargo/bin"
+      $HOME/.cargo/bin/rustup component add rustfmt
+      $HOME/.cargo/bin/rustup component add clippy
       $HOME/.cargo/bin/rustc -Vv
+      echo "##vso[task.prependpath]$HOME/.cargo/bin"
     displayName: Install Rust
   - bash: |
       set -e
@@ -64,14 +66,12 @@ steps:
     displayName: Compile protobufs
   - bash: |
       set -e
-      rustup component add rustfmt
       cargo fmt --version || true
       cargo fmt -- --check
       git diff
     displayName: Check source formatting
   - bash: |
       set -e
-      rustup component add clippy
       cargo clippy --version || true
       cargo clippy --release -- -Dwarnings
     displayName: Check for linter errors

--- a/.azure/azure-pipelines.yml
+++ b/.azure/azure-pipelines.yml
@@ -1,6 +1,6 @@
 variables:
   protobuf-version: 3.7.1
-  lkg-rust-nightly: "2019-04-12"
+  lkg-rust-nightly: "2019-05-16"
 
 trigger:
   - master

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -61,6 +61,7 @@ dependencies = [
  "ctrlc 3.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "fs_extra 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "grpcio 0.5.0-alpha.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -70,11 +71,6 @@ dependencies = [
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)",
- "tower-grpc 0.1.0 (git+https://github.com/tower-rs/tower-grpc?rev=55d004e49f6c6097a9f556752bceb8b32c8c700f)",
- "tower-h2 0.1.0 (git+https://github.com/tower-rs/tower-h2?rev=a3c958a243ef3d837933b31bf186ba0e6b0e60c9)",
- "tower-request-modifier 0.1.0 (git+https://github.com/tower-rs/tower-http?rev=e7ef6ef623411342ee89c0a83ef924db6206143a)",
- "tower-service 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tower-util 0.1.0 (git+https://github.com/tower-rs/tower?rev=979c1399127bdb269c751b99c12b3adfad55463c)",
  "xml-rs 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -109,17 +105,19 @@ version = "0.7.0"
 dependencies = [
  "azure-functions-shared-codegen 0.7.0",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
+ "grpcio 0.5.0-alpha.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "grpcio-compiler 0.5.0-alpha (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost-types 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "protobuf-build 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 0.15.34 (registry+https://github.com/rust-lang/crates.io-index)",
- "tower-grpc 0.1.0 (git+https://github.com/tower-rs/tower-grpc?rev=55d004e49f6c6097a9f556752bceb8b32c8c700f)",
- "tower-grpc-build 0.1.0 (git+https://github.com/tower-rs/tower-grpc?rev=55d004e49f6c6097a9f556752bceb8b32c8c700f)",
 ]
 
 [[package]]
@@ -148,16 +146,8 @@ name = "backtrace-sys"
 version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "cc 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "base64"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -198,13 +188,12 @@ version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "either 1.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "cc"
-version = "1.0.28"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -256,11 +245,11 @@ dependencies = [
 ]
 
 [[package]]
-name = "codegen"
-version = "0.1.1"
-source = "git+https://github.com/carllerche/codegen#87e270f74a9b686e8f8a2daf6b4b4112a2807f90"
+name = "cmake"
+version = "0.1.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "indexmap 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -330,6 +319,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive-new"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.34 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "digest"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -364,6 +363,18 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "backtrace 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "failure_derive"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.34 (registry+https://github.com/rust-lang/crates.io-index)",
+ "synstructure 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -428,20 +439,41 @@ dependencies = [
 ]
 
 [[package]]
-name = "h2"
-version = "0.1.18"
+name = "grpcio"
+version = "0.5.0-alpha.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
- "http 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "indexmap 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "grpcio-sys 0.5.0-alpha (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "string 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "prost 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "grpcio-compiler"
+version = "0.5.0-alpha"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "derive-new 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "prost 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "prost-build 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "prost-types 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "protobuf 2.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "protobuf-codegen 2.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tempfile 3.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "grpcio-sys"
+version = "0.5.0-alpha"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "cc 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cmake 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pkg-config 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -469,27 +501,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "http"
-version = "0.1.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "itoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "http-body"
-version = "0.1.0"
-source = "git+https://github.com/tower-rs/tower-http#e7ef6ef623411342ee89c0a83ef924db6206143a"
-dependencies = [
- "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
- "http 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-buf 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "http-example"
 version = "0.1.0"
 dependencies = [
@@ -498,11 +509,6 @@ dependencies = [
  "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
-
-[[package]]
-name = "indexmap"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "iovec"
@@ -647,7 +653,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "cc 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)",
+ "cc 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.48 (registry+https://github.com/rust-lang/crates.io-index)",
  "void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -717,11 +723,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "percent-encoding"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
 name = "pest"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -767,6 +768,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "fixedbitset 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "pkg-config"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "proc-macro2"
@@ -822,6 +828,64 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "prost 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "protobuf"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "protobuf-build"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "grpcio-compiler 0.5.0-alpha (registry+https://github.com/rust-lang/crates.io-index)",
+ "protoc-grpcio 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "protoc-rust 2.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.34 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "protobuf-codegen"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "protobuf 2.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "protoc"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "protoc-grpcio"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "grpcio-compiler 0.5.0-alpha (registry+https://github.com/rust-lang/crates.io-index)",
+ "protobuf 2.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "protobuf-codegen 2.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "protoc 2.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tempfile 3.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "protoc-rust"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "protobuf 2.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "protobuf-codegen 2.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "protoc 2.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tempfile 3.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -1131,11 +1195,6 @@ version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "string"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
 name = "strsim"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1147,6 +1206,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.34 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicode-xid 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1250,30 +1320,11 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-buf"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "either 1.5.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "tokio-codec"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "tokio-connect"
-version = "0.1.0"
-source = "git+https://github.com/carllerche/tokio-connect#f7ad1ca437973d6e24037ac6f7d5ef1013833c0b"
-dependencies = [
  "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1423,241 +1474,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tower"
-version = "0.1.0"
-source = "git+https://github.com/tower-rs/tower#979c1399127bdb269c751b99c12b3adfad55463c"
-dependencies = [
- "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
- "tower-buffer 0.1.0 (git+https://github.com/tower-rs/tower)",
- "tower-discover 0.1.0 (git+https://github.com/tower-rs/tower)",
- "tower-layer 0.1.0 (git+https://github.com/tower-rs/tower)",
- "tower-limit 0.1.0 (git+https://github.com/tower-rs/tower)",
- "tower-load-shed 0.1.0 (git+https://github.com/tower-rs/tower)",
- "tower-reconnect 0.1.0 (git+https://github.com/tower-rs/tower)",
- "tower-retry 0.1.0 (git+https://github.com/tower-rs/tower)",
- "tower-service 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tower-timeout 0.1.0 (git+https://github.com/tower-rs/tower)",
- "tower-util 0.1.0 (git+https://github.com/tower-rs/tower)",
-]
-
-[[package]]
-name = "tower-buffer"
-version = "0.1.0"
-source = "git+https://github.com/tower-rs/tower#979c1399127bdb269c751b99c12b3adfad55463c"
-dependencies = [
- "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-executor 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-sync 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "tower-layer 0.1.0 (git+https://github.com/tower-rs/tower)",
- "tower-service 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "tower-discover"
-version = "0.1.0"
-source = "git+https://github.com/tower-rs/tower#979c1399127bdb269c751b99c12b3adfad55463c"
-dependencies = [
- "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
- "tower-service 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "tower-grpc"
-version = "0.1.0"
-source = "git+https://github.com/tower-rs/tower-grpc?rev=55d004e49f6c6097a9f556752bceb8b32c8c700f#55d004e49f6c6097a9f556752bceb8b32c8c700f"
-dependencies = [
- "base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
- "h2 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
- "http 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "prost 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tower-h2 0.1.0 (git+https://github.com/tower-rs/tower-h2)",
- "tower-http 0.1.0 (git+https://github.com/tower-rs/tower-http)",
- "tower-service 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tower-util 0.1.0 (git+https://github.com/tower-rs/tower)",
-]
-
-[[package]]
-name = "tower-grpc-build"
-version = "0.1.0"
-source = "git+https://github.com/tower-rs/tower-grpc?rev=55d004e49f6c6097a9f556752bceb8b32c8c700f#55d004e49f6c6097a9f556752bceb8b32c8c700f"
-dependencies = [
- "codegen 0.1.1 (git+https://github.com/carllerche/codegen)",
- "heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "prost-build 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "tower-h2"
-version = "0.1.0"
-source = "git+https://github.com/tower-rs/tower-h2#a3c958a243ef3d837933b31bf186ba0e6b0e60c9"
-dependencies = [
- "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
- "h2 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
- "http 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-connect 0.1.0 (git+https://github.com/carllerche/tokio-connect)",
- "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "tower 0.1.0 (git+https://github.com/tower-rs/tower)",
- "tower-http 0.1.0 (git+https://github.com/tower-rs/tower-http)",
- "tower-service 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "tower-h2"
-version = "0.1.0"
-source = "git+https://github.com/tower-rs/tower-h2?rev=a3c958a243ef3d837933b31bf186ba0e6b0e60c9#a3c958a243ef3d837933b31bf186ba0e6b0e60c9"
-dependencies = [
- "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
- "h2 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)",
- "http 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-connect 0.1.0 (git+https://github.com/carllerche/tokio-connect)",
- "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "tower 0.1.0 (git+https://github.com/tower-rs/tower)",
- "tower-http 0.1.0 (git+https://github.com/tower-rs/tower-http)",
- "tower-service 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "tower-http"
-version = "0.1.0"
-source = "git+https://github.com/tower-rs/tower-http#e7ef6ef623411342ee89c0a83ef924db6206143a"
-dependencies = [
- "http-body 0.1.0 (git+https://github.com/tower-rs/tower-http)",
- "tower-http-util 0.1.0 (git+https://github.com/tower-rs/tower-http)",
-]
-
-[[package]]
-name = "tower-http-util"
-version = "0.1.0"
-source = "git+https://github.com/tower-rs/tower-http#e7ef6ef623411342ee89c0a83ef924db6206143a"
-dependencies = [
- "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
- "http 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "http-body 0.1.0 (git+https://github.com/tower-rs/tower-http)",
- "tokio-buf 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tower-service 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "tower-layer"
-version = "0.1.0"
-source = "git+https://github.com/tower-rs/tower#979c1399127bdb269c751b99c12b3adfad55463c"
-dependencies = [
- "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
- "tower-service 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "tower-layer"
-version = "0.1.0"
-source = "git+https://github.com/tower-rs/tower?rev=979c1399127bdb269c751b99c12b3adfad55463c#979c1399127bdb269c751b99c12b3adfad55463c"
-dependencies = [
- "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
- "tower-service 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "tower-limit"
-version = "0.1.0"
-source = "git+https://github.com/tower-rs/tower#979c1399127bdb269c751b99c12b3adfad55463c"
-dependencies = [
- "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-sync 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-timer 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "tower-layer 0.1.0 (git+https://github.com/tower-rs/tower)",
- "tower-service 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "tower-load-shed"
-version = "0.1.0"
-source = "git+https://github.com/tower-rs/tower#979c1399127bdb269c751b99c12b3adfad55463c"
-dependencies = [
- "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
- "tower-layer 0.1.0 (git+https://github.com/tower-rs/tower)",
- "tower-service 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "tower-reconnect"
-version = "0.1.0"
-source = "git+https://github.com/tower-rs/tower#979c1399127bdb269c751b99c12b3adfad55463c"
-dependencies = [
- "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
- "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "tower-service 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "tower-util 0.1.0 (git+https://github.com/tower-rs/tower)",
-]
-
-[[package]]
-name = "tower-request-modifier"
-version = "0.1.0"
-source = "git+https://github.com/tower-rs/tower-http?rev=e7ef6ef623411342ee89c0a83ef924db6206143a#e7ef6ef623411342ee89c0a83ef924db6206143a"
-dependencies = [
- "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
- "http 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
- "tower-service 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "tower-retry"
-version = "0.1.0"
-source = "git+https://github.com/tower-rs/tower#979c1399127bdb269c751b99c12b3adfad55463c"
-dependencies = [
- "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-timer 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "tower-layer 0.1.0 (git+https://github.com/tower-rs/tower)",
- "tower-service 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "tower-service"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "tower-timeout"
-version = "0.1.0"
-source = "git+https://github.com/tower-rs/tower#979c1399127bdb269c751b99c12b3adfad55463c"
-dependencies = [
- "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-timer 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "tower-layer 0.1.0 (git+https://github.com/tower-rs/tower)",
- "tower-service 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "tower-util"
-version = "0.1.0"
-source = "git+https://github.com/tower-rs/tower#979c1399127bdb269c751b99c12b3adfad55463c"
-dependencies = [
- "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
- "tokio-io 0.1.12 (registry+https://github.com/rust-lang/crates.io-index)",
- "tower-layer 0.1.0 (git+https://github.com/tower-rs/tower)",
- "tower-service 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
-name = "tower-util"
-version = "0.1.0"
-source = "git+https://github.com/tower-rs/tower?rev=979c1399127bdb269c751b99c12b3adfad55463c#979c1399127bdb269c751b99c12b3adfad55463c"
-dependencies = [
- "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
- "tower-layer 0.1.0 (git+https://github.com/tower-rs/tower?rev=979c1399127bdb269c751b99c12b3adfad55463c)",
- "tower-service 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
-]
-
-[[package]]
 name = "twilio-example"
 version = "0.1.0"
 dependencies = [
@@ -1800,28 +1616,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum autocfg 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "a6d640bee2da49f60a4068a7fae53acde8982514ab7bae8b8cea9e88cbcfd799"
 "checksum backtrace 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)" = "70af6de4789ac39587f100176ac7f704531e9e534b0f8676f658b3d909ce9a94"
 "checksum backtrace-sys 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)" = "797c830ac25ccc92a7f8a7b9862bde440715531514594a6154e3d4a54dd769b6"
-"checksum base64 0.10.1 (registry+https://github.com/rust-lang/crates.io-index)" = "0b25d992356d2eb0ed82172f5248873db5560c4721f564b13cb5193bda5e668e"
 "checksum bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "228047a76f468627ca71776ecdebd732a3423081fcf5125585bcd7c49886ce12"
 "checksum block-buffer 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a076c298b9ecdb530ed9d967e74a6027d6a7478924520acddcddc24c1c8ab3ab"
 "checksum byte-tools 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "560c32574a12a89ecd91f5e742165893f86e3ab98d21f8ea548658eb9eef5f40"
 "checksum byteorder 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a019b10a2a7cdeb292db131fc8113e57ea2a908f6e7894b0c3c671893b65dbeb"
 "checksum bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)" = "206fdffcfa2df7cbe15601ef46c813fce0965eb3286db6b56c583b814b51c81c"
-"checksum cc 1.0.28 (registry+https://github.com/rust-lang/crates.io-index)" = "bb4a8b715cb4597106ea87c7c84b2f1d452c7492033765df7f32651e66fcf749"
+"checksum cc 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)" = "39f75544d7bbaf57560d2168f28fd649ff9c76153874db88bdbdfd839b1a7e7d"
 "checksum cfg-if 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "082bb9b28e00d3c9d39cc03e64ce4cea0f1bb9b3fde493f0cbc008472d22bdf4"
 "checksum cgmath 0.16.1 (registry+https://github.com/rust-lang/crates.io-index)" = "64a4b57c8f4e3a2e9ac07e0f6abc9c24b6fc9e1b54c3478cfb598f3d0023e51c"
 "checksum chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "45912881121cb26fad7c38c17ba7daa18764771836b34fab7d3fbd93ed633878"
 "checksum clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5067f5bb2d80ef5d68b4c87db81601f0b75bca627bc2ef76b141d7b846a3c6d9"
 "checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
-"checksum codegen 0.1.1 (git+https://github.com/carllerche/codegen)" = "<none>"
+"checksum cmake 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)" = "2ca4386c8954b76a8415b63959337d940d724b336cabd3afe189c2b51a7e1ff0"
 "checksum colored 1.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6cdb90b60f2927f8d76139c72dbde7e10c3a2bc47c8594c9c7a66529f2687c03"
 "checksum crossbeam-deque 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b18cd2e169ad86297e6bc0ad9aa679aee9daa4f19e8163860faf7c164e4f5a71"
 "checksum crossbeam-epoch 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "04c9e3102cc2d69cd681412141b390abd55a362afc1540965dad0ad4d34280b4"
 "checksum crossbeam-queue 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7c979cd6cfe72335896575c6b5688da489e420d36a27a0b9eb0c73db574b4a4b"
 "checksum crossbeam-utils 0.6.5 (registry+https://github.com/rust-lang/crates.io-index)" = "f8306fcef4a7b563b76b7dd949ca48f52bc1141aa067d2ea09565f3e2652aa5c"
 "checksum ctrlc 3.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "5531b7f0698d9220b4729f8811931dbe0e91a05be2f7b3245fdc50dd856bae26"
+"checksum derive-new 0.5.6 (registry+https://github.com/rust-lang/crates.io-index)" = "6ca414e896ae072546f4d789f452daaecf60ddee4c9df5dc6d5936d769e3d87c"
 "checksum digest 0.7.6 (registry+https://github.com/rust-lang/crates.io-index)" = "03b072242a8cbaf9c145665af9d250c59af3b958f83ed6824e13533cf76d5b90"
 "checksum either 1.5.2 (registry+https://github.com/rust-lang/crates.io-index)" = "5527cfe0d098f36e3f8839852688e63c8fff1c90b2b405aef730615f9a7bcf7b"
 "checksum failure 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "795bd83d3abeb9220f257e597aa0080a508b27533824adf336529648f6abf7e2"
+"checksum failure_derive 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "ea1063915fd7ef4309e222a5a07cf9c319fb9c7836b1f89b85458672dbb127e1"
 "checksum fake-simd 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e88a8acf291dafb59c2d96e8f59828f3838bb1a70398823ade51a84de6a6deed"
 "checksum fixedbitset 0.1.9 (registry+https://github.com/rust-lang/crates.io-index)" = "86d4de0081402f5e88cdac65c8dcdcc73118c1a7a465e2a05f0da05843a8ea33"
 "checksum fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
@@ -1831,12 +1648,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 "checksum futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)" = "a2037ec1c6c1c4f79557762eab1f7eae1f64f6cb418ace90fae88f0942b60139"
 "checksum generic-array 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ef25c5683767570c2bbd7deba372926a55eaae9982d7726ee2a1050239d45b9d"
-"checksum h2 0.1.18 (registry+https://github.com/rust-lang/crates.io-index)" = "85ab6286db06040ddefb71641b50017c06874614001a134b423783e2db2920bd"
+"checksum grpcio 0.5.0-alpha.1 (registry+https://github.com/rust-lang/crates.io-index)" = "f06ce97d149a7e9c5cb0bbc4ab014f2500e478e584ac97bb577658b834842232"
+"checksum grpcio-compiler 0.5.0-alpha (registry+https://github.com/rust-lang/crates.io-index)" = "9a135632fa82163b355fd629acfc07e4521166a87ad4b0716e148203735fa450"
+"checksum grpcio-sys 0.5.0-alpha (registry+https://github.com/rust-lang/crates.io-index)" = "1e85ec75a9091220c12695560c63ace432481d8a3014812bd7f897f977a3f47c"
 "checksum handlebars 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "d82e5750d8027a97b9640e3fefa66bbaf852a35228e1c90790efd13c4b09c166"
 "checksum heck 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "20564e78d53d2bb135c343b3f47714a56af2061f1c928fdb541dc7b9fdd94205"
-"checksum http 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)" = "eed324f0f0daf6ec10c474f150505af2c143f251722bf9dbd1261bd1f2ee2c1a"
-"checksum http-body 0.1.0 (git+https://github.com/tower-rs/tower-http)" = "<none>"
-"checksum indexmap 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7e81a7c05f79578dbc15793d8b619db9ba32b4577003ef3af1a91c416798c58d"
 "checksum iovec 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "dbe6e417e7d0975db6512b90796e8ce223145ac4e33c377e4a42882a0e88bb08"
 "checksum itertools 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5b8467d9c1cebe26feb08c640139247fac215782d35371ade9a2136ed6085358"
 "checksum itoa 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "1306f3464951f30e30d12373d31c79fbd52d236e5e896fd92f96ec7babbbe60b"
@@ -1864,17 +1680,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum owning_ref 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "49a4b8ea2179e6a2e27411d3bca09ca6dd630821cf6894c6c7c8467a8ee7ef13"
 "checksum parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ab41b4aed082705d1056416ae4468b6ea99d52599ecf3169b00088d43113e337"
 "checksum parking_lot_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "94c8c7923936b28d546dfd14d4472eaf34c99b14e1c973a32b3e6d4eb04298c9"
-"checksum percent-encoding 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
 "checksum pest 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "54f0c72a98d8ab3c99560bfd16df8059cc10e1f9a8e83e6e3b97718dd766e9c3"
 "checksum pest_derive 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "833d1ae558dc601e9a60366421196a8d94bc0ac980476d0b67e1d0988d72b2d0"
 "checksum pest_generator 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "63120576c4efd69615b5537d3d052257328a4ca82876771d6944424ccfd9f646"
 "checksum pest_meta 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f5a3492a4ed208ffc247adcdcc7ba2a95be3104f58877d0d02f0df39bf3efb5e"
 "checksum petgraph 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)" = "9c3659d1ee90221741f65dd128d9998311b0e40c5d3c23a62445938214abce4f"
+"checksum pkg-config 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)" = "676e8eb2b1b4c9043511a9b7bea0915320d7e502b0a079fb03f9635a5252b18c"
 "checksum proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)" = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
 "checksum prost 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "96d14b1c185652833d24aaad41c5832b0be5616a590227c1fbff57c616754b23"
 "checksum prost-build 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "eb788126ea840817128183f8f603dce02cb7aea25c2a0b764359d8e20010702e"
 "checksum prost-derive 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5e7dc378b94ac374644181a2247cebf59a6ec1c88b49ac77f3a94b86b79d0e11"
 "checksum prost-types 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1de482a366941c8d56d19b650fac09ca08508f2a696119ee7513ad590c8bac6f"
+"checksum protobuf 2.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "bc7badf647ae2fa27ba51c218e347386c88cc604fcfe71f2aba0ad017f3f2b75"
+"checksum protobuf-build 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "f1927e7b72de5a3e3be3d93eba6d805e6daca76110f95b927ca75e6cab0830cd"
+"checksum protobuf-codegen 2.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "1be75a48019eb5143bd971a904cd99e58ffd25042f36361460b5b21e1de80487"
+"checksum protoc 2.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "e79a2fc9d9566c8b93b21ed17d05be388d3383a508c8ac8dbed5cc535415b77a"
+"checksum protoc-grpcio 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "da4389258ed4b768438edec1e1e813cc7fa29e70c1b1cb4eb2f8fc341dc562dd"
+"checksum protoc-rust 2.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "39a7385f15be35ba0539c4e790cf1822b5563e6f82ec9004dabb153748d8d6b6"
 "checksum quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9274b940887ce9addde99c4eee6b5c44cc494b182b97e73dc8ffdcb3397fd3f0"
 "checksum quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)" = "faf4799c5d274f3868a4aae320a0a182cbd2baee377b378f080e16a23e9d80db"
 "checksum rand 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
@@ -1909,9 +1731,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
 "checksum smallvec 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)" = "c4488ae950c49d403731982257768f48fada354a5203fe81f9bb6f43ca9002be"
 "checksum stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
-"checksum string 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "b639411d0b9c738748b5397d5ceba08e648f4f1992231aa859af1a017f31f60b"
 "checksum strsim 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8ea5119cdb4c55b55d432abb513a0429384878c15dde60cc77b1c99de1a95a6a"
 "checksum syn 0.15.34 (registry+https://github.com/rust-lang/crates.io-index)" = "a1393e4a97a19c01e900df2aec855a29f71cf02c402e2f443b8d2747c25c5dbe"
+"checksum synstructure 0.10.2 (registry+https://github.com/rust-lang/crates.io-index)" = "02353edf96d6e4dc81aea2d8490a7e9db177bf8acb0e951c24940bf866cb313f"
 "checksum tempdir 0.3.7 (registry+https://github.com/rust-lang/crates.io-index)" = "15f2b5fb00ccdf689e0149d1b1b3c03fead81c2b37735d812fa8bddbbf41b6d8"
 "checksum tempfile 3.0.7 (registry+https://github.com/rust-lang/crates.io-index)" = "b86c784c88d98c801132806dadd3819ed29d8600836c4088e855cdf3e178ed8a"
 "checksum termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "689a3bdfaab439fd92bc87df5c4c78417d3cbe537487274e9b0b2dce76e92096"
@@ -1919,9 +1741,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
 "checksum time 0.1.42 (registry+https://github.com/rust-lang/crates.io-index)" = "db8dcfca086c1143c9270ac42a2bbd8a7ee477b78ac8e45b19abfb0cbede4b6f"
 "checksum tokio 0.1.20 (registry+https://github.com/rust-lang/crates.io-index)" = "94a1f9396aec29d31bb16c24d155cfa144d1af91c40740125db3131bdaf76da8"
-"checksum tokio-buf 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "473a45a40e558d6d80e9f60e3d934c32488045def2745488a257e472941e9bce"
 "checksum tokio-codec 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "5c501eceaf96f0e1793cf26beb63da3d11c738c4a943fdf3746d81d64684c39f"
-"checksum tokio-connect 0.1.0 (git+https://github.com/carllerche/tokio-connect)" = "<none>"
 "checksum tokio-current-thread 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "d16217cad7f1b840c5a97dfb3c43b0c871fef423a6e8d2118c604e843662a443"
 "checksum tokio-executor 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "83ea44c6c0773cc034771693711c35c677b4b5a4b21b9e7071704c54de7d555e"
 "checksum tokio-fs 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "3fe6dc22b08d6993916647d108a1a7d15b9cd29c4f4496c62b92c45b5041b7af"
@@ -1934,26 +1754,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum tokio-trace-core 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "350c9edade9830dc185ae48ba45667a445ab59f6167ef6d0254ec9d2430d9dd3"
 "checksum tokio-udp 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "66268575b80f4a4a710ef83d087fdfeeabdce9b74c797535fbac18a2cb906e92"
 "checksum tokio-uds 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)" = "037ffc3ba0e12a0ab4aca92e5234e0dedeb48fddf6ccd260f1f150a36a9f2445"
-"checksum tower 0.1.0 (git+https://github.com/tower-rs/tower)" = "<none>"
-"checksum tower-buffer 0.1.0 (git+https://github.com/tower-rs/tower)" = "<none>"
-"checksum tower-discover 0.1.0 (git+https://github.com/tower-rs/tower)" = "<none>"
-"checksum tower-grpc 0.1.0 (git+https://github.com/tower-rs/tower-grpc?rev=55d004e49f6c6097a9f556752bceb8b32c8c700f)" = "<none>"
-"checksum tower-grpc-build 0.1.0 (git+https://github.com/tower-rs/tower-grpc?rev=55d004e49f6c6097a9f556752bceb8b32c8c700f)" = "<none>"
-"checksum tower-h2 0.1.0 (git+https://github.com/tower-rs/tower-h2)" = "<none>"
-"checksum tower-h2 0.1.0 (git+https://github.com/tower-rs/tower-h2?rev=a3c958a243ef3d837933b31bf186ba0e6b0e60c9)" = "<none>"
-"checksum tower-http 0.1.0 (git+https://github.com/tower-rs/tower-http)" = "<none>"
-"checksum tower-http-util 0.1.0 (git+https://github.com/tower-rs/tower-http)" = "<none>"
-"checksum tower-layer 0.1.0 (git+https://github.com/tower-rs/tower)" = "<none>"
-"checksum tower-layer 0.1.0 (git+https://github.com/tower-rs/tower?rev=979c1399127bdb269c751b99c12b3adfad55463c)" = "<none>"
-"checksum tower-limit 0.1.0 (git+https://github.com/tower-rs/tower)" = "<none>"
-"checksum tower-load-shed 0.1.0 (git+https://github.com/tower-rs/tower)" = "<none>"
-"checksum tower-reconnect 0.1.0 (git+https://github.com/tower-rs/tower)" = "<none>"
-"checksum tower-request-modifier 0.1.0 (git+https://github.com/tower-rs/tower-http?rev=e7ef6ef623411342ee89c0a83ef924db6206143a)" = "<none>"
-"checksum tower-retry 0.1.0 (git+https://github.com/tower-rs/tower)" = "<none>"
-"checksum tower-service 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2cc0c98637d23732f8de6dfd16494c9f1559c3b9e20b4a46462c8f9b9e827bfa"
-"checksum tower-timeout 0.1.0 (git+https://github.com/tower-rs/tower)" = "<none>"
-"checksum tower-util 0.1.0 (git+https://github.com/tower-rs/tower)" = "<none>"
-"checksum tower-util 0.1.0 (git+https://github.com/tower-rs/tower?rev=979c1399127bdb269c751b99c12b3adfad55463c)" = "<none>"
 "checksum typenum 1.10.0 (registry+https://github.com/rust-lang/crates.io-index)" = "612d636f949607bdf9b123b4a6f6d966dedf3ff669f7f045890d3a4a73948169"
 "checksum ucd-trie 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "71a9c5b1fe77426cf144cc30e49e955270f5086e31a6441dfa8b32efc09b9d77"
 "checksum ucd-util 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "535c204ee4d8434478593480b8f86ab45ec9aae0e83c568ca81abf0fd0e88f86"

--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ pub fn greet(req: HttpRequest) -> HttpResponse {
 
 - [Installation](#installation)
   - [Requirements](#requirements)
+    - [CMake](#cmake)
+    - [C++ Compiler](#c-compiler)
     - [.Net Core SDK](#.net-core-sdk)
     - [Azure Functions Core Tools](#azure-functions-core-tools)
   - [Installing the Azure Functions for Rust SDK](#installing-the-azure-functions-for-rust-sdk)
@@ -67,8 +69,63 @@ pub fn greet(req: HttpRequest) -> HttpResponse {
 
 ### Requirements
 
-#### .NET Core SDK
+#### CMake
 
+The `azure-functions` crate has a dependency on the `grpcio` crate that uses [CMake](https://cmake.org) to build and link against the gRPC native library.
+
+CMake must be installed and on the `PATH` to be able to use Azure Functions for Rust.
+
+##### Windows
+
+Install CMake from the [Windows installer](https://cmake.org/download/).
+
+##### macOS
+
+The easiest way to install CMake on macOS is with [Homebrew](https://brew.sh/):
+
+```
+$ brew install cmake
+```
+
+##### Linux
+
+Use your distro's package manager to install a `cmake` (or similar) package.
+
+For example on Debian/Ubuntu:
+
+```
+$ apt-get install cmake
+```
+
+#### C++ Compiler
+
+The `grpcio` crate builds a native library that implements the gRPC runtime.
+
+Therefore, a C++ compiler must be on your PATH.
+
+##### Windows
+
+Install [Visual Studio 2015 or later](https://visualstudio.microsoft.com/).
+
+##### macOS
+
+Ensure the XCode command line utilities are installed, as this will install `clang`:
+
+```
+$ xcode-select --install
+```
+
+##### Linux
+
+Use your distro's package manager to install `g++` (or similar) package:
+
+For example on Debian/Ubuntu:
+
+```
+$ apt-get install g++
+```
+
+#### .NET Core SDK
 
 A .NET Core SDK is required to synchronize Azure Functions Host binding extensions.
 
@@ -359,3 +416,4 @@ pub fn example(...) -> ((), Blob) {
 ```
 
 For the above example, there is no `$return` binding and the Azure Function "returns" no value.  Instead, a single output binding named `output1` is used.
+

--- a/azure-functions-shared/Cargo.toml
+++ b/azure-functions-shared/Cargo.toml
@@ -10,7 +10,8 @@ edition = "2018"
 
 [dependencies]
 azure-functions-shared-codegen = { version = "0.7.0", path = "../azure-functions-shared-codegen" }
-tower-grpc = { git = "https://github.com/tower-rs/tower-grpc", rev = "55d004e49f6c6097a9f556752bceb8b32c8c700f"}
+grpcio = { version = "0.5.0-alpha", default-features = false, features = ["prost-codec"] }
+futures = "0.1"
 prost = "0.5"
 prost-types = "0.5"
 bytes = "0.4"
@@ -23,7 +24,8 @@ proc-macro2 = { version = "0.4.30" }
 lazy_static = "1.3.0"
 
 [build-dependencies]
-tower-grpc-build = { git = "https://github.com/tower-rs/tower-grpc", rev = "55d004e49f6c6097a9f556752bceb8b32c8c700f"}
+grpcio-compiler = "0.5.0-alpha"
+protobuf-build = "0.4.2"
 
 [features]
 default = []

--- a/azure-functions-shared/build.rs
+++ b/azure-functions-shared/build.rs
@@ -1,11 +1,19 @@
 use std::env;
 use std::fs;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
+use std::process::Command;
 
 const OUT_DIR_VAR: &str = "OUT_DIR";
 const CACHE_DIR_NAME: &str = "cache";
 const PROTOBUF_INPUT_FILES: &[&str] = &["FunctionRpc.proto"];
 const OUTPUT_FILES: &[&str] = &["azure_functions_rpc_messages.rs"];
+
+fn format_source(path: &Path) {
+    Command::new("rustfmt")
+        .arg(path.to_str().unwrap())
+        .output()
+        .expect("Failed to format generated source");
+}
 
 fn compile_protobufs(out_dir: &PathBuf, cache_dir: &PathBuf) {
     grpcio_compiler::prost_codegen::compile_protos(
@@ -16,8 +24,14 @@ fn compile_protobufs(out_dir: &PathBuf, cache_dir: &PathBuf) {
     .unwrap();
 
     for file in OUTPUT_FILES {
-        fs::copy(out_dir.join(file), cache_dir.join(file))
-            .expect(&format!("can't update cache file '{}'", file));
+        let cached_output = cache_dir.join(file);
+
+        fs::copy(out_dir.join(file), &cached_output).expect(&format!(
+            "can't update cache file '{}'",
+            cached_output.display()
+        ));
+
+        format_source(&cached_output);
     }
 }
 

--- a/azure-functions-shared/build.rs
+++ b/azure-functions-shared/build.rs
@@ -8,10 +8,12 @@ const PROTOBUF_INPUT_FILES: &[&str] = &["FunctionRpc.proto"];
 const OUTPUT_FILES: &[&str] = &["azure_functions_rpc_messages.rs"];
 
 fn compile_protobufs(out_dir: &PathBuf, cache_dir: &PathBuf) {
-    tower_grpc_build::Config::new()
-        .enable_client(true)
-        .build(PROTOBUF_INPUT_FILES, &["protobuf/src/proto"])
-        .unwrap_or_else(|e| panic!("protobuf compilation failed: {}", e));
+    grpcio_compiler::prost_codegen::compile_protos(
+        PROTOBUF_INPUT_FILES,
+        &["protobuf/src/proto"],
+        out_dir.to_str().unwrap(),
+    )
+    .unwrap();
 
     for file in OUTPUT_FILES {
         fs::copy(out_dir.join(file), cache_dir.join(file))

--- a/azure-functions-shared/cache/azure_functions_rpc_messages.rs
+++ b/azure-functions-shared/cache/azure_functions_rpc_messages.rs
@@ -1,12 +1,12 @@
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct NullableString {
-    #[prost(oneof="nullable_string::String", tags="1")]
+    #[prost(oneof = "nullable_string::String", tags = "1")]
     pub string: ::std::option::Option<nullable_string::String>,
 }
 pub mod nullable_string {
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum String {
-        #[prost(string, tag="1")]
+        #[prost(string, tag = "1")]
         Value(std::string::String),
     }
 }
@@ -16,13 +16,13 @@ pub mod nullable_string {
 /// https://github.com/Azure/azure-webjobs-sdk-extensions/blob/dev/src/WebJobs.Extensions.Http/ClaimsIdentitySlim.cs
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct RpcClaimsIdentity {
-    #[prost(message, optional, tag="1")]
+    #[prost(message, optional, tag = "1")]
     pub authentication_type: ::std::option::Option<NullableString>,
-    #[prost(message, optional, tag="2")]
+    #[prost(message, optional, tag = "2")]
     pub name_claim_type: ::std::option::Option<NullableString>,
-    #[prost(message, optional, tag="3")]
+    #[prost(message, optional, tag = "3")]
     pub role_claim_type: ::std::option::Option<NullableString>,
-    #[prost(message, repeated, tag="4")]
+    #[prost(message, repeated, tag = "4")]
     pub claims: ::std::vec::Vec<RpcClaim>,
 }
 /// Light-weight representation of a .NET System.Security.Claims.Claim object.
@@ -31,18 +31,21 @@ pub struct RpcClaimsIdentity {
 /// https://github.com/Azure/azure-webjobs-sdk-extensions/blob/dev/src/WebJobs.Extensions.Http/ClaimSlim.cs
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct RpcClaim {
-    #[prost(string, tag="1")]
+    #[prost(string, tag = "1")]
     pub value: std::string::String,
-    #[prost(string, tag="2")]
+    #[prost(string, tag = "2")]
     pub r#type: std::string::String,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct StreamingMessage {
     /// Used to identify message between host and worker
-    #[prost(string, tag="1")]
+    #[prost(string, tag = "1")]
     pub request_id: std::string::String,
     /// Payload of the message
-    #[prost(oneof="streaming_message::Content", tags="20, 17, 16, 15, 14, 12, 13, 6, 7, 8, 9, 4, 5, 21, 2, 25, 26")]
+    #[prost(
+        oneof = "streaming_message::Content",
+        tags = "20, 17, 16, 15, 14, 12, 13, 6, 7, 8, 9, 4, 5, 21, 2, 25, 26"
+    )]
     pub content: ::std::option::Option<streaming_message::Content>,
 }
 pub mod streaming_message {
@@ -50,110 +53,110 @@ pub mod streaming_message {
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Content {
         /// Worker initiates stream
-        #[prost(message, tag="20")]
+        #[prost(message, tag = "20")]
         StartStream(super::StartStream),
         /// Host sends capabilities/init data to worker
-        #[prost(message, tag="17")]
+        #[prost(message, tag = "17")]
         WorkerInitRequest(super::WorkerInitRequest),
         /// Worker responds after initializing with its capabilities & status
-        #[prost(message, tag="16")]
+        #[prost(message, tag = "16")]
         WorkerInitResponse(super::WorkerInitResponse),
         /// Worker periodically sends empty heartbeat message to host
-        #[prost(message, tag="15")]
+        #[prost(message, tag = "15")]
         WorkerHeartbeat(super::WorkerHeartbeat),
         /// Host sends terminate message to worker.
         /// Worker terminates if it can, otherwise host terminates after a grace period
-        #[prost(message, tag="14")]
+        #[prost(message, tag = "14")]
         WorkerTerminate(super::WorkerTerminate),
         /// Add any worker relevant status to response
-        #[prost(message, tag="12")]
+        #[prost(message, tag = "12")]
         WorkerStatusRequest(super::WorkerStatusRequest),
-        #[prost(message, tag="13")]
+        #[prost(message, tag = "13")]
         WorkerStatusResponse(super::WorkerStatusResponse),
         /// On file change event, host sends notification to worker
-        #[prost(message, tag="6")]
+        #[prost(message, tag = "6")]
         FileChangeEventRequest(super::FileChangeEventRequest),
         /// Worker requests a desired action (restart worker, reload function)
-        #[prost(message, tag="7")]
+        #[prost(message, tag = "7")]
         WorkerActionResponse(super::WorkerActionResponse),
         /// Host sends required metadata to worker to load function
-        #[prost(message, tag="8")]
+        #[prost(message, tag = "8")]
         FunctionLoadRequest(super::FunctionLoadRequest),
         /// Worker responds after loading with the load result
-        #[prost(message, tag="9")]
+        #[prost(message, tag = "9")]
         FunctionLoadResponse(super::FunctionLoadResponse),
         /// Host requests a given invocation
-        #[prost(message, tag="4")]
+        #[prost(message, tag = "4")]
         InvocationRequest(super::InvocationRequest),
         /// Worker responds to a given invocation
-        #[prost(message, tag="5")]
+        #[prost(message, tag = "5")]
         InvocationResponse(super::InvocationResponse),
-        /// Host sends cancel message to attempt to cancel an invocation. 
+        /// Host sends cancel message to attempt to cancel an invocation.
         /// If an invocation is cancelled, host will receive an invocation response with status cancelled.
-        #[prost(message, tag="21")]
+        #[prost(message, tag = "21")]
         InvocationCancel(super::InvocationCancel),
         /// Worker logs a message back to the host
-        #[prost(message, tag="2")]
+        #[prost(message, tag = "2")]
         RpcLog(super::RpcLog),
-        #[prost(message, tag="25")]
+        #[prost(message, tag = "25")]
         FunctionEnvironmentReloadRequest(super::FunctionEnvironmentReloadRequest),
-        #[prost(message, tag="26")]
+        #[prost(message, tag = "26")]
         FunctionEnvironmentReloadResponse(super::FunctionEnvironmentReloadResponse),
     }
 }
 // Process.Start required info
 //   connection details
 //   protocol type
-//   protocol version 
+//   protocol version
 
 /// Worker sends the host information identifying itself
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct StartStream {
     /// id of the worker
-    #[prost(string, tag="2")]
+    #[prost(string, tag = "2")]
     pub worker_id: std::string::String,
 }
-/// Host requests the worker to initialize itself 
+/// Host requests the worker to initialize itself
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct WorkerInitRequest {
     /// version of the host sending init request
-    #[prost(string, tag="1")]
+    #[prost(string, tag = "1")]
     pub host_version: std::string::String,
     /// A map of host supported features/capabilities
-    #[prost(map="string, string", tag="2")]
+    #[prost(map = "string, string", tag = "2")]
     pub capabilities: ::std::collections::HashMap<std::string::String, std::string::String>,
     /// inform worker of supported categories and their levels
     /// i.e. Worker = Verbose, Function.MyFunc = None
-    #[prost(map="string, enumeration(rpc_log::Level)", tag="3")]
+    #[prost(map = "string, enumeration(rpc_log::Level)", tag = "3")]
     pub log_categories: ::std::collections::HashMap<std::string::String, i32>,
 }
 /// Worker responds with the result of initializing itself
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct WorkerInitResponse {
     /// Version of worker
-    #[prost(string, tag="1")]
+    #[prost(string, tag = "1")]
     pub worker_version: std::string::String,
     /// A map of worker supported features/capabilities
-    #[prost(map="string, string", tag="2")]
+    #[prost(map = "string, string", tag = "2")]
     pub capabilities: ::std::collections::HashMap<std::string::String, std::string::String>,
     /// Status of the response
-    #[prost(message, optional, tag="3")]
+    #[prost(message, optional, tag = "3")]
     pub result: ::std::option::Option<StatusResult>,
 }
 /// Used by the host to determine success/failure/cancellation
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct StatusResult {
     /// Status for the given result
-    #[prost(enumeration="status_result::Status", tag="4")]
+    #[prost(enumeration = "status_result::Status", tag = "4")]
     pub status: i32,
     /// Specific message about the result
-    #[prost(string, tag="1")]
+    #[prost(string, tag = "1")]
     pub result: std::string::String,
     /// Exception message (if exists) for the status
-    #[prost(message, optional, tag="2")]
+    #[prost(message, optional, tag = "2")]
     pub exception: ::std::option::Option<RpcException>,
     /// Captured logs or relevant details can use the logs property
-    #[prost(message, repeated, tag="3")]
+    #[prost(message, repeated, tag = "3")]
     pub logs: ::std::vec::Vec<RpcLog>,
 }
 pub mod status_result {
@@ -170,26 +173,25 @@ pub mod status_result {
 
 /// Message is empty by design - Will add more fields in future if needed
 #[derive(Clone, PartialEq, ::prost::Message)]
-pub struct WorkerHeartbeat {
-}
+pub struct WorkerHeartbeat {}
 /// Warning before killing the process after grace_period
 /// Worker self terminates ..no response on this
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct WorkerTerminate {
-    #[prost(message, optional, tag="1")]
+    #[prost(message, optional, tag = "1")]
     pub grace_period: ::std::option::Option<::prost_types::Duration>,
 }
 /// Host notifies worker of file content change
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct FileChangeEventRequest {
     /// type for this event
-    #[prost(enumeration="file_change_event_request::Type", tag="1")]
+    #[prost(enumeration = "file_change_event_request::Type", tag = "1")]
     pub r#type: i32,
     /// full file path for the file change notification
-    #[prost(string, tag="2")]
+    #[prost(string, tag = "2")]
     pub full_path: std::string::String,
     /// Name of the function affected
-    #[prost(string, tag="3")]
+    #[prost(string, tag = "3")]
     pub name: std::string::String,
 }
 pub mod file_change_event_request {
@@ -209,10 +211,10 @@ pub mod file_change_event_request {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct WorkerActionResponse {
     /// action for this response
-    #[prost(enumeration="worker_action_response::Action", tag="1")]
+    #[prost(enumeration = "worker_action_response::Action", tag = "1")]
     pub action: i32,
     /// text reason for the response
-    #[prost(string, tag="2")]
+    #[prost(string, tag = "2")]
     pub reason: std::string::String,
 }
 pub mod worker_action_response {
@@ -226,137 +228,136 @@ pub mod worker_action_response {
 }
 /// NOT USED
 #[derive(Clone, PartialEq, ::prost::Message)]
-pub struct WorkerStatusRequest {
-}
+pub struct WorkerStatusRequest {}
 /// NOT USED
 #[derive(Clone, PartialEq, ::prost::Message)]
-pub struct WorkerStatusResponse {
-}
+pub struct WorkerStatusResponse {}
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct FunctionEnvironmentReloadRequest {
     /// Environment variables from the current process
-    #[prost(map="string, string", tag="1")]
-    pub environment_variables: ::std::collections::HashMap<std::string::String, std::string::String>,
+    #[prost(map = "string, string", tag = "1")]
+    pub environment_variables:
+        ::std::collections::HashMap<std::string::String, std::string::String>,
 }
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct FunctionEnvironmentReloadResponse {
     /// Status of the response
-    #[prost(message, optional, tag="3")]
+    #[prost(message, optional, tag = "3")]
     pub result: ::std::option::Option<StatusResult>,
 }
 /// Host tells the worker to load a Function
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct FunctionLoadRequest {
     /// unique function identifier (avoid name collisions, facilitate reload case)
-    #[prost(string, tag="1")]
+    #[prost(string, tag = "1")]
     pub function_id: std::string::String,
     /// Metadata for the request
-    #[prost(message, optional, tag="2")]
+    #[prost(message, optional, tag = "2")]
     pub metadata: ::std::option::Option<RpcFunctionMetadata>,
     /// A flag indicating if managed dependency is enabled or not
-    #[prost(bool, tag="3")]
+    #[prost(bool, tag = "3")]
     pub managed_dependency_enabled: bool,
 }
 /// Worker tells host result of reload
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct FunctionLoadResponse {
     /// unique function identifier
-    #[prost(string, tag="1")]
+    #[prost(string, tag = "1")]
     pub function_id: std::string::String,
     /// Result of load operation
     ///
     /// TODO: return type expected?
-    #[prost(message, optional, tag="2")]
+    #[prost(message, optional, tag = "2")]
     pub result: ::std::option::Option<StatusResult>,
     /// Result of load operation
-    #[prost(bool, tag="3")]
+    #[prost(bool, tag = "3")]
     pub is_dependency_downloaded: bool,
 }
 /// Information on how a Function should be loaded and its bindings
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct RpcFunctionMetadata {
     /// TODO: do we want the host's name - the language worker might do a better job of assignment than the host
-    #[prost(string, tag="4")]
+    #[prost(string, tag = "4")]
     pub name: std::string::String,
     /// base directory for the Function
-    #[prost(string, tag="1")]
+    #[prost(string, tag = "1")]
     pub directory: std::string::String,
     /// Script file specified
-    #[prost(string, tag="2")]
+    #[prost(string, tag = "2")]
     pub script_file: std::string::String,
     /// Entry point specified
-    #[prost(string, tag="3")]
+    #[prost(string, tag = "3")]
     pub entry_point: std::string::String,
     /// Bindings info
-    #[prost(map="string, message", tag="6")]
+    #[prost(map = "string, message", tag = "6")]
     pub bindings: ::std::collections::HashMap<std::string::String, BindingInfo>,
 }
 /// Host requests worker to invoke a Function
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct InvocationRequest {
     /// Unique id for each invocation
-    #[prost(string, tag="1")]
+    #[prost(string, tag = "1")]
     pub invocation_id: std::string::String,
     /// Unique id for each Function
-    #[prost(string, tag="2")]
+    #[prost(string, tag = "2")]
     pub function_id: std::string::String,
     /// Input bindings (include trigger)
-    #[prost(message, repeated, tag="3")]
+    #[prost(message, repeated, tag = "3")]
     pub input_data: ::std::vec::Vec<ParameterBinding>,
     /// binding metadata from trigger
-    #[prost(map="string, message", tag="4")]
+    #[prost(map = "string, message", tag = "4")]
     pub trigger_metadata: ::std::collections::HashMap<std::string::String, TypedData>,
 }
 /// Host requests worker to cancel invocation
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct InvocationCancel {
     /// Unique id for invocation
-    #[prost(string, tag="2")]
+    #[prost(string, tag = "2")]
     pub invocation_id: std::string::String,
     /// Time period before force shutdown
     ///
     /// could also use absolute time
-    #[prost(message, optional, tag="1")]
+    #[prost(message, optional, tag = "1")]
     pub grace_period: ::std::option::Option<::prost_types::Duration>,
 }
 /// Worker responds with status of Invocation
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct InvocationResponse {
     /// Unique id for invocation
-    #[prost(string, tag="1")]
+    #[prost(string, tag = "1")]
     pub invocation_id: std::string::String,
     /// Output binding data
-    #[prost(message, repeated, tag="2")]
+    #[prost(message, repeated, tag = "2")]
     pub output_data: ::std::vec::Vec<ParameterBinding>,
     /// data returned from Function (for $return and triggers with return support)
-    #[prost(message, optional, tag="4")]
+    #[prost(message, optional, tag = "4")]
     pub return_value: ::std::option::Option<TypedData>,
     /// Status of the invocation (success/failure/canceled)
-    #[prost(message, optional, tag="3")]
+    #[prost(message, optional, tag = "3")]
     pub result: ::std::option::Option<StatusResult>,
 }
 /// Used to encapsulate data which could be a variety of types
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct TypedData {
-    #[prost(oneof="typed_data::Data", tags="1, 2, 3, 4, 5, 6, 7")]
+    #[prost(oneof = "typed_data::Data", tags = "1, 2, 3, 4, 5, 6, 7")]
     pub data: ::std::option::Option<typed_data::Data>,
 }
 pub mod typed_data {
     #[derive(Clone, PartialEq, ::prost::Oneof)]
     pub enum Data {
-        #[prost(string, tag="1")]
+        #[prost(string, tag = "1")]
         String(std::string::String),
-        #[prost(string, tag="2")]
+        #[prost(string, tag = "2")]
         Json(std::string::String),
-        #[prost(bytes, tag="3")]
+        #[prost(bytes, tag = "3")]
         Bytes(std::vec::Vec<u8>),
-        #[prost(bytes, tag="4")]
+        #[prost(bytes, tag = "4")]
         Stream(std::vec::Vec<u8>),
-        #[prost(message, tag="5")]
+        #[prost(message, tag = "5")]
         Http(Box<super::RpcHttp>),
-        #[prost(sint64, tag="6")]
+        #[prost(sint64, tag = "6")]
         Int(i64),
-        #[prost(double, tag="7")]
+        #[prost(double, tag = "7")]
         Double(f64),
     }
 }
@@ -364,22 +365,22 @@ pub mod typed_data {
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct ParameterBinding {
     /// Name for the binding
-    #[prost(string, tag="1")]
+    #[prost(string, tag = "1")]
     pub name: std::string::String,
     /// Data for the binding
-    #[prost(message, optional, tag="2")]
+    #[prost(message, optional, tag = "2")]
     pub data: ::std::option::Option<TypedData>,
 }
 /// Used to describe a given binding on load
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct BindingInfo {
     /// Type of binding (e.g. HttpTrigger)
-    #[prost(string, tag="2")]
+    #[prost(string, tag = "2")]
     pub r#type: std::string::String,
     /// Direction of the given binding
-    #[prost(enumeration="binding_info::Direction", tag="3")]
+    #[prost(enumeration = "binding_info::Direction", tag = "3")]
     pub direction: i32,
-    #[prost(enumeration="binding_info::DataType", tag="4")]
+    #[prost(enumeration = "binding_info::DataType", tag = "4")]
     pub data_type: i32,
 }
 pub mod binding_info {
@@ -401,30 +402,30 @@ pub mod binding_info {
         Stream = 3,
     }
 }
-/// Used to send logs back to the Host 
+/// Used to send logs back to the Host
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct RpcLog {
     /// Unique id for invocation (if exists)
-    #[prost(string, tag="1")]
+    #[prost(string, tag = "1")]
     pub invocation_id: std::string::String,
     /// TOD: This should be an enum
     /// Category for the log (startup, load, invocation, etc.)
-    #[prost(string, tag="2")]
+    #[prost(string, tag = "2")]
     pub category: std::string::String,
     /// Level for the given log message
-    #[prost(enumeration="rpc_log::Level", tag="3")]
+    #[prost(enumeration = "rpc_log::Level", tag = "3")]
     pub level: i32,
     /// Message for the given log
-    #[prost(string, tag="4")]
+    #[prost(string, tag = "4")]
     pub message: std::string::String,
     /// Id for the even associated with this log (if exists)
-    #[prost(string, tag="5")]
+    #[prost(string, tag = "5")]
     pub event_id: std::string::String,
     /// Exception (if exists)
-    #[prost(message, optional, tag="6")]
+    #[prost(message, optional, tag = "6")]
     pub exception: ::std::option::Option<RpcException>,
     /// json serialized property bag, or could use a type scheme like map<string, TypedData>
-    #[prost(string, tag="7")]
+    #[prost(string, tag = "7")]
     pub properties: std::string::String,
 }
 pub mod rpc_log {
@@ -443,73 +444,105 @@ pub mod rpc_log {
         None = 6,
     }
 }
-/// Encapsulates an Exception 
+/// Encapsulates an Exception
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct RpcException {
     /// Source of the exception
-    #[prost(string, tag="3")]
+    #[prost(string, tag = "3")]
     pub source: std::string::String,
     /// Stack trace for the exception
-    #[prost(string, tag="1")]
+    #[prost(string, tag = "1")]
     pub stack_trace: std::string::String,
     /// Textual message describing hte exception
-    #[prost(string, tag="2")]
+    #[prost(string, tag = "2")]
     pub message: std::string::String,
 }
 /// TODO - solidify this or remove it
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct RpcHttp {
-    #[prost(string, tag="1")]
+    #[prost(string, tag = "1")]
     pub method: std::string::String,
-    #[prost(string, tag="2")]
+    #[prost(string, tag = "2")]
     pub url: std::string::String,
-    #[prost(map="string, string", tag="3")]
+    #[prost(map = "string, string", tag = "3")]
     pub headers: ::std::collections::HashMap<std::string::String, std::string::String>,
-    #[prost(message, optional, boxed, tag="4")]
+    #[prost(message, optional, boxed, tag = "4")]
     pub body: ::std::option::Option<::std::boxed::Box<TypedData>>,
-    #[prost(map="string, string", tag="10")]
+    #[prost(map = "string, string", tag = "10")]
     pub params: ::std::collections::HashMap<std::string::String, std::string::String>,
-    #[prost(string, tag="12")]
+    #[prost(string, tag = "12")]
     pub status_code: std::string::String,
-    #[prost(map="string, string", tag="15")]
+    #[prost(map = "string, string", tag = "15")]
     pub query: ::std::collections::HashMap<std::string::String, std::string::String>,
-    #[prost(bool, tag="16")]
+    #[prost(bool, tag = "16")]
     pub enable_content_negotiation: bool,
-    #[prost(message, optional, boxed, tag="17")]
+    #[prost(message, optional, boxed, tag = "17")]
     pub raw_body: ::std::option::Option<::std::boxed::Box<TypedData>>,
-    #[prost(message, repeated, tag="18")]
+    #[prost(message, repeated, tag = "18")]
     pub identities: ::std::vec::Vec<RpcClaimsIdentity>,
 }
-pub mod client {
-    use ::tower_grpc::codegen::client::*;
-    use super::StreamingMessage;
-
-    /// Interface exported by the server.
-    #[derive(Debug, Clone)]
-    pub struct FunctionRpc<T> {
-        inner: grpc::Grpc<T>,
-    }
-
-    impl<T> FunctionRpc<T> {
-        pub fn new(inner: T) -> Self {
-            let inner = grpc::Grpc::new(inner);
-            Self { inner }
-        }
-
-        pub fn poll_ready<R>(&mut self) -> futures::Poll<(), grpc::Status>
-        where T: grpc::GrpcService<R>,
-        {
-            self.inner.poll_ready()
-        }
-
-        /// Interface exported by the server.
-        pub fn event_stream<R, B>(&mut self, request: grpc::Request<B>) -> grpc::streaming::ResponseFuture<StreamingMessage, T::Future>
-        where T: grpc::GrpcService<R>,
-              B: futures::Stream<Item = StreamingMessage>,
-              B: grpc::Encodable<R>,
-        {
-            let path = http::PathAndQuery::from_static("/AzureFunctionsRpcMessages.FunctionRpc/EventStream");
-            self.inner.streaming(request, path)
+const METHOD_FUNCTION_RPC_EVENT_STREAM: ::grpcio::Method<StreamingMessage, StreamingMessage> =
+    ::grpcio::Method {
+        ty: ::grpcio::MethodType::Duplex,
+        name: "/AzureFunctionsRpcMessages.FunctionRpc/EventStream",
+        req_mar: ::grpcio::Marshaller {
+            ser: ::grpcio::pr_ser,
+            de: ::grpcio::pr_de,
+        },
+        resp_mar: ::grpcio::Marshaller {
+            ser: ::grpcio::pr_ser,
+            de: ::grpcio::pr_de,
+        },
+    };
+#[derive(Clone)]
+pub struct FunctionRpcClient {
+    client: ::grpcio::Client,
+}
+impl FunctionRpcClient {
+    pub fn new(channel: ::grpcio::Channel) -> Self {
+        FunctionRpcClient {
+            client: ::grpcio::Client::new(channel),
         }
     }
+    pub fn event_stream_opt(
+        &self,
+        opt: ::grpcio::CallOption,
+    ) -> ::grpcio::Result<(
+        ::grpcio::ClientDuplexSender<StreamingMessage>,
+        ::grpcio::ClientDuplexReceiver<StreamingMessage>,
+    )> {
+        self.client
+            .duplex_streaming(&METHOD_FUNCTION_RPC_EVENT_STREAM, opt)
+    }
+    pub fn event_stream(
+        &self,
+    ) -> ::grpcio::Result<(
+        ::grpcio::ClientDuplexSender<StreamingMessage>,
+        ::grpcio::ClientDuplexReceiver<StreamingMessage>,
+    )> {
+        self.event_stream_opt(::grpcio::CallOption::default())
+    }
+    pub fn spawn<F>(&self, f: F)
+    where
+        F: ::futures::Future<Item = (), Error = ()> + Send + 'static,
+    {
+        self.client.spawn(f)
+    }
+}
+pub trait FunctionRpc {
+    fn event_stream(
+        &mut self,
+        ctx: ::grpcio::RpcContext,
+        stream: ::grpcio::RequestStream<StreamingMessage>,
+        sink: ::grpcio::DuplexSink<StreamingMessage>,
+    );
+}
+pub fn create_function_rpc<S: FunctionRpc + Send + Clone + 'static>(s: S) -> ::grpcio::Service {
+    let mut builder = ::grpcio::ServiceBuilder::new();
+    let mut instance = s.clone();
+    builder = builder
+        .add_duplex_streaming_handler(&METHOD_FUNCTION_RPC_EVENT_STREAM, move |ctx, req, resp| {
+            instance.event_stream(ctx, req, resp)
+        });
+    builder.build()
 }

--- a/azure-functions/Cargo.toml
+++ b/azure-functions/Cargo.toml
@@ -11,11 +11,7 @@ edition = "2018"
 [dependencies]
 azure-functions-shared = { version = "0.7.0", path = "../azure-functions-shared" }
 azure-functions-codegen = { version = "0.7.0", path = "../azure-functions-codegen" }
-tower-h2 = { git = "https://github.com/tower-rs/tower-h2", rev = "a3c958a243ef3d837933b31bf186ba0e6b0e60c9"}
-tower-request-modifier = { git = "https://github.com/tower-rs/tower-http", rev = "e7ef6ef623411342ee89c0a83ef924db6206143a" }
-tower-grpc = { git = "https://github.com/tower-rs/tower-grpc", rev = "55d004e49f6c6097a9f556752bceb8b32c8c700f"}
-tower-service = "0.2.0"
-tower-util = { git = "https://github.com/tower-rs/tower", rev = "979c1399127bdb269c751b99c12b3adfad55463c" }
+grpcio = { version = "0.5.0-alpha", default-features = false, features = ["prost-codec"] }
 log = { version = "0.4.6", features = ["std"] }
 futures = "0.1.27"
 clap = "2.33.0"


### PR DESCRIPTION
This PR reverts the gRPC implementation from tower-grpc back to grpc-rs.

Unfortunately tower-grpc isn't yet ready to be published and we can't depend on
it for our published crates.

Thankfully, the change back was pretty straight forward due to grpc-rs' support
for prost rather than rust-protobuf.

This should enable us to publish 0.8.0.  We will revert this commit once
tower-grpc has been published.