### PR TITLE
Bump versions to 0.8.0.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -51,10 +51,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "azure-functions"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
- "azure-functions-codegen 0.7.0",
- "azure-functions-shared 0.7.0",
+ "azure-functions-codegen 0.8.0",
+ "azure-functions-shared 0.8.0",
  "backtrace 0.3.17 (registry+https://github.com/rust-lang/crates.io-index)",
  "chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -76,9 +76,9 @@ dependencies = [
 
 [[package]]
 name = "azure-functions-codegen"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
- "azure-functions-shared 0.7.0",
+ "azure-functions-shared 0.8.0",
  "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "syn 0.15.34 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -86,7 +86,7 @@ dependencies = [
 
 [[package]]
 name = "azure-functions-sdk"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "clap 2.33.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -101,9 +101,9 @@ dependencies = [
 
 [[package]]
 name = "azure-functions-shared"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
- "azure-functions-shared-codegen 0.7.0",
+ "azure-functions-shared-codegen 0.8.1",
  "bytes 0.4.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures 0.1.27 (registry+https://github.com/rust-lang/crates.io-index)",
  "grpcio 0.5.0-alpha.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -122,7 +122,7 @@ dependencies = [
 
 [[package]]
 name = "azure-functions-shared-codegen"
-version = "0.7.0"
+version = "0.8.1"
 dependencies = [
  "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote 0.6.12 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -159,7 +159,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "blob-example"
 version = "0.1.0"
 dependencies = [
- "azure-functions 0.7.0",
+ "azure-functions 0.8.0",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -265,7 +265,7 @@ dependencies = [
 name = "cosmosdb-example"
 version = "0.1.0"
 dependencies = [
- "azure-functions 0.7.0",
+ "azure-functions 0.8.0",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -345,7 +345,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "event-grid-example"
 version = "0.1.0"
 dependencies = [
- "azure-functions 0.7.0",
+ "azure-functions 0.8.0",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -353,7 +353,7 @@ dependencies = [
 name = "event-hub-example"
 version = "0.1.0"
 dependencies = [
- "azure-functions 0.7.0",
+ "azure-functions 0.8.0",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -433,7 +433,7 @@ dependencies = [
 name = "generic-example"
 version = "0.1.0"
 dependencies = [
- "azure-functions 0.7.0",
+ "azure-functions 0.8.0",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -504,7 +504,7 @@ dependencies = [
 name = "http-example"
 version = "0.1.0"
 dependencies = [
- "azure-functions 0.7.0",
+ "azure-functions 0.8.0",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -892,7 +892,7 @@ dependencies = [
 name = "queue-example"
 version = "0.1.0"
 dependencies = [
- "azure-functions 0.7.0",
+ "azure-functions 0.8.0",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1119,7 +1119,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "sendgrid-example"
 version = "0.1.0"
 dependencies = [
- "azure-functions 0.7.0",
+ "azure-functions 0.8.0",
 ]
 
 [[package]]
@@ -1154,7 +1154,7 @@ dependencies = [
 name = "service-bus-example"
 version = "0.1.0"
 dependencies = [
- "azure-functions 0.7.0",
+ "azure-functions 0.8.0",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1173,7 +1173,7 @@ dependencies = [
 name = "signalr-example"
 version = "0.1.0"
 dependencies = [
- "azure-functions 0.7.0",
+ "azure-functions 0.8.0",
  "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1224,7 +1224,7 @@ dependencies = [
 name = "table-example"
 version = "0.1.0"
 dependencies = [
- "azure-functions 0.7.0",
+ "azure-functions 0.8.0",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -1291,7 +1291,7 @@ dependencies = [
 name = "timer-example"
 version = "0.1.0"
 dependencies = [
- "azure-functions 0.7.0",
+ "azure-functions 0.8.0",
  "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1477,7 +1477,7 @@ dependencies = [
 name = "twilio-example"
 version = "0.1.0"
 dependencies = [
- "azure-functions 0.7.0",
+ "azure-functions 0.8.0",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ pub fn greet(req: HttpRequest) -> HttpResponse {
 ## Get Started
 
 - [More Examples](https://github.com/peterhuene/azure-functions-rs/tree/master/examples)
-- [Documentation](https://docs.rs/azure-functions/0.7.0/azure_functions/)
+- [Documentation](https://docs.rs/azure-functions/0.8.0/azure_functions/)
 - [Installation](#installation)
 - [Contributing](https://github.com/peterhuene/azure-functions-rs/blob/master/CONTRIBUTING.md)
 

--- a/azure-functions-codegen/Cargo.toml
+++ b/azure-functions-codegen/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "azure-functions-codegen"
 license = "MIT"
-version = "0.7.0"
+version = "0.8.0"
 authors = ["Peter Huene <peterhuene@protonmail.com>"]
 description = "Azure Functions for Rust code generation support"
 repository = "https://github.com/peterhuene/azure-functions-rs/"
@@ -12,7 +12,7 @@ edition = "2018"
 proc-macro = true
 
 [dependencies]
-azure-functions-shared = { version = "0.7.0", path = "../azure-functions-shared" }
+azure-functions-shared = { version = "0.8.0", path = "../azure-functions-shared" }
 quote = "0.6.12"
 syn = { version = "0.15.34", features = ["full"] }
 proc-macro2 = { version = "0.4.30" }

--- a/azure-functions-sdk/Cargo.toml
+++ b/azure-functions-sdk/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "azure-functions-sdk"
 license = "MIT"
-version = "0.7.0"
+version = "0.8.0"
 authors = ["Peter Huene <peterhuene@protonmail.com>"]
 description = "Azure Functions for Rust Developer Tools"
 repository = "https://github.com/peterhuene/azure-functions-rs/"

--- a/azure-functions-shared-codegen/Cargo.toml
+++ b/azure-functions-shared-codegen/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "azure-functions-shared-codegen"
 license = "MIT"
-version = "0.7.0"
+version = "0.8.1"
 authors = ["Peter Huene <peterhuene@protonmail.com>"]
 description = "Azure Functions for Rust shared code generation support."
 repository = "https://github.com/peterhuene/azure-functions-rs/"

--- a/azure-functions-shared/Cargo.toml
+++ b/azure-functions-shared/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "azure-functions-shared"
 license = "MIT"
-version = "0.7.0"
+version = "0.8.0"
 authors = ["Peter Huene <peterhuene@protonmail.com>"]
 description = "Implementations shared between the azure-functions-codegen and azure-functions crates."
 repository = "https://github.com/peterhuene/azure-functions-rs/"
@@ -9,7 +9,7 @@ homepage = "https://functions.rs"
 edition = "2018"
 
 [dependencies]
-azure-functions-shared-codegen = { version = "0.7.0", path = "../azure-functions-shared-codegen" }
+azure-functions-shared-codegen = { version = "0.8.1", path = "../azure-functions-shared-codegen" }
 grpcio = { version = "0.5.0-alpha", default-features = false, features = ["prost-codec"] }
 futures = "0.1"
 prost = "0.5"

--- a/azure-functions/Cargo.toml
+++ b/azure-functions/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "azure-functions"
 license = "MIT"
-version = "0.7.0"
+version = "0.8.0"
 authors = ["Peter Huene <peterhuene@protonmail.com>"]
 description = "Azure Functions for Rust"
 repository = "https://github.com/peterhuene/azure-functions-rs/"
@@ -9,8 +9,8 @@ homepage = "https://functions.rs"
 edition = "2018"
 
 [dependencies]
-azure-functions-shared = { version = "0.7.0", path = "../azure-functions-shared" }
-azure-functions-codegen = { version = "0.7.0", path = "../azure-functions-codegen" }
+azure-functions-shared = { version = "0.8.0", path = "../azure-functions-shared" }
+azure-functions-codegen = { version = "0.8.0", path = "../azure-functions-codegen" }
 grpcio = { version = "0.5.0-alpha", default-features = false, features = ["prost-codec"] }
 log = { version = "0.4.6", features = ["std"] }
 futures = "0.1.27"

--- a/examples/blob/Dockerfile
+++ b/examples/blob/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile-upstream:experimental
 
-FROM peterhuene/azure-functions-rs-build:0.7.0 AS build-image
+FROM peterhuene/azure-functions-rs-build:0.8.0 AS build-image
 
 WORKDIR /src
 COPY . /src

--- a/examples/cosmosdb/Dockerfile
+++ b/examples/cosmosdb/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile-upstream:experimental
 
-FROM peterhuene/azure-functions-rs-build:0.7.0 AS build-image
+FROM peterhuene/azure-functions-rs-build:0.8.0 AS build-image
 
 WORKDIR /src
 COPY . /src

--- a/examples/event-grid/Dockerfile
+++ b/examples/event-grid/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile-upstream:experimental
 
-FROM peterhuene/azure-functions-rs-build:0.7.0 AS build-image
+FROM peterhuene/azure-functions-rs-build:0.8.0 AS build-image
 
 WORKDIR /src
 COPY . /src

--- a/examples/event-hub/Dockerfile
+++ b/examples/event-hub/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile-upstream:experimental
 
-FROM peterhuene/azure-functions-rs-build:0.7.0 AS build-image
+FROM peterhuene/azure-functions-rs-build:0.8.0 AS build-image
 
 WORKDIR /src
 COPY . /src

--- a/examples/generic/Dockerfile
+++ b/examples/generic/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile-upstream:experimental
 
-FROM peterhuene/azure-functions-rs-build:0.7.0 AS build-image
+FROM peterhuene/azure-functions-rs-build:0.8.0 AS build-image
 
 WORKDIR /src
 COPY . /src

--- a/examples/http/Dockerfile
+++ b/examples/http/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile-upstream:experimental
 
-FROM peterhuene/azure-functions-rs-build:0.7.0 AS build-image
+FROM peterhuene/azure-functions-rs-build:0.8.0 AS build-image
 
 WORKDIR /src
 COPY . /src

--- a/examples/queue/Dockerfile
+++ b/examples/queue/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile-upstream:experimental
 
-FROM peterhuene/azure-functions-rs-build:0.7.0 AS build-image
+FROM peterhuene/azure-functions-rs-build:0.8.0 AS build-image
 
 WORKDIR /src
 COPY . /src

--- a/examples/sendgrid/Dockerfile
+++ b/examples/sendgrid/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile-upstream:experimental
 
-FROM peterhuene/azure-functions-rs-build:0.7.0 AS build-image
+FROM peterhuene/azure-functions-rs-build:0.8.0 AS build-image
 
 WORKDIR /src
 COPY . /src

--- a/examples/service-bus/Dockerfile
+++ b/examples/service-bus/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile-upstream:experimental
 
-FROM peterhuene/azure-functions-rs-build:0.7.0 AS build-image
+FROM peterhuene/azure-functions-rs-build:0.8.0 AS build-image
 
 WORKDIR /src
 COPY . /src

--- a/examples/signalr/Dockerfile
+++ b/examples/signalr/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile-upstream:experimental
 
-FROM peterhuene/azure-functions-rs-build:0.7.0 AS build-image
+FROM peterhuene/azure-functions-rs-build:0.8.0 AS build-image
 
 WORKDIR /src
 COPY . /src

--- a/examples/table/Dockerfile
+++ b/examples/table/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile-upstream:experimental
 
-FROM peterhuene/azure-functions-rs-build:0.7.0 AS build-image
+FROM peterhuene/azure-functions-rs-build:0.8.0 AS build-image
 
 WORKDIR /src
 COPY . /src

--- a/examples/timer/Dockerfile
+++ b/examples/timer/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile-upstream:experimental
 
-FROM peterhuene/azure-functions-rs-build:0.7.0 AS build-image
+FROM peterhuene/azure-functions-rs-build:0.8.0 AS build-image
 
 WORKDIR /src
 COPY . /src

--- a/examples/twilio/Dockerfile
+++ b/examples/twilio/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile-upstream:experimental
 
-FROM peterhuene/azure-functions-rs-build:0.7.0 AS build-image
+FROM peterhuene/azure-functions-rs-build:0.8.0 AS build-image
 
 WORKDIR /src
 COPY . /src


### PR DESCRIPTION
Note: azure-functions-shared-codegen was accidentally published already as
0.8.0, so this bumps it to 0.8.1.

When 0.9.0 ships, we'll correct this so all the crates have the same version.