### PR TITLE
HttpResponse and SendGridMessage use build()...finish() pattern

### DIFF
--- a/azure-functions/src/bindings/http_response.rs
+++ b/azure-functions/src/bindings/http_response.rs
@@ -66,7 +66,7 @@ use std::collections::HashMap;
 ///         .status(Status::MovedPermanently)
 ///         .header("Location", "http://example.com")
 ///         .body("The requested resource has moved to: http://example.com")
-///         .into()
+///         .finish()
 /// }
 /// ```
 #[derive(Default, Debug)]
@@ -91,7 +91,7 @@ impl HttpResponse {
     /// use azure_functions::bindings::HttpResponse;
     /// use azure_functions::http::Status;
     ///
-    /// let response: HttpResponse = HttpResponse::build().status(Status::NotFound).into();
+    /// let response = HttpResponse::build().status(Status::NotFound).finish();
     /// assert_eq!(response.status(), Status::NotFound);
     /// ```
     pub fn build() -> ResponseBuilder {
@@ -106,7 +106,7 @@ impl HttpResponse {
     /// use azure_functions::bindings::HttpResponse;
     /// use azure_functions::http::Status;
     ///
-    /// let response: HttpResponse = HttpResponse::build().status(Status::BadRequest).into();
+    /// let response = HttpResponse::build().status(Status::BadRequest).finish();
     /// assert_eq!(response.status(), Status::BadRequest);
     /// ```
     pub fn status(&self) -> Status {
@@ -120,7 +120,8 @@ impl HttpResponse {
     /// ```rust
     /// use azure_functions::bindings::HttpResponse;
     ///
-    /// let response: HttpResponse = HttpResponse::build().body("example").into();
+    /// let response = HttpResponse::build().body("example").finish();
+    ///
     /// assert_eq!(response.body().as_str().unwrap(), "example");
     /// ```
     pub fn body(&self) -> Body {
@@ -138,7 +139,8 @@ impl HttpResponse {
     /// ```rust
     /// use azure_functions::bindings::HttpResponse;
     ///
-    /// let response: HttpResponse = HttpResponse::build().header("Content-Type", "text/plain").into();
+    /// let response = HttpResponse::build().header("Content-Type", "text/plain").finish();
+    ///
     /// assert_eq!(response.headers().get("Content-Type").unwrap(), "text/plain");
     /// ```
     pub fn headers(&self) -> &HashMap<String, String> {
@@ -151,13 +153,7 @@ where
     T: Into<Body<'a>>,
 {
     fn from(data: T) -> Self {
-        HttpResponse::build().body(data).into()
-    }
-}
-
-impl From<ResponseBuilder> for HttpResponse {
-    fn from(builder: ResponseBuilder) -> Self {
-        builder.0
+        HttpResponse::build().body(data).finish()
     }
 }
 
@@ -188,7 +184,7 @@ mod tests {
 
     #[test]
     fn it_is_empty_from_a_builder() {
-        let response: HttpResponse = HttpResponse::build().into();
+        let response: HttpResponse = HttpResponse::build().finish();
 
         assert_eq!(response.status(), Status::Ok);
         assert!(matches!(response.body(), Body::Empty));
@@ -196,7 +192,7 @@ mod tests {
 
     #[test]
     fn it_builds_with_a_status() {
-        let response: HttpResponse = HttpResponse::build().status(Status::Continue).into();
+        let response: HttpResponse = HttpResponse::build().status(Status::Continue).finish();
 
         assert_eq!(response.status(), Status::Continue);
     }
@@ -205,7 +201,7 @@ mod tests {
     fn it_builds_with_a_string_body() {
         const BODY: &'static str = "test body";
 
-        let response: HttpResponse = HttpResponse::build().body(BODY).into();
+        let response: HttpResponse = HttpResponse::build().body(BODY).finish();
 
         assert_eq!(
             response.headers().get("Content-Type").unwrap(),
@@ -227,9 +223,9 @@ mod tests {
             message: MESSAGE.to_string(),
         };
 
-        let response: HttpResponse = HttpResponse::build()
+        let response = HttpResponse::build()
             .body(::serde_json::to_value(data).unwrap())
-            .into();
+            .finish();
 
         assert_eq!(
             response.headers().get("Content-Type").unwrap(),
@@ -242,7 +238,7 @@ mod tests {
     fn it_builds_with_a_bytes_body() {
         const BODY: &'static [u8] = &[1, 2, 3];
 
-        let response: HttpResponse = HttpResponse::build().body(BODY).into();
+        let response: HttpResponse = HttpResponse::build().body(BODY).finish();
 
         assert_eq!(
             response.headers().get("Content-Type").unwrap(),
@@ -257,7 +253,7 @@ mod tests {
             .header("header1", "value1")
             .header("header2", "value2")
             .header("header3", "value3")
-            .into();
+            .finish();
 
         assert_eq!(response.headers().get("header1").unwrap(), "value1");
         assert_eq!(response.headers().get("header2").unwrap(), "value2");
@@ -270,7 +266,7 @@ mod tests {
             .status(Status::BadRequest)
             .header("header", "value")
             .body("body")
-            .into();
+            .finish();
 
         let data: TypedData = response.into();
         match data.data {

--- a/azure-functions/src/bindings/http_response.rs
+++ b/azure-functions/src/bindings/http_response.rs
@@ -88,7 +88,7 @@ impl HttpResponse {
     /// # Examples
     ///
     /// ```rust
-    /// use azure_functions::bindings::HttpResponse;
+    /// # use azure_functions::bindings::HttpResponse;
     /// use azure_functions::http::Status;
     ///
     /// let response = HttpResponse::build().status(Status::NotFound).finish();
@@ -103,7 +103,7 @@ impl HttpResponse {
     /// # Examples
     ///
     /// ```rust
-    /// use azure_functions::bindings::HttpResponse;
+    /// # use azure_functions::bindings::HttpResponse;
     /// use azure_functions::http::Status;
     ///
     /// let response = HttpResponse::build().status(Status::BadRequest).finish();
@@ -118,8 +118,7 @@ impl HttpResponse {
     /// # Examples
     ///
     /// ```rust
-    /// use azure_functions::bindings::HttpResponse;
-    ///
+    /// # use azure_functions::bindings::HttpResponse;
     /// let response = HttpResponse::build().body("example").finish();
     ///
     /// assert_eq!(response.body().as_str().unwrap(), "example");
@@ -137,8 +136,7 @@ impl HttpResponse {
     /// # Examples
     ///
     /// ```rust
-    /// use azure_functions::bindings::HttpResponse;
-    ///
+    /// # use azure_functions::bindings::HttpResponse;
     /// let response = HttpResponse::build().header("Content-Type", "text/plain").finish();
     ///
     /// assert_eq!(response.headers().get("Content-Type").unwrap(), "text/plain");

--- a/azure-functions/src/bindings/send_grid_message.rs
+++ b/azure-functions/src/bindings/send_grid_message.rs
@@ -1,8 +1,8 @@
 use crate::{
     rpc::{typed_data::Data, TypedData},
     send_grid::{
-        Attachment, Content, EmailAddress, MailSettings, Personalization, TrackingSettings,
-        UnsubscribeGroup,
+        Attachment, Content, EmailAddress, MailSettings, MessageBuilder, Personalization,
+        TrackingSettings, UnsubscribeGroup,
     },
     FromVec,
 };
@@ -37,11 +37,11 @@ use std::collections::HashMap;
 ///
 ///     (
 ///         "The email was sent.".into(),
-///         MessageBuilder::new()
+///         MessageBuilder::build()
 ///             .to(params.get("to").unwrap().as_str())
 ///             .subject(params.get("subject").unwrap().as_str())
 ///             .content(params.get("content").unwrap().as_str())
-///             .build(),
+///             .finish(),
 ///     )
 /// }
 /// ```
@@ -98,6 +98,29 @@ pub struct SendGridMessage {
     /// The email address and name of the individual who should receive responses to the email message.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub reply_to: Option<EmailAddress>,
+}
+
+impl SendGridMessage {
+    /// Creates a new [MessageBuilder](../send_grid/struct.MessageBuilder.html) for building a SendGrid message.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use azure_functions::bindings::SendGridMessage;
+    ///
+    /// let message = SendGridMessage::build()
+    ///     .to("foo@example.com")
+    ///     .subject("The subject of the message")
+    ///     .content("I hope this message finds you well.")
+    ///     .finish();
+    ///
+    /// assert_eq!(message.personalizations[0].to[0].email, "foo@example.com");
+    /// assert_eq!(message.personalizations[0].subject[0].email, "The subject of the message");
+    /// assert_eq!(message.contents[0].value, "I hope this message finds you well.");
+    /// ```
+    pub fn build() -> MessageBuilder {
+        MessageBuilder::new()
+    }
 }
 
 #[doc(hidden)]

--- a/azure-functions/src/bindings/send_grid_message.rs
+++ b/azure-functions/src/bindings/send_grid_message.rs
@@ -26,7 +26,6 @@ use std::collections::HashMap;
 /// ```rust
 /// use azure_functions::{
 ///     bindings::{HttpRequest, HttpResponse, SendGridMessage},
-///     send_grid::MessageBuilder,
 ///     func,
 /// };
 ///
@@ -37,7 +36,7 @@ use std::collections::HashMap;
 ///
 ///     (
 ///         "The email was sent.".into(),
-///         MessageBuilder::build()
+///         SendGridMessage::build()
 ///             .to(params.get("to").unwrap().as_str())
 ///             .subject(params.get("subject").unwrap().as_str())
 ///             .content(params.get("content").unwrap().as_str())
@@ -115,7 +114,7 @@ impl SendGridMessage {
     ///     .finish();
     ///
     /// assert_eq!(message.personalizations[0].to[0].email, "foo@example.com");
-    /// assert_eq!(message.personalizations[0].subject[0].email, "The subject of the message");
+    /// assert_eq!(message.personalizations[0].subject, Some("The subject of the message".to_owned()));
     /// assert_eq!(message.contents[0].value, "I hope this message finds you well.");
     /// ```
     pub fn build() -> MessageBuilder {

--- a/azure-functions/src/http/response_builder.rs
+++ b/azure-functions/src/http/response_builder.rs
@@ -16,10 +16,10 @@ impl ResponseBuilder {
     /// # Examples
     ///
     /// ```rust
-    /// use azure_functions::bindings::HttpResponse;
+    /// # use azure_functions::http::ResponseBuilder;
     /// use azure_functions::http::Status;
     ///
-    /// let response = HttpResponse::build()
+    /// let response = ResponseBuilder::new()
     ///     .status(Status::InternalServerError)
     ///     .finish();
     ///
@@ -35,11 +35,11 @@ impl ResponseBuilder {
     /// # Examples
     ///
     /// ```rust
-    /// use azure_functions::bindings::HttpResponse;
+    /// # use azure_functions::http::ResponseBuilder;
     ///
     /// let value = "custom header value";
     ///
-    /// let response = HttpResponse::build()
+    /// let response = ResponseBuilder::new()
     ///     .header("X-Custom-Header", value)
     ///     .finish();
     ///
@@ -63,12 +63,12 @@ impl ResponseBuilder {
     /// # Examples
     ///
     /// ```rust
-    /// use azure_functions::bindings::HttpResponse;
+    /// # use azure_functions::http::ResponseBuilder;
     /// use azure_functions::http::{Body, Status};
     ///
     /// let message = "The resouce was created.";
     ///
-    /// let response = HttpResponse::build()
+    /// let response = ResponseBuilder::new()
     ///     .status(Status::Created)
     ///     .body(message)
     ///     .finish();

--- a/azure-functions/src/http/response_builder.rs
+++ b/azure-functions/src/http/response_builder.rs
@@ -68,10 +68,10 @@ impl ResponseBuilder {
     ///
     /// let message = "The resouce was created.";
     ///
-    /// let response: HttpResponse = HttpResponse::build()
+    /// let response = HttpResponse::build()
     ///     .status(Status::Created)
     ///     .body(message)
-    ///     .into();
+    ///     .finish();
     ///
     /// assert_eq!(response.status(), Status::Created);
     /// assert_eq!(
@@ -98,6 +98,11 @@ impl ResponseBuilder {
         self.0.data.body = Some(Box::new(body.into()));
         self
     }
+
+    /// Consumes the builder and returns the HTTP response.
+    pub fn finish(self) -> HttpResponse {
+        self.0
+    }
 }
 
 #[cfg(test)]
@@ -106,28 +111,28 @@ mod tests {
 
     #[test]
     fn it_creates_an_empty_response() {
-        let response: HttpResponse = ResponseBuilder::new().into();
+        let response: HttpResponse = ResponseBuilder::new().finish();
         assert_eq!(response.status(), Status::Ok);
         assert_eq!(response.body().as_str().unwrap(), "");
     }
 
     #[test]
     fn it_sets_a_status() {
-        let response: HttpResponse = ResponseBuilder::new().status(Status::BadRequest).into();
+        let response: HttpResponse = ResponseBuilder::new().status(Status::BadRequest).finish();
         assert_eq!(response.status(), Status::BadRequest);
         assert_eq!(response.body().as_str().unwrap(), "");
     }
 
     #[test]
     fn it_sets_a_header() {
-        let response: HttpResponse = ResponseBuilder::new().header("foo", "bar").into();
+        let response: HttpResponse = ResponseBuilder::new().header("foo", "bar").finish();
         assert_eq!(response.headers().get("foo").unwrap(), "bar");
         assert_eq!(response.body().as_str().unwrap(), "");
     }
 
     #[test]
     fn it_sets_a_body() {
-        let response: HttpResponse = ResponseBuilder::new().body("test").into();
+        let response: HttpResponse = ResponseBuilder::new().body("test").finish();
         assert_eq!(
             response.headers().get("Content-Type").unwrap(),
             "text/plain"

--- a/azure-functions/src/http/response_builder.rs
+++ b/azure-functions/src/http/response_builder.rs
@@ -19,9 +19,9 @@ impl ResponseBuilder {
     /// use azure_functions::bindings::HttpResponse;
     /// use azure_functions::http::Status;
     ///
-    /// let response: HttpResponse = HttpResponse::build()
+    /// let response = HttpResponse::build()
     ///     .status(Status::InternalServerError)
-    ///     .into();
+    ///     .finish();
     ///
     /// assert_eq!(response.status(), Status::InternalServerError);
     /// ```
@@ -39,9 +39,9 @@ impl ResponseBuilder {
     ///
     /// let value = "custom header value";
     ///
-    /// let response: HttpResponse = HttpResponse::build()
+    /// let response = HttpResponse::build()
     ///     .header("X-Custom-Header", value)
-    ///     .into();
+    ///     .finish();
     ///
     /// assert_eq!(
     ///     response

--- a/azure-functions/src/send_grid/message_builder.rs
+++ b/azure-functions/src/send_grid/message_builder.rs
@@ -641,6 +641,9 @@ impl MessageBuilder {
 
     /// Adds multiple attachments to the message.
     ///
+    /// > SendGrid expects the `content` argument to be Base 64 encoded.
+    /// > In this example, "hello world" is encoded as "aGVsbG8gd29ybGQ="
+    ///
     /// # Examples
     ///
     /// ```rust
@@ -650,13 +653,13 @@ impl MessageBuilder {
     /// let message = SendGridMessage::build()
     ///     .attachments(
     ///         vec![
-    ///             Attachment{ filename: "hello.txt".to_owned(), mime_type: "text/plain".to_owned(), content: "hello world".to_owned(), ..Default::default() }
+    ///             Attachment{ filename: "hello.txt".to_owned(), mime_type: "text/plain".to_owned(), content: "aGVsbG8gd29ybGQ=".to_owned(), ..Default::default() }
     ///         ])
     ///     .finish();
     ///
     /// assert_eq!(message.attachments[0].filename, "hello.txt");
     /// assert_eq!(message.attachments[0].mime_type, "text/plain");
-    /// assert_eq!(message.attachments[0].content, "hello world");
+    /// assert_eq!(message.attachments[0].content, "aGVsbG8gd29ybGQ=");
     /// ```
     pub fn attachments<T>(mut self, attachments: T) -> MessageBuilder
     where

--- a/azure-functions/src/send_grid/message_builder.rs
+++ b/azure-functions/src/send_grid/message_builder.rs
@@ -865,7 +865,7 @@ impl MessageBuilder {
     /// Sets the global "send at" timestamp for all personalizations of the message.
     ///
     /// > Note:
-    /// > This trait uses a Unix timestamp. A handy Unix timestamp converter can be found at [unixtimestamp.com/](https://www.unixtimestamp.com/)
+    /// > This trait uses a Unix timestamp. A handy Unix timestamp converter can be found at [unixtimestamp.com](https://www.unixtimestamp.com/)
     ///
     /// # Examples
     ///

--- a/azure-functions/src/send_grid/message_builder.rs
+++ b/azure-functions/src/send_grid/message_builder.rs
@@ -19,10 +19,7 @@ impl MessageBuilder {
     /// # Examples
     ///
     /// ```rust
-    // @peterhuene, I removed a `#` from this example that I think was included by mistake.
-    // Just checking with you. It is repeated several places, but I think it's just an error propagated by
-    // copy/paste.
-    /// use azure_functions::bindings::SendGridMessage;
+    /// # use azure_functions::bindings::SendGridMessage;
     ///
     /// let message = SendGridMessage::build().to("foo@example.com").finish();
     ///
@@ -42,7 +39,7 @@ impl MessageBuilder {
     /// # Examples
     ///
     /// ```rust
-    /// use azure_functions::bindings::SendGridMessage;
+    /// # use azure_functions::bindings::SendGridMessage;
     ///
     /// let message = SendGridMessage::build().to_with_name("foo@example.com", "Peter").finish();
     ///
@@ -64,8 +61,8 @@ impl MessageBuilder {
     /// # Examples
     ///
     /// ```rust
-    /// use azure_functions::bindings::SendGridMessage;
-    /// use azure_functions::send_grid::EmailAddress;
+    /// # use azure_functions::bindings::SendGridMessage;
+    /// # use azure_functions::send_grid::EmailAddress;
     ///
     /// let message = SendGridMessage::build().tos(
     ///     vec![
@@ -92,7 +89,7 @@ impl MessageBuilder {
     /// # Examples
     ///
     /// ```rust
-    /// use azure_functions::bindings::SendGridMessage;
+    /// # use azure_functions::bindings::SendGridMessage;
     ///
     /// let message = SendGridMessage::build().cc("foo@example.com").finish();
     ///
@@ -112,7 +109,7 @@ impl MessageBuilder {
     /// # Examples
     ///
     /// ```rust
-    /// use azure_functions::bindings::SendGridMessage;
+    /// # use azure_functions::bindings::SendGridMessage;
     ///
     /// let message = SendGridMessage::build().cc_with_name("foo@example.com", "Peter").finish();
     ///
@@ -133,8 +130,8 @@ impl MessageBuilder {
     /// # Examples
     ///
     /// ```rust
-    /// use azure_functions::bindings::SendGridMessage;
-    /// use azure_functions::send_grid::EmailAddress;
+    /// # use azure_functions::bindings::SendGridMessage;
+    /// # use azure_functions::send_grid::EmailAddress;
     ///
     /// let message = SendGridMessage::build().ccs(
     ///     vec![
@@ -161,7 +158,7 @@ impl MessageBuilder {
     /// # Examples
     ///
     /// ```rust
-    /// use azure_functions::bindings::SendGridMessage;
+    /// # use azure_functions::bindings::SendGridMessage;
     ///
     /// let message = SendGridMessage::build().bcc("foo@example.com").finish();
     ///
@@ -181,7 +178,7 @@ impl MessageBuilder {
     /// # Examples
     ///
     /// ```rust
-    /// use azure_functions::bindings::SendGridMessage;
+    /// # use azure_functions::bindings::SendGridMessage;
     ///
     /// let message = SendGridMessage::build().bcc_with_name("foo@example.com", "Peter").finish();
     ///
@@ -202,8 +199,8 @@ impl MessageBuilder {
     /// # Examples
     ///
     /// ```rust
-    /// use azure_functions::bindings::SendGridMessage;
-    /// use azure_functions::send_grid::EmailAddress;
+    /// # use azure_functions::bindings::SendGridMessage;
+    /// # use azure_functions::send_grid::EmailAddress;
     ///
     /// let message = SendGridMessage::build().bccs(
     ///     vec![
@@ -230,7 +227,7 @@ impl MessageBuilder {
     /// # Examples
     ///
     /// ```rust
-    /// use azure_functions::bindings::SendGridMessage;
+    /// # use azure_functions::bindings::SendGridMessage;
     ///
     /// let message = SendGridMessage::build().subject("hello world!").finish();
     ///
@@ -250,7 +247,7 @@ impl MessageBuilder {
     /// # Examples
     ///
     /// ```rust
-    /// use azure_functions::bindings::SendGridMessage;
+    /// # use azure_functions::bindings::SendGridMessage;
     ///
     /// let message = SendGridMessage::build().header("foo", "bar").finish();
     ///
@@ -273,8 +270,8 @@ impl MessageBuilder {
     /// # Examples
     ///
     /// ```rust
-    /// use azure_functions::bindings::SendGridMessage;
-    /// use std::collections::HashMap;
+    /// # use azure_functions::bindings::SendGridMessage;
+    /// # use std::collections::HashMap;
     ///
     /// let mut headers = HashMap::new();
     /// headers.insert("foo".to_owned(), "bar".to_owned());
@@ -299,7 +296,7 @@ impl MessageBuilder {
     /// # Examples
     ///
     /// ```rust
-    /// use azure_functions::bindings::SendGridMessage;
+    /// # use azure_functions::bindings::SendGridMessage;
     ///
     /// let message = SendGridMessage::build().substitution("foo", "bar").finish();
     ///
@@ -322,8 +319,8 @@ impl MessageBuilder {
     /// # Examples
     ///
     /// ```rust
-    /// use azure_functions::bindings::SendGridMessage;
-    /// use std::collections::HashMap;
+    /// # use azure_functions::bindings::SendGridMessage;
+    /// # use std::collections::HashMap;
     ///
     /// let mut substitutions = HashMap::new();
     /// substitutions.insert("foo".to_owned(), "bar".to_owned());
@@ -350,8 +347,8 @@ impl MessageBuilder {
     /// # Examples
     ///
     /// ```rust
-    /// use azure_functions::bindings::SendGridMessage;
-    /// use serde_json::{json, to_string};
+    /// # use azure_functions::bindings::SendGridMessage;
+    /// # use serde_json::{json, to_string};
     ///
     /// let message = SendGridMessage::build().template_data(json!({ "foo": "bar" })).finish();
     ///
@@ -373,7 +370,7 @@ impl MessageBuilder {
     /// # Examples
     ///
     /// ```rust
-    /// use azure_functions::bindings::SendGridMessage;
+    /// # use azure_functions::bindings::SendGridMessage;
     ///
     /// let message = SendGridMessage::build().custom_arg("foo", "bar").finish();
     ///
@@ -396,8 +393,8 @@ impl MessageBuilder {
     /// # Examples
     ///
     /// ```rust
-    /// use azure_functions::bindings::SendGridMessage;
-    /// use std::collections::HashMap;
+    /// # use azure_functions::bindings::SendGridMessage;
+    /// # use std::collections::HashMap;
     ///
     /// let mut args = HashMap::new();
     /// args.insert("foo".to_owned(), "bar".to_owned());
@@ -425,7 +422,7 @@ impl MessageBuilder {
     /// # Examples
     ///
     /// ```rust
-    /// use azure_functions::bindings::SendGridMessage;
+    /// # use azure_functions::bindings::SendGridMessage;
     ///
     /// let message = SendGridMessage::build().send_at(1555890183).finish();
     ///
@@ -442,7 +439,7 @@ impl MessageBuilder {
     /// # Examples
     ///
     /// ```rust
-    /// use azure_functions::bindings::SendGridMessage;
+    /// # use azure_functions::bindings::SendGridMessage;
     ///
     /// let message = SendGridMessage::build().from("foo@example.com").finish();
     ///
@@ -462,7 +459,7 @@ impl MessageBuilder {
     /// # Examples
     ///
     /// ```rust
-    /// use azure_functions::bindings::SendGridMessage;
+    /// # use azure_functions::bindings::SendGridMessage;
     ///
     /// let message = SendGridMessage::build().from_with_name("foo@example.com", "Peter").finish();
     ///
@@ -484,7 +481,7 @@ impl MessageBuilder {
     /// # Examples
     ///
     /// ```rust
-    /// use azure_functions::bindings::SendGridMessage;
+    /// # use azure_functions::bindings::SendGridMessage;
     ///
     /// let message = SendGridMessage::build().global_subject("hello world").finish();
     ///
@@ -503,7 +500,7 @@ impl MessageBuilder {
     /// # Examples
     ///
     /// ```rust
-    /// use azure_functions::bindings::SendGridMessage;
+    /// # use azure_functions::bindings::SendGridMessage;
     ///
     /// let message = SendGridMessage::build().content("hello world").finish();
     ///
@@ -527,7 +524,7 @@ impl MessageBuilder {
     /// # Examples
     ///
     /// ```rust
-    /// use azure_functions::bindings::SendGridMessage;
+    /// # use azure_functions::bindings::SendGridMessage;
     ///
     /// let message = SendGridMessage::build().content_with_type("hello world", "text/plain").finish();
     ///
@@ -552,8 +549,8 @@ impl MessageBuilder {
     /// # Examples
     ///
     /// ```rust
-    /// use azure_functions::bindings::SendGridMessage;
-    /// use azure_functions::send_grid::Content;
+    /// # use azure_functions::bindings::SendGridMessage;
+    /// # use azure_functions::send_grid::Content;
     ///
     /// let message = SendGridMessage::build()
     ///     .contents(
@@ -575,19 +572,19 @@ impl MessageBuilder {
 
     /// Adds an attachment to the message.
     ///
+    /// > SendGrid expects the `content` argument to be Base 64 encoded.
+    /// > In this example, "hello world" is encoded as "aGVsbG8gd29ybGQ="
+    ///
     /// # Examples
     ///
     /// ```rust
-    /// use azure_functions::bindings::SendGridMessage;
+    /// # use azure_functions::bindings::SendGridMessage;
     ///
-    // @peterhuene I changed the content here because when I was reading through and saw the original string
-    // it caused some initial confusion that it might be a secret key or a magical incantation. I don't want others
-    // to pause on that same moment of confusion.
-    /// let message = SendGridMessage::build().attachment("hello.txt", "text/plain", "hello world").finish();
+    /// let message = SendGridMessage::build().attachment("hello.txt", "text/plain", "aGVsbG8gd29ybGQ=").finish();
     ///
     /// assert_eq!(message.attachments[0].filename, "hello.txt");
     /// assert_eq!(message.attachments[0].mime_type, "text/plain");
-    /// assert_eq!(message.attachments[0].content, "hello world");
+    /// assert_eq!(message.attachments[0].content, "aGVsbG8gd29ybGQ=");
     /// ```
     pub fn attachment<T, U, V>(mut self, filename: T, mime_type: U, content: V) -> MessageBuilder
     where
@@ -609,7 +606,7 @@ impl MessageBuilder {
     /// # Examples
     ///
     /// ```rust
-    /// use azure_functions::bindings::SendGridMessage;
+    /// # use azure_functions::bindings::SendGridMessage;
     ///
     /// let message = SendGridMessage::build().inline_attachment("hello.jpg", "image/jpeg", "hello world", "img_139db99fdb5c3704").finish();
     ///
@@ -647,7 +644,7 @@ impl MessageBuilder {
     /// # Examples
     ///
     /// ```rust
-    /// use azure_functions::bindings::SendGridMessage;
+    /// # use azure_functions::bindings::SendGridMessage;
     /// use azure_functions::send_grid::Attachment;
     ///
     /// let message = SendGridMessage::build()
@@ -673,7 +670,7 @@ impl MessageBuilder {
     ///
     /// # Examples
     /// ```rust
-    /// use azure_functions::bindings::SendGridMessage;
+    /// # use azure_functions::bindings::SendGridMessage;
     /// use azure_functions::send_grid::Attachment;
     ///
     /// let message = SendGridMessage::build().template_id("id").finish();
@@ -693,7 +690,7 @@ impl MessageBuilder {
     /// # Examples
     ///
     /// ```rust
-    /// use azure_functions::bindings::SendGridMessage;
+    /// # use azure_functions::bindings::SendGridMessage;
     ///
     /// let message = SendGridMessage::build().section("foo", "bar").finish();
     ///
@@ -713,7 +710,7 @@ impl MessageBuilder {
     /// # Examples
     ///
     /// ```rust
-    /// use azure_functions::bindings::SendGridMessage;
+    /// # use azure_functions::bindings::SendGridMessage;
     /// use std::collections::HashMap;
     ///
     /// let mut sections = HashMap::new();
@@ -738,7 +735,7 @@ impl MessageBuilder {
     /// # Examples
     ///
     /// ```rust
-    /// use azure_functions::bindings::SendGridMessage;
+    /// # use azure_functions::bindings::SendGridMessage;
     ///
     /// let message = SendGridMessage::build().category("foo").finish();
     ///
@@ -757,7 +754,7 @@ impl MessageBuilder {
     /// # Examples
     ///
     /// ```rust
-    /// use azure_functions::bindings::SendGridMessage;
+    /// # use azure_functions::bindings::SendGridMessage;
     ///
     /// let message = SendGridMessage::build().categories(vec!["foo".to_owned(), "bar".to_owned(), "baz".to_owned()]).finish();
     ///
@@ -778,7 +775,7 @@ impl MessageBuilder {
     /// # Examples
     ///
     /// ```rust
-    /// use azure_functions::bindings::SendGridMessage;
+    /// # use azure_functions::bindings::SendGridMessage;
     ///
     /// let message = SendGridMessage::build().global_header("foo", "bar").finish();
     ///
@@ -798,7 +795,7 @@ impl MessageBuilder {
     /// # Examples
     ///
     /// ```rust
-    /// use azure_functions::bindings::SendGridMessage;
+    /// # use azure_functions::bindings::SendGridMessage;
     /// use std::collections::HashMap;
     ///
     /// let mut headers = HashMap::new();
@@ -823,7 +820,7 @@ impl MessageBuilder {
     /// # Examples
     ///
     /// ```rust
-    /// use azure_functions::bindings::SendGridMessage;
+    /// # use azure_functions::bindings::SendGridMessage;
     ///
     /// let message = SendGridMessage::build().global_custom_arg("foo", "bar").finish();
     ///
@@ -844,7 +841,7 @@ impl MessageBuilder {
     /// # Examples
     ///
     /// ```rust
-    /// use azure_functions::bindings::SendGridMessage;
+    /// # use azure_functions::bindings::SendGridMessage;
     /// use std::collections::HashMap;
     ///
     /// let mut args = HashMap::new();
@@ -873,7 +870,7 @@ impl MessageBuilder {
     /// # Examples
     ///
     /// ```rust
-    /// use azure_functions::bindings::SendGridMessage;
+    /// # use azure_functions::bindings::SendGridMessage;
     ///
     /// let message = SendGridMessage::build().global_send_at(1555890183).finish();
     ///
@@ -890,7 +887,7 @@ impl MessageBuilder {
     /// # Examples
     ///
     /// ```rust
-    /// use azure_functions::bindings::SendGridMessage;
+    /// # use azure_functions::bindings::SendGridMessage;
     ///
     /// let message = SendGridMessage::build().batch_id("HkJ5yLYULb7Rj8GKSx7u025ouWVlMgAi").finish();
     ///

--- a/azure-functions/src/send_grid/message_builder.rs
+++ b/azure-functions/src/send_grid/message_builder.rs
@@ -19,9 +19,9 @@ impl MessageBuilder {
     /// # Examples
     ///
     /// ```rust
-    /// # use azure_functions::bindings::SendGridMessage;
+    /// # use azure_functions::send_grid::MessageBuilder;
     ///
-    /// let message = SendGridMessage::build().to("foo@example.com").finish();
+    /// let message = MessageBuilder::new().to("foo@example.com").finish();
     ///
     /// assert_eq!(message.personalizations[0].to[0].email, "foo@example.com");
     /// assert_eq!(message.personalizations[0].to[0].name, None);
@@ -39,9 +39,9 @@ impl MessageBuilder {
     /// # Examples
     ///
     /// ```rust
-    /// # use azure_functions::bindings::SendGridMessage;
+    /// # use azure_functions::send_grid::MessageBuilder;
     ///
-    /// let message = SendGridMessage::build().to_with_name("foo@example.com", "Peter").finish();
+    /// let message = MessageBuilder::new().to_with_name("foo@example.com", "Peter").finish();
     ///
     /// assert_eq!(message.personalizations[0].to[0].email, "foo@example.com");
     /// assert_eq!(message.personalizations[0].to[0].name, Some("Peter".to_owned()));
@@ -61,10 +61,10 @@ impl MessageBuilder {
     /// # Examples
     ///
     /// ```rust
-    /// # use azure_functions::bindings::SendGridMessage;
+    /// # use azure_functions::send_grid::MessageBuilder;
     /// # use azure_functions::send_grid::EmailAddress;
     ///
-    /// let message = SendGridMessage::build().tos(
+    /// let message = MessageBuilder::new().tos(
     ///     vec![
     ///         EmailAddress::new("foo@example.com"),
     ///         EmailAddress::new_with_name("bar@example.com", "Peter"),
@@ -89,9 +89,9 @@ impl MessageBuilder {
     /// # Examples
     ///
     /// ```rust
-    /// # use azure_functions::bindings::SendGridMessage;
+    /// # use azure_functions::send_grid::MessageBuilder;
     ///
-    /// let message = SendGridMessage::build().cc("foo@example.com").finish();
+    /// let message = MessageBuilder::new().cc("foo@example.com").finish();
     ///
     /// assert_eq!(message.personalizations[0].cc[0].email, "foo@example.com");
     /// assert_eq!(message.personalizations[0].cc[0].name, None);
@@ -109,9 +109,9 @@ impl MessageBuilder {
     /// # Examples
     ///
     /// ```rust
-    /// # use azure_functions::bindings::SendGridMessage;
+    /// # use azure_functions::send_grid::MessageBuilder;
     ///
-    /// let message = SendGridMessage::build().cc_with_name("foo@example.com", "Peter").finish();
+    /// let message = MessageBuilder::new().cc_with_name("foo@example.com", "Peter").finish();
     ///
     /// assert_eq!(message.personalizations[0].cc[0].email, "foo@example.com");
     /// assert_eq!(message.personalizations[0].cc[0].name, Some("Peter".to_owned()));
@@ -130,10 +130,10 @@ impl MessageBuilder {
     /// # Examples
     ///
     /// ```rust
-    /// # use azure_functions::bindings::SendGridMessage;
+    /// # use azure_functions::send_grid::MessageBuilder;
     /// # use azure_functions::send_grid::EmailAddress;
     ///
-    /// let message = SendGridMessage::build().ccs(
+    /// let message = MessageBuilder::new().ccs(
     ///     vec![
     ///         EmailAddress::new("foo@example.com"),
     ///         EmailAddress::new_with_name("bar@example.com", "Peter"),
@@ -158,9 +158,9 @@ impl MessageBuilder {
     /// # Examples
     ///
     /// ```rust
-    /// # use azure_functions::bindings::SendGridMessage;
+    /// # use azure_functions::send_grid::MessageBuilder;
     ///
-    /// let message = SendGridMessage::build().bcc("foo@example.com").finish();
+    /// let message = MessageBuilder::new().bcc("foo@example.com").finish();
     ///
     /// assert_eq!(message.personalizations[0].bcc[0].email, "foo@example.com");
     /// assert_eq!(message.personalizations[0].bcc[0].name, None);
@@ -178,9 +178,9 @@ impl MessageBuilder {
     /// # Examples
     ///
     /// ```rust
-    /// # use azure_functions::bindings::SendGridMessage;
+    /// # use azure_functions::send_grid::MessageBuilder;
     ///
-    /// let message = SendGridMessage::build().bcc_with_name("foo@example.com", "Peter").finish();
+    /// let message = MessageBuilder::new().bcc_with_name("foo@example.com", "Peter").finish();
     ///
     /// assert_eq!(message.personalizations[0].bcc[0].email, "foo@example.com");
     /// assert_eq!(message.personalizations[0].bcc[0].name, Some("Peter".to_owned()));
@@ -199,10 +199,10 @@ impl MessageBuilder {
     /// # Examples
     ///
     /// ```rust
-    /// # use azure_functions::bindings::SendGridMessage;
+    /// # use azure_functions::send_grid::MessageBuilder;
     /// # use azure_functions::send_grid::EmailAddress;
     ///
-    /// let message = SendGridMessage::build().bccs(
+    /// let message = MessageBuilder::new().bccs(
     ///     vec![
     ///         EmailAddress::new("foo@example.com"),
     ///         EmailAddress::new_with_name("bar@example.com", "Peter"),
@@ -227,9 +227,9 @@ impl MessageBuilder {
     /// # Examples
     ///
     /// ```rust
-    /// # use azure_functions::bindings::SendGridMessage;
+    /// # use azure_functions::send_grid::MessageBuilder;
     ///
-    /// let message = SendGridMessage::build().subject("hello world!").finish();
+    /// let message = MessageBuilder::new().subject("hello world!").finish();
     ///
     /// assert_eq!(message.personalizations[0].subject, Some("hello world!".to_owned()));
     /// ```
@@ -247,9 +247,9 @@ impl MessageBuilder {
     /// # Examples
     ///
     /// ```rust
-    /// # use azure_functions::bindings::SendGridMessage;
+    /// # use azure_functions::send_grid::MessageBuilder;
     ///
-    /// let message = SendGridMessage::build().header("foo", "bar").finish();
+    /// let message = MessageBuilder::new().header("foo", "bar").finish();
     ///
     /// assert_eq!(message.personalizations[0].headers.get("foo").map(String::as_str), Some("bar"));
     /// ```
@@ -270,14 +270,14 @@ impl MessageBuilder {
     /// # Examples
     ///
     /// ```rust
-    /// # use azure_functions::bindings::SendGridMessage;
+    /// # use azure_functions::send_grid::MessageBuilder;
     /// # use std::collections::HashMap;
     ///
     /// let mut headers = HashMap::new();
     /// headers.insert("foo".to_owned(), "bar".to_owned());
     /// headers.insert("bar".to_owned(), "baz".to_owned());
     ///
-    /// let message = SendGridMessage::build().headers(headers).finish();
+    /// let message = MessageBuilder::new().headers(headers).finish();
     ///
     /// assert_eq!(message.personalizations[0].headers.get("foo").map(String::as_str), Some("bar"));
     /// assert_eq!(message.personalizations[0].headers.get("bar").map(String::as_str), Some("baz"));
@@ -296,9 +296,9 @@ impl MessageBuilder {
     /// # Examples
     ///
     /// ```rust
-    /// # use azure_functions::bindings::SendGridMessage;
+    /// # use azure_functions::send_grid::MessageBuilder;
     ///
-    /// let message = SendGridMessage::build().substitution("foo", "bar").finish();
+    /// let message = MessageBuilder::new().substitution("foo", "bar").finish();
     ///
     /// assert_eq!(message.personalizations[0].substitutions.get("foo").map(String::as_str), Some("bar"));
     /// ```
@@ -319,14 +319,14 @@ impl MessageBuilder {
     /// # Examples
     ///
     /// ```rust
-    /// # use azure_functions::bindings::SendGridMessage;
+    /// # use azure_functions::send_grid::MessageBuilder;
     /// # use std::collections::HashMap;
     ///
     /// let mut substitutions = HashMap::new();
     /// substitutions.insert("foo".to_owned(), "bar".to_owned());
     /// substitutions.insert("bar".to_owned(), "baz".to_owned());
     ///
-    /// let message = SendGridMessage::build().substitutions(substitutions).finish();
+    /// let message = MessageBuilder::new().substitutions(substitutions).finish();
     ///
     /// assert_eq!(message.personalizations[0].substitutions.get("foo").map(String::as_str), Some("bar"));
     /// assert_eq!(message.personalizations[0].substitutions.get("bar").map(String::as_str), Some("baz"));
@@ -347,10 +347,10 @@ impl MessageBuilder {
     /// # Examples
     ///
     /// ```rust
-    /// # use azure_functions::bindings::SendGridMessage;
+    /// # use azure_functions::send_grid::MessageBuilder;
     /// # use serde_json::{json, to_string};
     ///
-    /// let message = SendGridMessage::build().template_data(json!({ "foo": "bar" })).finish();
+    /// let message = MessageBuilder::new().template_data(json!({ "foo": "bar" })).finish();
     ///
     /// assert_eq!(to_string(message.personalizations[0].template_data.as_ref().unwrap()).unwrap(), r#"{"foo":"bar"}"#);
     /// ```
@@ -370,9 +370,9 @@ impl MessageBuilder {
     /// # Examples
     ///
     /// ```rust
-    /// # use azure_functions::bindings::SendGridMessage;
+    /// # use azure_functions::send_grid::MessageBuilder;
     ///
-    /// let message = SendGridMessage::build().custom_arg("foo", "bar").finish();
+    /// let message = MessageBuilder::new().custom_arg("foo", "bar").finish();
     ///
     /// assert_eq!(message.personalizations[0].custom_args.get("foo").map(String::as_str), Some("bar"));
     /// ```
@@ -393,14 +393,14 @@ impl MessageBuilder {
     /// # Examples
     ///
     /// ```rust
-    /// # use azure_functions::bindings::SendGridMessage;
+    /// # use azure_functions::send_grid::MessageBuilder;
     /// # use std::collections::HashMap;
     ///
     /// let mut args = HashMap::new();
     /// args.insert("foo".to_owned(), "bar".to_owned());
     /// args.insert("bar".to_owned(), "baz".to_owned());
     ///
-    /// let message = SendGridMessage::build().custom_args(args).finish();
+    /// let message = MessageBuilder::new().custom_args(args).finish();
     ///
     /// assert_eq!(message.personalizations[0].custom_args.get("foo").map(String::as_str), Some("bar"));
     /// assert_eq!(message.personalizations[0].custom_args.get("bar").map(String::as_str), Some("baz"));
@@ -422,9 +422,9 @@ impl MessageBuilder {
     /// # Examples
     ///
     /// ```rust
-    /// # use azure_functions::bindings::SendGridMessage;
+    /// # use azure_functions::send_grid::MessageBuilder;
     ///
-    /// let message = SendGridMessage::build().send_at(1555890183).finish();
+    /// let message = MessageBuilder::new().send_at(1555890183).finish();
     ///
     /// assert_eq!(message.personalizations[0].send_at, Some(1555890183));
     /// ```
@@ -439,9 +439,9 @@ impl MessageBuilder {
     /// # Examples
     ///
     /// ```rust
-    /// # use azure_functions::bindings::SendGridMessage;
+    /// # use azure_functions::send_grid::MessageBuilder;
     ///
-    /// let message = SendGridMessage::build().from("foo@example.com").finish();
+    /// let message = MessageBuilder::new().from("foo@example.com").finish();
     ///
     /// assert_eq!(message.from.as_ref().unwrap().email, "foo@example.com");
     /// assert_eq!(message.from.as_ref().unwrap().name, None);
@@ -459,9 +459,9 @@ impl MessageBuilder {
     /// # Examples
     ///
     /// ```rust
-    /// # use azure_functions::bindings::SendGridMessage;
+    /// # use azure_functions::send_grid::MessageBuilder;
     ///
-    /// let message = SendGridMessage::build().from_with_name("foo@example.com", "Peter").finish();
+    /// let message = MessageBuilder::new().from_with_name("foo@example.com", "Peter").finish();
     ///
     /// assert_eq!(message.from.as_ref().unwrap().email, "foo@example.com");
     /// assert_eq!(message.from.as_ref().unwrap().name, Some("Peter".to_owned()));
@@ -481,9 +481,9 @@ impl MessageBuilder {
     /// # Examples
     ///
     /// ```rust
-    /// # use azure_functions::bindings::SendGridMessage;
+    /// # use azure_functions::send_grid::MessageBuilder;
     ///
-    /// let message = SendGridMessage::build().global_subject("hello world").finish();
+    /// let message = MessageBuilder::new().global_subject("hello world").finish();
     ///
     /// assert_eq!(message.subject, Some("hello world".to_owned()));
     /// ```
@@ -500,9 +500,9 @@ impl MessageBuilder {
     /// # Examples
     ///
     /// ```rust
-    /// # use azure_functions::bindings::SendGridMessage;
+    /// # use azure_functions::send_grid::MessageBuilder;
     ///
-    /// let message = SendGridMessage::build().content("hello world").finish();
+    /// let message = MessageBuilder::new().content("hello world").finish();
     ///
     /// assert_eq!(message.contents[0].mime_type, "text/plain");
     /// assert_eq!(message.contents[0].value, "hello world");
@@ -524,9 +524,9 @@ impl MessageBuilder {
     /// # Examples
     ///
     /// ```rust
-    /// # use azure_functions::bindings::SendGridMessage;
+    /// # use azure_functions::send_grid::MessageBuilder;
     ///
-    /// let message = SendGridMessage::build().content_with_type("hello world", "text/plain").finish();
+    /// let message = MessageBuilder::new().content_with_type("hello world", "text/plain").finish();
     ///
     /// assert_eq!(message.contents[0].mime_type, "text/plain");
     /// assert_eq!(message.contents[0].value, "hello world");
@@ -549,10 +549,10 @@ impl MessageBuilder {
     /// # Examples
     ///
     /// ```rust
-    /// # use azure_functions::bindings::SendGridMessage;
+    /// # use azure_functions::send_grid::MessageBuilder;
     /// # use azure_functions::send_grid::Content;
     ///
-    /// let message = SendGridMessage::build()
+    /// let message = MessageBuilder::new()
     ///     .contents(
     ///         vec![
     ///             Content{ mime_type: "text/plain".to_owned(), value: "hello world".to_owned() }
@@ -578,9 +578,9 @@ impl MessageBuilder {
     /// # Examples
     ///
     /// ```rust
-    /// # use azure_functions::bindings::SendGridMessage;
+    /// # use azure_functions::send_grid::MessageBuilder;
     ///
-    /// let message = SendGridMessage::build().attachment("hello.txt", "text/plain", "aGVsbG8gd29ybGQ=").finish();
+    /// let message = MessageBuilder::new().attachment("hello.txt", "text/plain", "aGVsbG8gd29ybGQ=").finish();
     ///
     /// assert_eq!(message.attachments[0].filename, "hello.txt");
     /// assert_eq!(message.attachments[0].mime_type, "text/plain");
@@ -603,16 +603,19 @@ impl MessageBuilder {
 
     /// Adds an attachment to the message.
     ///
+    /// > SendGrid expects the `content` argument to be Base 64 encoded.
+    /// > In this example, "hello world" is encoded as "aGVsbG8gd29ybGQ="
+    ///
     /// # Examples
     ///
     /// ```rust
-    /// # use azure_functions::bindings::SendGridMessage;
+    /// # use azure_functions::send_grid::MessageBuilder;
     ///
-    /// let message = SendGridMessage::build().inline_attachment("hello.jpg", "image/jpeg", "hello world", "img_139db99fdb5c3704").finish();
+    /// let message = MessageBuilder::new().inline_attachment("hello.jpg", "image/jpeg", "aGVsbG8gd29ybGQ=", "img_139db99fdb5c3704").finish();
     ///
     /// assert_eq!(message.attachments[0].filename, "hello.jpg");
     /// assert_eq!(message.attachments[0].mime_type, "image/jpeg");
-    /// assert_eq!(message.attachments[0].content, "hello world");
+    /// assert_eq!(message.attachments[0].content, "aGVsbG8gd29ybGQ=");
     /// assert_eq!(message.attachments[0].disposition, Some("inline".to_owned()));
     /// assert_eq!(message.attachments[0].content_id, Some("img_139db99fdb5c3704".to_owned()));
     /// ```
@@ -647,10 +650,10 @@ impl MessageBuilder {
     /// # Examples
     ///
     /// ```rust
-    /// # use azure_functions::bindings::SendGridMessage;
+    /// # use azure_functions::send_grid::MessageBuilder;
     /// use azure_functions::send_grid::Attachment;
     ///
-    /// let message = SendGridMessage::build()
+    /// let message = MessageBuilder::new()
     ///     .attachments(
     ///         vec![
     ///             Attachment{ filename: "hello.txt".to_owned(), mime_type: "text/plain".to_owned(), content: "aGVsbG8gd29ybGQ=".to_owned(), ..Default::default() }
@@ -673,10 +676,10 @@ impl MessageBuilder {
     ///
     /// # Examples
     /// ```rust
-    /// # use azure_functions::bindings::SendGridMessage;
+    /// # use azure_functions::send_grid::MessageBuilder;
     /// use azure_functions::send_grid::Attachment;
     ///
-    /// let message = SendGridMessage::build().template_id("id").finish();
+    /// let message = MessageBuilder::new().template_id("id").finish();
     ///
     /// assert_eq!(message.template_id, Some("id".to_owned()));
     /// ```
@@ -693,9 +696,9 @@ impl MessageBuilder {
     /// # Examples
     ///
     /// ```rust
-    /// # use azure_functions::bindings::SendGridMessage;
+    /// # use azure_functions::send_grid::MessageBuilder;
     ///
-    /// let message = SendGridMessage::build().section("foo", "bar").finish();
+    /// let message = MessageBuilder::new().section("foo", "bar").finish();
     ///
     /// assert_eq!(message.sections.get("foo").map(String::as_str), Some("bar"));
     /// ```
@@ -713,14 +716,14 @@ impl MessageBuilder {
     /// # Examples
     ///
     /// ```rust
-    /// # use azure_functions::bindings::SendGridMessage;
+    /// # use azure_functions::send_grid::MessageBuilder;
     /// use std::collections::HashMap;
     ///
     /// let mut sections = HashMap::new();
     /// sections.insert("foo".to_owned(), "bar".to_owned());
     /// sections.insert("bar".to_owned(), "baz".to_owned());
     ///
-    /// let message = SendGridMessage::build().sections(sections).finish();
+    /// let message = MessageBuilder::new().sections(sections).finish();
     ///
     /// assert_eq!(message.sections.get("foo").map(String::as_str), Some("bar"));
     /// assert_eq!(message.sections.get("bar").map(String::as_str), Some("baz"));
@@ -738,9 +741,9 @@ impl MessageBuilder {
     /// # Examples
     ///
     /// ```rust
-    /// # use azure_functions::bindings::SendGridMessage;
+    /// # use azure_functions::send_grid::MessageBuilder;
     ///
-    /// let message = SendGridMessage::build().category("foo").finish();
+    /// let message = MessageBuilder::new().category("foo").finish();
     ///
     /// assert_eq!(message.categories[0], "foo");
     /// ```
@@ -757,9 +760,9 @@ impl MessageBuilder {
     /// # Examples
     ///
     /// ```rust
-    /// # use azure_functions::bindings::SendGridMessage;
+    /// # use azure_functions::send_grid::MessageBuilder;
     ///
-    /// let message = SendGridMessage::build().categories(vec!["foo".to_owned(), "bar".to_owned(), "baz".to_owned()]).finish();
+    /// let message = MessageBuilder::new().categories(vec!["foo".to_owned(), "bar".to_owned(), "baz".to_owned()]).finish();
     ///
     /// assert_eq!(message.categories[0], "foo");
     /// assert_eq!(message.categories[1], "bar");
@@ -778,9 +781,9 @@ impl MessageBuilder {
     /// # Examples
     ///
     /// ```rust
-    /// # use azure_functions::bindings::SendGridMessage;
+    /// # use azure_functions::send_grid::MessageBuilder;
     ///
-    /// let message = SendGridMessage::build().global_header("foo", "bar").finish();
+    /// let message = MessageBuilder::new().global_header("foo", "bar").finish();
     ///
     /// assert_eq!(message.headers.get("foo").map(String::as_str), Some("bar"));
     /// ```
@@ -798,14 +801,14 @@ impl MessageBuilder {
     /// # Examples
     ///
     /// ```rust
-    /// # use azure_functions::bindings::SendGridMessage;
+    /// # use azure_functions::send_grid::MessageBuilder;
     /// use std::collections::HashMap;
     ///
     /// let mut headers = HashMap::new();
     /// headers.insert("foo".to_owned(), "bar".to_owned());
     /// headers.insert("bar".to_owned(), "baz".to_owned());
     ///
-    /// let message = SendGridMessage::build().global_headers(headers).finish();
+    /// let message = MessageBuilder::new().global_headers(headers).finish();
     ///
     /// assert_eq!(message.headers.get("foo").map(String::as_str), Some("bar"));
     /// assert_eq!(message.headers.get("bar").map(String::as_str), Some("baz"));
@@ -823,9 +826,9 @@ impl MessageBuilder {
     /// # Examples
     ///
     /// ```rust
-    /// # use azure_functions::bindings::SendGridMessage;
+    /// # use azure_functions::send_grid::MessageBuilder;
     ///
-    /// let message = SendGridMessage::build().global_custom_arg("foo", "bar").finish();
+    /// let message = MessageBuilder::new().global_custom_arg("foo", "bar").finish();
     ///
     /// assert_eq!(message.custom_args.get("foo").map(String::as_str), Some("bar"));
     /// ```
@@ -844,14 +847,14 @@ impl MessageBuilder {
     /// # Examples
     ///
     /// ```rust
-    /// # use azure_functions::bindings::SendGridMessage;
+    /// # use azure_functions::send_grid::MessageBuilder;
     /// use std::collections::HashMap;
     ///
     /// let mut args = HashMap::new();
     /// args.insert("foo".to_owned(), "bar".to_owned());
     /// args.insert("bar".to_owned(), "baz".to_owned());
     ///
-    /// let message = SendGridMessage::build().global_custom_args(args).finish();
+    /// let message = MessageBuilder::new().global_custom_args(args).finish();
     ///
     /// assert_eq!(message.custom_args.get("foo").map(String::as_str), Some("bar"));
     /// assert_eq!(message.custom_args.get("bar").map(String::as_str), Some("baz"));
@@ -873,9 +876,9 @@ impl MessageBuilder {
     /// # Examples
     ///
     /// ```rust
-    /// # use azure_functions::bindings::SendGridMessage;
+    /// # use azure_functions::send_grid::MessageBuilder;
     ///
-    /// let message = SendGridMessage::build().global_send_at(1555890183).finish();
+    /// let message = MessageBuilder::new().global_send_at(1555890183).finish();
     ///
     /// assert_eq!(message.send_at, Some(1555890183));
     /// ```
@@ -890,9 +893,9 @@ impl MessageBuilder {
     /// # Examples
     ///
     /// ```rust
-    /// # use azure_functions::bindings::SendGridMessage;
+    /// # use azure_functions::send_grid::MessageBuilder;
     ///
-    /// let message = SendGridMessage::build().batch_id("HkJ5yLYULb7Rj8GKSx7u025ouWVlMgAi").finish();
+    /// let message = MessageBuilder::new().batch_id("HkJ5yLYULb7Rj8GKSx7u025ouWVlMgAi").finish();
     ///
     /// assert_eq!(message.batch_id.unwrap(), "HkJ5yLYULb7Rj8GKSx7u025ouWVlMgAi");
     /// ```

--- a/azure-functions/src/send_grid/message_builder.rs
+++ b/azure-functions/src/send_grid/message_builder.rs
@@ -22,9 +22,9 @@ impl MessageBuilder {
     // @peterhuene, I removed a `#` from this example that I think was included by mistake.
     // Just checking with you. It is repeated several places, but I think it's just an error propagated by
     // copy/paste.
-    /// use azure_functions::send_grid::MessageBuilder;
+    /// use azure_functions::bindings::SendGridMessage;
     ///
-    /// let message = MessageBuilder::build().to("foo@example.com").finish();
+    /// let message = SendGridMessage::build().to("foo@example.com").finish();
     ///
     /// assert_eq!(message.personalizations[0].to[0].email, "foo@example.com");
     /// assert_eq!(message.personalizations[0].to[0].name, None);
@@ -42,9 +42,9 @@ impl MessageBuilder {
     /// # Examples
     ///
     /// ```rust
-    /// use azure_functions::send_grid::MessageBuilder;
+    /// use azure_functions::bindings::SendGridMessage;
     ///
-    /// let message = MessageBuilder::build().to_with_name("foo@example.com", "Peter").finish();
+    /// let message = SendGridMessage::build().to_with_name("foo@example.com", "Peter").finish();
     ///
     /// assert_eq!(message.personalizations[0].to[0].email, "foo@example.com");
     /// assert_eq!(message.personalizations[0].to[0].name, Some("Peter".to_owned()));
@@ -64,10 +64,10 @@ impl MessageBuilder {
     /// # Examples
     ///
     /// ```rust
-    /// use azure_functions::send_grid::MessageBuilder;
+    /// use azure_functions::bindings::SendGridMessage;
     /// use azure_functions::send_grid::EmailAddress;
     ///
-    /// let message = MessageBuilder::build().tos(
+    /// let message = SendGridMessage::build().tos(
     ///     vec![
     ///         EmailAddress::new("foo@example.com"),
     ///         EmailAddress::new_with_name("bar@example.com", "Peter"),
@@ -92,9 +92,9 @@ impl MessageBuilder {
     /// # Examples
     ///
     /// ```rust
-    /// use azure_functions::send_grid::MessageBuilder;
+    /// use azure_functions::bindings::SendGridMessage;
     ///
-    /// let message = MessageBuilder::build().cc("foo@example.com").finish();
+    /// let message = SendGridMessage::build().cc("foo@example.com").finish();
     ///
     /// assert_eq!(message.personalizations[0].cc[0].email, "foo@example.com");
     /// assert_eq!(message.personalizations[0].cc[0].name, None);
@@ -112,9 +112,9 @@ impl MessageBuilder {
     /// # Examples
     ///
     /// ```rust
-    /// use azure_functions::send_grid::MessageBuilder;
+    /// use azure_functions::bindings::SendGridMessage;
     ///
-    /// let message = MessageBuilder::build().cc_with_name("foo@example.com", "Peter").finish();
+    /// let message = SendGridMessage::build().cc_with_name("foo@example.com", "Peter").finish();
     ///
     /// assert_eq!(message.personalizations[0].cc[0].email, "foo@example.com");
     /// assert_eq!(message.personalizations[0].cc[0].name, Some("Peter".to_owned()));
@@ -133,10 +133,10 @@ impl MessageBuilder {
     /// # Examples
     ///
     /// ```rust
-    /// use azure_functions::send_grid::MessageBuilder;
+    /// use azure_functions::bindings::SendGridMessage;
     /// use azure_functions::send_grid::EmailAddress;
     ///
-    /// let message = MessageBuilder::build().ccs(
+    /// let message = SendGridMessage::build().ccs(
     ///     vec![
     ///         EmailAddress::new("foo@example.com"),
     ///         EmailAddress::new_with_name("bar@example.com", "Peter"),
@@ -161,9 +161,9 @@ impl MessageBuilder {
     /// # Examples
     ///
     /// ```rust
-    /// use azure_functions::send_grid::MessageBuilder;
+    /// use azure_functions::bindings::SendGridMessage;
     ///
-    /// let message = MessageBuilder::build().bcc("foo@example.com").finish();
+    /// let message = SendGridMessage::build().bcc("foo@example.com").finish();
     ///
     /// assert_eq!(message.personalizations[0].bcc[0].email, "foo@example.com");
     /// assert_eq!(message.personalizations[0].bcc[0].name, None);
@@ -181,9 +181,9 @@ impl MessageBuilder {
     /// # Examples
     ///
     /// ```rust
-    /// use azure_functions::send_grid::MessageBuilder;
+    /// use azure_functions::bindings::SendGridMessage;
     ///
-    /// let message = MessageBuilder::build().bcc_with_name("foo@example.com", "Peter").finish();
+    /// let message = SendGridMessage::build().bcc_with_name("foo@example.com", "Peter").finish();
     ///
     /// assert_eq!(message.personalizations[0].bcc[0].email, "foo@example.com");
     /// assert_eq!(message.personalizations[0].bcc[0].name, Some("Peter".to_owned()));
@@ -202,10 +202,10 @@ impl MessageBuilder {
     /// # Examples
     ///
     /// ```rust
-    /// use azure_functions::send_grid::MessageBuilder;
+    /// use azure_functions::bindings::SendGridMessage;
     /// use azure_functions::send_grid::EmailAddress;
     ///
-    /// let message = MessageBuilder::build().bccs(
+    /// let message = SendGridMessage::build().bccs(
     ///     vec![
     ///         EmailAddress::new("foo@example.com"),
     ///         EmailAddress::new_with_name("bar@example.com", "Peter"),
@@ -230,9 +230,9 @@ impl MessageBuilder {
     /// # Examples
     ///
     /// ```rust
-    /// use azure_functions::send_grid::MessageBuilder;
+    /// use azure_functions::bindings::SendGridMessage;
     ///
-    /// let message = MessageBuilder::build().subject("hello world!").finish();
+    /// let message = SendGridMessage::build().subject("hello world!").finish();
     ///
     /// assert_eq!(message.personalizations[0].subject, Some("hello world!".to_owned()));
     /// ```
@@ -250,9 +250,9 @@ impl MessageBuilder {
     /// # Examples
     ///
     /// ```rust
-    /// use azure_functions::send_grid::MessageBuilder;
+    /// use azure_functions::bindings::SendGridMessage;
     ///
-    /// let message = MessageBuilder::build().header("foo", "bar").finish();
+    /// let message = SendGridMessage::build().header("foo", "bar").finish();
     ///
     /// assert_eq!(message.personalizations[0].headers.get("foo").map(String::as_str), Some("bar"));
     /// ```
@@ -273,14 +273,14 @@ impl MessageBuilder {
     /// # Examples
     ///
     /// ```rust
-    /// use azure_functions::send_grid::MessageBuilder;
+    /// use azure_functions::bindings::SendGridMessage;
     /// use std::collections::HashMap;
     ///
     /// let mut headers = HashMap::new();
     /// headers.insert("foo".to_owned(), "bar".to_owned());
     /// headers.insert("bar".to_owned(), "baz".to_owned());
     ///
-    /// let message = MessageBuilder::build().headers(headers).finish();
+    /// let message = SendGridMessage::build().headers(headers).finish();
     ///
     /// assert_eq!(message.personalizations[0].headers.get("foo").map(String::as_str), Some("bar"));
     /// assert_eq!(message.personalizations[0].headers.get("bar").map(String::as_str), Some("baz"));
@@ -299,9 +299,9 @@ impl MessageBuilder {
     /// # Examples
     ///
     /// ```rust
-    /// use azure_functions::send_grid::MessageBuilder;
+    /// use azure_functions::bindings::SendGridMessage;
     ///
-    /// let message = MessageBuilder::build().substitution("foo", "bar").finish();
+    /// let message = SendGridMessage::build().substitution("foo", "bar").finish();
     ///
     /// assert_eq!(message.personalizations[0].substitutions.get("foo").map(String::as_str), Some("bar"));
     /// ```
@@ -322,14 +322,14 @@ impl MessageBuilder {
     /// # Examples
     ///
     /// ```rust
-    /// use azure_functions::send_grid::MessageBuilder;
+    /// use azure_functions::bindings::SendGridMessage;
     /// use std::collections::HashMap;
     ///
     /// let mut substitutions = HashMap::new();
     /// substitutions.insert("foo".to_owned(), "bar".to_owned());
     /// substitutions.insert("bar".to_owned(), "baz".to_owned());
     ///
-    /// let message = MessageBuilder::build().substitutions(substitutions).finish();
+    /// let message = SendGridMessage::build().substitutions(substitutions).finish();
     ///
     /// assert_eq!(message.personalizations[0].substitutions.get("foo").map(String::as_str), Some("bar"));
     /// assert_eq!(message.personalizations[0].substitutions.get("bar").map(String::as_str), Some("baz"));
@@ -350,10 +350,10 @@ impl MessageBuilder {
     /// # Examples
     ///
     /// ```rust
-    /// use azure_functions::send_grid::MessageBuilder;
+    /// use azure_functions::bindings::SendGridMessage;
     /// use serde_json::{json, to_string};
     ///
-    /// let message = MessageBuilder::build().template_data(json!({ "foo": "bar" })).finish();
+    /// let message = SendGridMessage::build().template_data(json!({ "foo": "bar" })).finish();
     ///
     /// assert_eq!(to_string(message.personalizations[0].template_data.as_ref().unwrap()).unwrap(), r#"{"foo":"bar"}"#);
     /// ```
@@ -373,9 +373,9 @@ impl MessageBuilder {
     /// # Examples
     ///
     /// ```rust
-    /// use azure_functions::send_grid::MessageBuilder;
+    /// use azure_functions::bindings::SendGridMessage;
     ///
-    /// let message = MessageBuilder::build().custom_arg("foo", "bar").finish();
+    /// let message = SendGridMessage::build().custom_arg("foo", "bar").finish();
     ///
     /// assert_eq!(message.personalizations[0].custom_args.get("foo").map(String::as_str), Some("bar"));
     /// ```
@@ -396,14 +396,14 @@ impl MessageBuilder {
     /// # Examples
     ///
     /// ```rust
-    /// use azure_functions::send_grid::MessageBuilder;
+    /// use azure_functions::bindings::SendGridMessage;
     /// use std::collections::HashMap;
     ///
     /// let mut args = HashMap::new();
     /// args.insert("foo".to_owned(), "bar".to_owned());
     /// args.insert("bar".to_owned(), "baz".to_owned());
     ///
-    /// let message = MessageBuilder::build().custom_args(args).finish();
+    /// let message = SendGridMessage::build().custom_args(args).finish();
     ///
     /// assert_eq!(message.personalizations[0].custom_args.get("foo").map(String::as_str), Some("bar"));
     /// assert_eq!(message.personalizations[0].custom_args.get("bar").map(String::as_str), Some("baz"));
@@ -425,9 +425,9 @@ impl MessageBuilder {
     /// # Examples
     ///
     /// ```rust
-    /// use azure_functions::send_grid::MessageBuilder;
+    /// use azure_functions::bindings::SendGridMessage;
     ///
-    /// let message = MessageBuilder::build().send_at(1555890183).finish();
+    /// let message = SendGridMessage::build().send_at(1555890183).finish();
     ///
     /// assert_eq!(message.personalizations[0].send_at, Some(1555890183));
     /// ```
@@ -442,9 +442,9 @@ impl MessageBuilder {
     /// # Examples
     ///
     /// ```rust
-    /// use azure_functions::send_grid::MessageBuilder;
+    /// use azure_functions::bindings::SendGridMessage;
     ///
-    /// let message = MessageBuilder::build().from("foo@example.com").finish();
+    /// let message = SendGridMessage::build().from("foo@example.com").finish();
     ///
     /// assert_eq!(message.from.as_ref().unwrap().email, "foo@example.com");
     /// assert_eq!(message.from.as_ref().unwrap().name, None);
@@ -462,9 +462,9 @@ impl MessageBuilder {
     /// # Examples
     ///
     /// ```rust
-    /// use azure_functions::send_grid::MessageBuilder;
+    /// use azure_functions::bindings::SendGridMessage;
     ///
-    /// let message = MessageBuilder::build().from_with_name("foo@example.com", "Peter").finish();
+    /// let message = SendGridMessage::build().from_with_name("foo@example.com", "Peter").finish();
     ///
     /// assert_eq!(message.from.as_ref().unwrap().email, "foo@example.com");
     /// assert_eq!(message.from.as_ref().unwrap().name, Some("Peter".to_owned()));
@@ -484,9 +484,9 @@ impl MessageBuilder {
     /// # Examples
     ///
     /// ```rust
-    /// use azure_functions::send_grid::MessageBuilder;
+    /// use azure_functions::bindings::SendGridMessage;
     ///
-    /// let message = MessageBuilder::build().global_subject("hello world").finish();
+    /// let message = SendGridMessage::build().global_subject("hello world").finish();
     ///
     /// assert_eq!(message.subject, Some("hello world".to_owned()));
     /// ```
@@ -503,9 +503,9 @@ impl MessageBuilder {
     /// # Examples
     ///
     /// ```rust
-    /// use azure_functions::send_grid::MessageBuilder;
+    /// use azure_functions::bindings::SendGridMessage;
     ///
-    /// let message = MessageBuilder::build().content("hello world").finish();
+    /// let message = SendGridMessage::build().content("hello world").finish();
     ///
     /// assert_eq!(message.contents[0].mime_type, "text/plain");
     /// assert_eq!(message.contents[0].value, "hello world");
@@ -527,9 +527,9 @@ impl MessageBuilder {
     /// # Examples
     ///
     /// ```rust
-    /// use azure_functions::send_grid::MessageBuilder;
+    /// use azure_functions::bindings::SendGridMessage;
     ///
-    /// let message = MessageBuilder::build().content_with_type("hello world", "text/plain").finish();
+    /// let message = SendGridMessage::build().content_with_type("hello world", "text/plain").finish();
     ///
     /// assert_eq!(message.contents[0].mime_type, "text/plain");
     /// assert_eq!(message.contents[0].value, "hello world");
@@ -552,10 +552,10 @@ impl MessageBuilder {
     /// # Examples
     ///
     /// ```rust
-    /// use azure_functions::send_grid::MessageBuilder;
+    /// use azure_functions::bindings::SendGridMessage;
     /// use azure_functions::send_grid::Content;
     ///
-    /// let message = MessageBuilder::build()
+    /// let message = SendGridMessage::build()
     ///     .contents(
     ///         vec![
     ///             Content{ mime_type: "text/plain".to_owned(), value: "hello world".to_owned() }
@@ -578,12 +578,12 @@ impl MessageBuilder {
     /// # Examples
     ///
     /// ```rust
-    /// use azure_functions::send_grid::MessageBuilder;
+    /// use azure_functions::bindings::SendGridMessage;
     ///
     // @peterhuene I changed the content here because when I was reading through and saw the original string
     // it caused some initial confusion that it might be a secret key or a magical incantation. I don't want others
     // to pause on that same moment of confusion.
-    /// let message = MessageBuilder::build().attachment("hello.txt", "text/plain", "hello world").finish();
+    /// let message = SendGridMessage::build().attachment("hello.txt", "text/plain", "hello world").finish();
     ///
     /// assert_eq!(message.attachments[0].filename, "hello.txt");
     /// assert_eq!(message.attachments[0].mime_type, "text/plain");
@@ -609,9 +609,9 @@ impl MessageBuilder {
     /// # Examples
     ///
     /// ```rust
-    /// use azure_functions::send_grid::MessageBuilder;
+    /// use azure_functions::bindings::SendGridMessage;
     ///
-    /// let message = MessageBuilder::build().inline_attachment("hello.jpg", "image/jpeg", "hello world", "img_139db99fdb5c3704").finish();
+    /// let message = SendGridMessage::build().inline_attachment("hello.jpg", "image/jpeg", "hello world", "img_139db99fdb5c3704").finish();
     ///
     /// assert_eq!(message.attachments[0].filename, "hello.jpg");
     /// assert_eq!(message.attachments[0].mime_type, "image/jpeg");
@@ -647,10 +647,10 @@ impl MessageBuilder {
     /// # Examples
     ///
     /// ```rust
-    /// use azure_functions::send_grid::MessageBuilder;
+    /// use azure_functions::bindings::SendGridMessage;
     /// use azure_functions::send_grid::Attachment;
     ///
-    /// let message = MessageBuilder::build()
+    /// let message = SendGridMessage::build()
     ///     .attachments(
     ///         vec![
     ///             Attachment{ filename: "hello.txt".to_owned(), mime_type: "text/plain".to_owned(), content: "hello world".to_owned(), ..Default::default() }
@@ -673,10 +673,10 @@ impl MessageBuilder {
     ///
     /// # Examples
     /// ```rust
-    /// use azure_functions::send_grid::MessageBuilder;
+    /// use azure_functions::bindings::SendGridMessage;
     /// use azure_functions::send_grid::Attachment;
     ///
-    /// let message = MessageBuilder::build().template_id("id").finish();
+    /// let message = SendGridMessage::build().template_id("id").finish();
     ///
     /// assert_eq!(message.template_id, Some("id".to_owned()));
     /// ```
@@ -693,9 +693,9 @@ impl MessageBuilder {
     /// # Examples
     ///
     /// ```rust
-    /// use azure_functions::send_grid::MessageBuilder;
+    /// use azure_functions::bindings::SendGridMessage;
     ///
-    /// let message = MessageBuilder::build().section("foo", "bar").finish();
+    /// let message = SendGridMessage::build().section("foo", "bar").finish();
     ///
     /// assert_eq!(message.sections.get("foo").map(String::as_str), Some("bar"));
     /// ```
@@ -713,14 +713,14 @@ impl MessageBuilder {
     /// # Examples
     ///
     /// ```rust
-    /// use azure_functions::send_grid::MessageBuilder;
+    /// use azure_functions::bindings::SendGridMessage;
     /// use std::collections::HashMap;
     ///
     /// let mut sections = HashMap::new();
     /// sections.insert("foo".to_owned(), "bar".to_owned());
     /// sections.insert("bar".to_owned(), "baz".to_owned());
     ///
-    /// let message = MessageBuilder::build().sections(sections).finish();
+    /// let message = SendGridMessage::build().sections(sections).finish();
     ///
     /// assert_eq!(message.sections.get("foo").map(String::as_str), Some("bar"));
     /// assert_eq!(message.sections.get("bar").map(String::as_str), Some("baz"));
@@ -738,9 +738,9 @@ impl MessageBuilder {
     /// # Examples
     ///
     /// ```rust
-    /// use azure_functions::send_grid::MessageBuilder;
+    /// use azure_functions::bindings::SendGridMessage;
     ///
-    /// let message = MessageBuilder::build().category("foo").finish();
+    /// let message = SendGridMessage::build().category("foo").finish();
     ///
     /// assert_eq!(message.categories[0], "foo");
     /// ```
@@ -757,9 +757,9 @@ impl MessageBuilder {
     /// # Examples
     ///
     /// ```rust
-    /// use azure_functions::send_grid::MessageBuilder;
+    /// use azure_functions::bindings::SendGridMessage;
     ///
-    /// let message = MessageBuilder::build().categories(vec!["foo".to_owned(), "bar".to_owned(), "baz".to_owned()]).finish();
+    /// let message = SendGridMessage::build().categories(vec!["foo".to_owned(), "bar".to_owned(), "baz".to_owned()]).finish();
     ///
     /// assert_eq!(message.categories[0], "foo");
     /// assert_eq!(message.categories[1], "bar");
@@ -778,9 +778,9 @@ impl MessageBuilder {
     /// # Examples
     ///
     /// ```rust
-    /// use azure_functions::send_grid::MessageBuilder;
+    /// use azure_functions::bindings::SendGridMessage;
     ///
-    /// let message = MessageBuilder::build().global_header("foo", "bar").finish();
+    /// let message = SendGridMessage::build().global_header("foo", "bar").finish();
     ///
     /// assert_eq!(message.headers.get("foo").map(String::as_str), Some("bar"));
     /// ```
@@ -798,14 +798,14 @@ impl MessageBuilder {
     /// # Examples
     ///
     /// ```rust
-    /// use azure_functions::send_grid::MessageBuilder;
+    /// use azure_functions::bindings::SendGridMessage;
     /// use std::collections::HashMap;
     ///
     /// let mut headers = HashMap::new();
     /// headers.insert("foo".to_owned(), "bar".to_owned());
     /// headers.insert("bar".to_owned(), "baz".to_owned());
     ///
-    /// let message = MessageBuilder::build().global_headers(headers).finish();
+    /// let message = SendGridMessage::build().global_headers(headers).finish();
     ///
     /// assert_eq!(message.headers.get("foo").map(String::as_str), Some("bar"));
     /// assert_eq!(message.headers.get("bar").map(String::as_str), Some("baz"));
@@ -823,9 +823,9 @@ impl MessageBuilder {
     /// # Examples
     ///
     /// ```rust
-    /// use azure_functions::send_grid::MessageBuilder;
+    /// use azure_functions::bindings::SendGridMessage;
     ///
-    /// let message = MessageBuilder::build().global_custom_arg("foo", "bar").finish();
+    /// let message = SendGridMessage::build().global_custom_arg("foo", "bar").finish();
     ///
     /// assert_eq!(message.custom_args.get("foo").map(String::as_str), Some("bar"));
     /// ```
@@ -844,14 +844,14 @@ impl MessageBuilder {
     /// # Examples
     ///
     /// ```rust
-    /// use azure_functions::send_grid::MessageBuilder;
+    /// use azure_functions::bindings::SendGridMessage;
     /// use std::collections::HashMap;
     ///
     /// let mut args = HashMap::new();
     /// args.insert("foo".to_owned(), "bar".to_owned());
     /// args.insert("bar".to_owned(), "baz".to_owned());
     ///
-    /// let message = MessageBuilder::build().global_custom_args(args).finish();
+    /// let message = SendGridMessage::build().global_custom_args(args).finish();
     ///
     /// assert_eq!(message.custom_args.get("foo").map(String::as_str), Some("bar"));
     /// assert_eq!(message.custom_args.get("bar").map(String::as_str), Some("baz"));
@@ -873,9 +873,9 @@ impl MessageBuilder {
     /// # Examples
     ///
     /// ```rust
-    /// use azure_functions::send_grid::MessageBuilder;
+    /// use azure_functions::bindings::SendGridMessage;
     ///
-    /// let message = MessageBuilder::build().global_send_at(1555890183).finish();
+    /// let message = SendGridMessage::build().global_send_at(1555890183).finish();
     ///
     /// assert_eq!(message.send_at, Some(1555890183));
     /// ```
@@ -890,9 +890,9 @@ impl MessageBuilder {
     /// # Examples
     ///
     /// ```rust
-    /// use azure_functions::send_grid::MessageBuilder;
+    /// use azure_functions::bindings::SendGridMessage;
     ///
-    /// let message = MessageBuilder::build().batch_id("HkJ5yLYULb7Rj8GKSx7u025ouWVlMgAi").finish();
+    /// let message = SendGridMessage::build().batch_id("HkJ5yLYULb7Rj8GKSx7u025ouWVlMgAi").finish();
     ///
     /// assert_eq!(message.batch_id.unwrap(), "HkJ5yLYULb7Rj8GKSx7u025ouWVlMgAi");
     /// ```

--- a/azure-functions/src/send_grid/message_builder.rs
+++ b/azure-functions/src/send_grid/message_builder.rs
@@ -906,34 +906,22 @@ impl MessageBuilder {
         self.0
     }
 
-    // PRIVATE: Appends a `to` email address to the SendGrid message addresses.
     fn append_to(&mut self, address: EmailAddress) {
         self.append_personalization();
         self.0.personalizations[0].to.push(address);
     }
 
-    // PRIVATE: Appends a `cc` email address to the SendGrid message addresses.
     fn append_cc(&mut self, address: EmailAddress) {
         self.append_personalization();
         self.0.personalizations[0].cc.push(address);
     }
 
-    // PRIVATE: Appends a `bcc` email address to the SendGrid message addresses.
     fn append_bcc(&mut self, address: EmailAddress) {
         self.append_personalization();
         self.0.personalizations[0].bcc.push(address);
     }
 
-    // PRIVATE: Instantiate personalizations for the SendGrid message if none exists.
     fn append_personalization(&mut self) {
-        // if !self.0.personalizations.is_empty() {
-        //     return;
-        // }
-
-        // @peterhuene, I think this more clearly demonstrates the logic. What do you think?
-        // Additionally, though it may not be worth the refactoring, changing this function name from
-        // `append_personalization` to `instantiate_personalization` or `initialize_personalization`
-        // may disambiguate this function from the other `append...` functions.
         if self.0.personalizations.is_empty() {
             self.0.personalizations.push(Personalization {
                 ..Default::default()

--- a/azure-functions/src/send_grid/message_builder.rs
+++ b/azure-functions/src/send_grid/message_builder.rs
@@ -19,8 +19,13 @@ impl MessageBuilder {
     /// # Examples
     ///
     /// ```rust
-    /// # use azure_functions::send_grid::MessageBuilder;
-    /// let message = MessageBuilder::new().to("foo@example.com").build();
+    // @peterhuene, I removed a `#` from this example that I think was included by mistake.
+    // Just checking with you. It is repeated several places, but I think it's just an error propagated by
+    // copy/paste.
+    /// use azure_functions::send_grid::MessageBuilder;
+    ///
+    /// let message = MessageBuilder::build().to("foo@example.com").finish();
+    ///
     /// assert_eq!(message.personalizations[0].to[0].email, "foo@example.com");
     /// assert_eq!(message.personalizations[0].to[0].name, None);
     /// ```
@@ -37,8 +42,10 @@ impl MessageBuilder {
     /// # Examples
     ///
     /// ```rust
-    /// # use azure_functions::send_grid::MessageBuilder;
-    /// let message = MessageBuilder::new().to_with_name("foo@example.com", "Peter").build();
+    /// use azure_functions::send_grid::MessageBuilder;
+    ///
+    /// let message = MessageBuilder::build().to_with_name("foo@example.com", "Peter").finish();
+    ///
     /// assert_eq!(message.personalizations[0].to[0].email, "foo@example.com");
     /// assert_eq!(message.personalizations[0].to[0].name, Some("Peter".to_owned()));
     /// ```
@@ -57,13 +64,15 @@ impl MessageBuilder {
     /// # Examples
     ///
     /// ```rust
-    /// # use azure_functions::send_grid::MessageBuilder;
+    /// use azure_functions::send_grid::MessageBuilder;
     /// use azure_functions::send_grid::EmailAddress;
-    /// let message = MessageBuilder::new().tos(
+    ///
+    /// let message = MessageBuilder::build().tos(
     ///     vec![
     ///         EmailAddress::new("foo@example.com"),
     ///         EmailAddress::new_with_name("bar@example.com", "Peter"),
-    ///     ]).build();
+    ///     ]).finish();
+    ///
     /// assert_eq!(message.personalizations[0].to[0].email, "foo@example.com");
     /// assert_eq!(message.personalizations[0].to[0].name, None);
     /// assert_eq!(message.personalizations[0].to[1].email, "bar@example.com");
@@ -83,8 +92,10 @@ impl MessageBuilder {
     /// # Examples
     ///
     /// ```rust
-    /// # use azure_functions::send_grid::MessageBuilder;
-    /// let message = MessageBuilder::new().cc("foo@example.com").build();
+    /// use azure_functions::send_grid::MessageBuilder;
+    ///
+    /// let message = MessageBuilder::build().cc("foo@example.com").finish();
+    ///
     /// assert_eq!(message.personalizations[0].cc[0].email, "foo@example.com");
     /// assert_eq!(message.personalizations[0].cc[0].name, None);
     /// ```
@@ -101,8 +112,10 @@ impl MessageBuilder {
     /// # Examples
     ///
     /// ```rust
-    /// # use azure_functions::send_grid::MessageBuilder;
-    /// let message = MessageBuilder::new().cc_with_name("foo@example.com", "Peter").build();
+    /// use azure_functions::send_grid::MessageBuilder;
+    ///
+    /// let message = MessageBuilder::build().cc_with_name("foo@example.com", "Peter").finish();
+    ///
     /// assert_eq!(message.personalizations[0].cc[0].email, "foo@example.com");
     /// assert_eq!(message.personalizations[0].cc[0].name, Some("Peter".to_owned()));
     /// ```
@@ -120,13 +133,15 @@ impl MessageBuilder {
     /// # Examples
     ///
     /// ```rust
-    /// # use azure_functions::send_grid::MessageBuilder;
+    /// use azure_functions::send_grid::MessageBuilder;
     /// use azure_functions::send_grid::EmailAddress;
-    /// let message = MessageBuilder::new().ccs(
+    ///
+    /// let message = MessageBuilder::build().ccs(
     ///     vec![
     ///         EmailAddress::new("foo@example.com"),
     ///         EmailAddress::new_with_name("bar@example.com", "Peter"),
-    ///     ]).build();
+    ///     ]).finish();
+    ///
     /// assert_eq!(message.personalizations[0].cc[0].email, "foo@example.com");
     /// assert_eq!(message.personalizations[0].cc[0].name, None);
     /// assert_eq!(message.personalizations[0].cc[1].email, "bar@example.com");
@@ -146,8 +161,10 @@ impl MessageBuilder {
     /// # Examples
     ///
     /// ```rust
-    /// # use azure_functions::send_grid::MessageBuilder;
-    /// let message = MessageBuilder::new().bcc("foo@example.com").build();
+    /// use azure_functions::send_grid::MessageBuilder;
+    ///
+    /// let message = MessageBuilder::build().bcc("foo@example.com").finish();
+    ///
     /// assert_eq!(message.personalizations[0].bcc[0].email, "foo@example.com");
     /// assert_eq!(message.personalizations[0].bcc[0].name, None);
     /// ```
@@ -164,8 +181,10 @@ impl MessageBuilder {
     /// # Examples
     ///
     /// ```rust
-    /// # use azure_functions::send_grid::MessageBuilder;
-    /// let message = MessageBuilder::new().bcc_with_name("foo@example.com", "Peter").build();
+    /// use azure_functions::send_grid::MessageBuilder;
+    ///
+    /// let message = MessageBuilder::build().bcc_with_name("foo@example.com", "Peter").finish();
+    ///
     /// assert_eq!(message.personalizations[0].bcc[0].email, "foo@example.com");
     /// assert_eq!(message.personalizations[0].bcc[0].name, Some("Peter".to_owned()));
     /// ```
@@ -183,13 +202,15 @@ impl MessageBuilder {
     /// # Examples
     ///
     /// ```rust
-    /// # use azure_functions::send_grid::MessageBuilder;
+    /// use azure_functions::send_grid::MessageBuilder;
     /// use azure_functions::send_grid::EmailAddress;
-    /// let message = MessageBuilder::new().bccs(
+    ///
+    /// let message = MessageBuilder::build().bccs(
     ///     vec![
     ///         EmailAddress::new("foo@example.com"),
     ///         EmailAddress::new_with_name("bar@example.com", "Peter"),
-    ///     ]).build();
+    ///     ]).finish();
+    ///
     /// assert_eq!(message.personalizations[0].bcc[0].email, "foo@example.com");
     /// assert_eq!(message.personalizations[0].bcc[0].name, None);
     /// assert_eq!(message.personalizations[0].bcc[1].email, "bar@example.com");
@@ -209,8 +230,10 @@ impl MessageBuilder {
     /// # Examples
     ///
     /// ```rust
-    /// # use azure_functions::send_grid::MessageBuilder;
-    /// let message = MessageBuilder::new().subject("hello world!").build();
+    /// use azure_functions::send_grid::MessageBuilder;
+    ///
+    /// let message = MessageBuilder::build().subject("hello world!").finish();
+    ///
     /// assert_eq!(message.personalizations[0].subject, Some("hello world!".to_owned()));
     /// ```
     pub fn subject<T>(mut self, subject: T) -> MessageBuilder
@@ -227,8 +250,10 @@ impl MessageBuilder {
     /// # Examples
     ///
     /// ```rust
-    /// # use azure_functions::send_grid::MessageBuilder;
-    /// let message = MessageBuilder::new().header("foo", "bar").build();
+    /// use azure_functions::send_grid::MessageBuilder;
+    ///
+    /// let message = MessageBuilder::build().header("foo", "bar").finish();
+    ///
     /// assert_eq!(message.personalizations[0].headers.get("foo").map(String::as_str), Some("bar"));
     /// ```
     pub fn header<T, U>(mut self, key: T, value: U) -> MessageBuilder
@@ -248,12 +273,15 @@ impl MessageBuilder {
     /// # Examples
     ///
     /// ```rust
-    /// # use azure_functions::send_grid::MessageBuilder;
-    /// # use std::collections::HashMap;
+    /// use azure_functions::send_grid::MessageBuilder;
+    /// use std::collections::HashMap;
+    ///
     /// let mut headers = HashMap::new();
     /// headers.insert("foo".to_owned(), "bar".to_owned());
     /// headers.insert("bar".to_owned(), "baz".to_owned());
-    /// let message = MessageBuilder::new().headers(headers).build();
+    ///
+    /// let message = MessageBuilder::build().headers(headers).finish();
+    ///
     /// assert_eq!(message.personalizations[0].headers.get("foo").map(String::as_str), Some("bar"));
     /// assert_eq!(message.personalizations[0].headers.get("bar").map(String::as_str), Some("baz"));
     /// ```
@@ -271,8 +299,10 @@ impl MessageBuilder {
     /// # Examples
     ///
     /// ```rust
-    /// # use azure_functions::send_grid::MessageBuilder;
-    /// let message = MessageBuilder::new().substitution("foo", "bar").build();
+    /// use azure_functions::send_grid::MessageBuilder;
+    ///
+    /// let message = MessageBuilder::build().substitution("foo", "bar").finish();
+    ///
     /// assert_eq!(message.personalizations[0].substitutions.get("foo").map(String::as_str), Some("bar"));
     /// ```
     pub fn substitution<T, U>(mut self, key: T, value: U) -> MessageBuilder
@@ -292,12 +322,15 @@ impl MessageBuilder {
     /// # Examples
     ///
     /// ```rust
-    /// # use azure_functions::send_grid::MessageBuilder;
-    /// # use std::collections::HashMap;
+    /// use azure_functions::send_grid::MessageBuilder;
+    /// use std::collections::HashMap;
+    ///
     /// let mut substitutions = HashMap::new();
     /// substitutions.insert("foo".to_owned(), "bar".to_owned());
     /// substitutions.insert("bar".to_owned(), "baz".to_owned());
-    /// let message = MessageBuilder::new().substitutions(substitutions).build();
+    ///
+    /// let message = MessageBuilder::build().substitutions(substitutions).finish();
+    ///
     /// assert_eq!(message.personalizations[0].substitutions.get("foo").map(String::as_str), Some("bar"));
     /// assert_eq!(message.personalizations[0].substitutions.get("bar").map(String::as_str), Some("baz"));
     /// ```
@@ -317,9 +350,11 @@ impl MessageBuilder {
     /// # Examples
     ///
     /// ```rust
-    /// # use azure_functions::send_grid::MessageBuilder;
+    /// use azure_functions::send_grid::MessageBuilder;
     /// use serde_json::{json, to_string};
-    /// let message = MessageBuilder::new().template_data(json!({ "foo": "bar" })).build();
+    ///
+    /// let message = MessageBuilder::build().template_data(json!({ "foo": "bar" })).finish();
+    ///
     /// assert_eq!(to_string(message.personalizations[0].template_data.as_ref().unwrap()).unwrap(), r#"{"foo":"bar"}"#);
     /// ```
     pub fn template_data(mut self, data: Value) -> MessageBuilder {
@@ -338,8 +373,10 @@ impl MessageBuilder {
     /// # Examples
     ///
     /// ```rust
-    /// # use azure_functions::send_grid::MessageBuilder;
-    /// let message = MessageBuilder::new().custom_arg("foo", "bar").build();
+    /// use azure_functions::send_grid::MessageBuilder;
+    ///
+    /// let message = MessageBuilder::build().custom_arg("foo", "bar").finish();
+    ///
     /// assert_eq!(message.personalizations[0].custom_args.get("foo").map(String::as_str), Some("bar"));
     /// ```
     pub fn custom_arg<T, U>(mut self, key: T, value: U) -> MessageBuilder
@@ -359,12 +396,15 @@ impl MessageBuilder {
     /// # Examples
     ///
     /// ```rust
-    /// # use azure_functions::send_grid::MessageBuilder;
-    /// # use std::collections::HashMap;
+    /// use azure_functions::send_grid::MessageBuilder;
+    /// use std::collections::HashMap;
+    ///
     /// let mut args = HashMap::new();
     /// args.insert("foo".to_owned(), "bar".to_owned());
     /// args.insert("bar".to_owned(), "baz".to_owned());
-    /// let message = MessageBuilder::new().custom_args(args).build();
+    ///
+    /// let message = MessageBuilder::build().custom_args(args).finish();
+    ///
     /// assert_eq!(message.personalizations[0].custom_args.get("foo").map(String::as_str), Some("bar"));
     /// assert_eq!(message.personalizations[0].custom_args.get("bar").map(String::as_str), Some("baz"));
     /// ```
@@ -379,11 +419,16 @@ impl MessageBuilder {
 
     /// Sets the "send at" timestamp for the first personalization of the message.
     ///
+    /// > Note:
+    /// > This trait uses a Unix timestamp. A handy Unix timestamp converter can be found at [unixtimestamp.com/](https://www.unixtimestamp.com/)
+    ///
     /// # Examples
     ///
     /// ```rust
-    /// # use azure_functions::send_grid::MessageBuilder;
-    /// let message = MessageBuilder::new().send_at(1555890183).build();
+    /// use azure_functions::send_grid::MessageBuilder;
+    ///
+    /// let message = MessageBuilder::build().send_at(1555890183).finish();
+    ///
     /// assert_eq!(message.personalizations[0].send_at, Some(1555890183));
     /// ```
     pub fn send_at(mut self, timestamp: i64) -> MessageBuilder {
@@ -397,8 +442,10 @@ impl MessageBuilder {
     /// # Examples
     ///
     /// ```rust
-    /// # use azure_functions::send_grid::MessageBuilder;
-    /// let message = MessageBuilder::new().from("foo@example.com").build();
+    /// use azure_functions::send_grid::MessageBuilder;
+    ///
+    /// let message = MessageBuilder::build().from("foo@example.com").finish();
+    ///
     /// assert_eq!(message.from.as_ref().unwrap().email, "foo@example.com");
     /// assert_eq!(message.from.as_ref().unwrap().name, None);
     /// ```
@@ -415,8 +462,10 @@ impl MessageBuilder {
     /// # Examples
     ///
     /// ```rust
-    /// # use azure_functions::send_grid::MessageBuilder;
-    /// let message = MessageBuilder::new().from_with_name("foo@example.com", "Peter").build();
+    /// use azure_functions::send_grid::MessageBuilder;
+    ///
+    /// let message = MessageBuilder::build().from_with_name("foo@example.com", "Peter").finish();
+    ///
     /// assert_eq!(message.from.as_ref().unwrap().email, "foo@example.com");
     /// assert_eq!(message.from.as_ref().unwrap().name, Some("Peter".to_owned()));
     /// ```
@@ -435,8 +484,10 @@ impl MessageBuilder {
     /// # Examples
     ///
     /// ```rust
-    /// # use azure_functions::send_grid::MessageBuilder;
-    /// let message = MessageBuilder::new().global_subject("hello world").build();
+    /// use azure_functions::send_grid::MessageBuilder;
+    ///
+    /// let message = MessageBuilder::build().global_subject("hello world").finish();
+    ///
     /// assert_eq!(message.subject, Some("hello world".to_owned()));
     /// ```
     pub fn global_subject<T>(mut self, subject: T) -> MessageBuilder
@@ -452,8 +503,10 @@ impl MessageBuilder {
     /// # Examples
     ///
     /// ```rust
-    /// # use azure_functions::send_grid::MessageBuilder;
-    /// let message = MessageBuilder::new().content("hello world").build();
+    /// use azure_functions::send_grid::MessageBuilder;
+    ///
+    /// let message = MessageBuilder::build().content("hello world").finish();
+    ///
     /// assert_eq!(message.contents[0].mime_type, "text/plain");
     /// assert_eq!(message.contents[0].value, "hello world");
     /// ```
@@ -474,8 +527,10 @@ impl MessageBuilder {
     /// # Examples
     ///
     /// ```rust
-    /// # use azure_functions::send_grid::MessageBuilder;
-    /// let message = MessageBuilder::new().content_with_type("hello world", "text/plain").build();
+    /// use azure_functions::send_grid::MessageBuilder;
+    ///
+    /// let message = MessageBuilder::build().content_with_type("hello world", "text/plain").finish();
+    ///
     /// assert_eq!(message.contents[0].mime_type, "text/plain");
     /// assert_eq!(message.contents[0].value, "hello world");
     /// ```
@@ -497,14 +552,16 @@ impl MessageBuilder {
     /// # Examples
     ///
     /// ```rust
-    /// # use azure_functions::send_grid::MessageBuilder;
+    /// use azure_functions::send_grid::MessageBuilder;
     /// use azure_functions::send_grid::Content;
-    /// let message = MessageBuilder::new()
+    ///
+    /// let message = MessageBuilder::build()
     ///     .contents(
     ///         vec![
     ///             Content{ mime_type: "text/plain".to_owned(), value: "hello world".to_owned() }
     ///         ])
-    ///     .build();
+    ///     .finish();
+    ///
     /// assert_eq!(message.contents[0].mime_type, "text/plain");
     /// assert_eq!(message.contents[0].value, "hello world");
     /// ```
@@ -521,11 +578,16 @@ impl MessageBuilder {
     /// # Examples
     ///
     /// ```rust
-    /// # use azure_functions::send_grid::MessageBuilder;
-    /// let message = MessageBuilder::new().attachment("hello.txt", "text/plain", "aGVsbG8gd29ybGQ=").build();
+    /// use azure_functions::send_grid::MessageBuilder;
+    ///
+    // @peterhuene I changed the content here because when I was reading through and saw the original string
+    // it caused some initial confusion that it might be a secret key or a magical incantation. I don't want others
+    // to pause on that same moment of confusion.
+    /// let message = MessageBuilder::build().attachment("hello.txt", "text/plain", "hello world").finish();
+    ///
     /// assert_eq!(message.attachments[0].filename, "hello.txt");
     /// assert_eq!(message.attachments[0].mime_type, "text/plain");
-    /// assert_eq!(message.attachments[0].content, "aGVsbG8gd29ybGQ=");
+    /// assert_eq!(message.attachments[0].content, "hello world");
     /// ```
     pub fn attachment<T, U, V>(mut self, filename: T, mime_type: U, content: V) -> MessageBuilder
     where
@@ -547,11 +609,13 @@ impl MessageBuilder {
     /// # Examples
     ///
     /// ```rust
-    /// # use azure_functions::send_grid::MessageBuilder;
-    /// let message = MessageBuilder::new().inline_attachment("hello.jpg", "image/jpeg", "aGVsbG8gd29ybGQ=", "img_139db99fdb5c3704").build();
+    /// use azure_functions::send_grid::MessageBuilder;
+    ///
+    /// let message = MessageBuilder::build().inline_attachment("hello.jpg", "image/jpeg", "hello world", "img_139db99fdb5c3704").finish();
+    ///
     /// assert_eq!(message.attachments[0].filename, "hello.jpg");
     /// assert_eq!(message.attachments[0].mime_type, "image/jpeg");
-    /// assert_eq!(message.attachments[0].content, "aGVsbG8gd29ybGQ=");
+    /// assert_eq!(message.attachments[0].content, "hello world");
     /// assert_eq!(message.attachments[0].disposition, Some("inline".to_owned()));
     /// assert_eq!(message.attachments[0].content_id, Some("img_139db99fdb5c3704".to_owned()));
     /// ```
@@ -583,17 +647,19 @@ impl MessageBuilder {
     /// # Examples
     ///
     /// ```rust
-    /// # use azure_functions::send_grid::MessageBuilder;
+    /// use azure_functions::send_grid::MessageBuilder;
     /// use azure_functions::send_grid::Attachment;
-    /// let message = MessageBuilder::new()
+    ///
+    /// let message = MessageBuilder::build()
     ///     .attachments(
     ///         vec![
-    ///             Attachment{ filename: "hello.txt".to_owned(), mime_type: "text/plain".to_owned(), content: "aGVsbG8gd29ybGQ=".to_owned(), ..Default::default() }
+    ///             Attachment{ filename: "hello.txt".to_owned(), mime_type: "text/plain".to_owned(), content: "hello world".to_owned(), ..Default::default() }
     ///         ])
-    ///     .build();
+    ///     .finish();
+    ///
     /// assert_eq!(message.attachments[0].filename, "hello.txt");
     /// assert_eq!(message.attachments[0].mime_type, "text/plain");
-    /// assert_eq!(message.attachments[0].content, "aGVsbG8gd29ybGQ=");
+    /// assert_eq!(message.attachments[0].content, "hello world");
     /// ```
     pub fn attachments<T>(mut self, attachments: T) -> MessageBuilder
     where
@@ -607,9 +673,11 @@ impl MessageBuilder {
     ///
     /// # Examples
     /// ```rust
-    /// # use azure_functions::send_grid::MessageBuilder;
+    /// use azure_functions::send_grid::MessageBuilder;
     /// use azure_functions::send_grid::Attachment;
-    /// let message = MessageBuilder::new().template_id("id").build();
+    ///
+    /// let message = MessageBuilder::build().template_id("id").finish();
+    ///
     /// assert_eq!(message.template_id, Some("id".to_owned()));
     /// ```
     pub fn template_id<T>(mut self, id: T) -> MessageBuilder
@@ -625,8 +693,10 @@ impl MessageBuilder {
     /// # Examples
     ///
     /// ```rust
-    /// # use azure_functions::send_grid::MessageBuilder;
-    /// let message = MessageBuilder::new().section("foo", "bar").build();
+    /// use azure_functions::send_grid::MessageBuilder;
+    ///
+    /// let message = MessageBuilder::build().section("foo", "bar").finish();
+    ///
     /// assert_eq!(message.sections.get("foo").map(String::as_str), Some("bar"));
     /// ```
     pub fn section<T, U>(mut self, key: T, value: U) -> MessageBuilder
@@ -643,12 +713,15 @@ impl MessageBuilder {
     /// # Examples
     ///
     /// ```rust
-    /// # use azure_functions::send_grid::MessageBuilder;
-    /// # use std::collections::HashMap;
+    /// use azure_functions::send_grid::MessageBuilder;
+    /// use std::collections::HashMap;
+    ///
     /// let mut sections = HashMap::new();
     /// sections.insert("foo".to_owned(), "bar".to_owned());
     /// sections.insert("bar".to_owned(), "baz".to_owned());
-    /// let message = MessageBuilder::new().sections(sections).build();
+    ///
+    /// let message = MessageBuilder::build().sections(sections).finish();
+    ///
     /// assert_eq!(message.sections.get("foo").map(String::as_str), Some("bar"));
     /// assert_eq!(message.sections.get("bar").map(String::as_str), Some("baz"));
     /// ```
@@ -665,8 +738,10 @@ impl MessageBuilder {
     /// # Examples
     ///
     /// ```rust
-    /// # use azure_functions::send_grid::MessageBuilder;
-    /// let message = MessageBuilder::new().category("foo").build();
+    /// use azure_functions::send_grid::MessageBuilder;
+    ///
+    /// let message = MessageBuilder::build().category("foo").finish();
+    ///
     /// assert_eq!(message.categories[0], "foo");
     /// ```
     pub fn category<T>(mut self, category: T) -> MessageBuilder
@@ -682,8 +757,10 @@ impl MessageBuilder {
     /// # Examples
     ///
     /// ```rust
-    /// # use azure_functions::send_grid::MessageBuilder;
-    /// let message = MessageBuilder::new().categories(vec!["foo".to_owned(), "bar".to_owned(), "baz".to_owned()]).build();
+    /// use azure_functions::send_grid::MessageBuilder;
+    ///
+    /// let message = MessageBuilder::build().categories(vec!["foo".to_owned(), "bar".to_owned(), "baz".to_owned()]).finish();
+    ///
     /// assert_eq!(message.categories[0], "foo");
     /// assert_eq!(message.categories[1], "bar");
     /// assert_eq!(message.categories[2], "baz");
@@ -701,8 +778,10 @@ impl MessageBuilder {
     /// # Examples
     ///
     /// ```rust
-    /// # use azure_functions::send_grid::MessageBuilder;
-    /// let message = MessageBuilder::new().global_header("foo", "bar").build();
+    /// use azure_functions::send_grid::MessageBuilder;
+    ///
+    /// let message = MessageBuilder::build().global_header("foo", "bar").finish();
+    ///
     /// assert_eq!(message.headers.get("foo").map(String::as_str), Some("bar"));
     /// ```
     pub fn global_header<T, U>(mut self, key: T, value: U) -> MessageBuilder
@@ -719,12 +798,15 @@ impl MessageBuilder {
     /// # Examples
     ///
     /// ```rust
-    /// # use azure_functions::send_grid::MessageBuilder;
-    /// # use std::collections::HashMap;
+    /// use azure_functions::send_grid::MessageBuilder;
+    /// use std::collections::HashMap;
+    ///
     /// let mut headers = HashMap::new();
     /// headers.insert("foo".to_owned(), "bar".to_owned());
     /// headers.insert("bar".to_owned(), "baz".to_owned());
-    /// let message = MessageBuilder::new().global_headers(headers).build();
+    ///
+    /// let message = MessageBuilder::build().global_headers(headers).finish();
+    ///
     /// assert_eq!(message.headers.get("foo").map(String::as_str), Some("bar"));
     /// assert_eq!(message.headers.get("bar").map(String::as_str), Some("baz"));
     /// ```
@@ -741,8 +823,10 @@ impl MessageBuilder {
     /// # Examples
     ///
     /// ```rust
-    /// # use azure_functions::send_grid::MessageBuilder;
-    /// let message = MessageBuilder::new().global_custom_arg("foo", "bar").build();
+    /// use azure_functions::send_grid::MessageBuilder;
+    ///
+    /// let message = MessageBuilder::build().global_custom_arg("foo", "bar").finish();
+    ///
     /// assert_eq!(message.custom_args.get("foo").map(String::as_str), Some("bar"));
     /// ```
     pub fn global_custom_arg<T, U>(mut self, key: T, value: U) -> MessageBuilder
@@ -760,12 +844,15 @@ impl MessageBuilder {
     /// # Examples
     ///
     /// ```rust
-    /// # use azure_functions::send_grid::MessageBuilder;
-    /// # use std::collections::HashMap;
+    /// use azure_functions::send_grid::MessageBuilder;
+    /// use std::collections::HashMap;
+    ///
     /// let mut args = HashMap::new();
     /// args.insert("foo".to_owned(), "bar".to_owned());
     /// args.insert("bar".to_owned(), "baz".to_owned());
-    /// let message = MessageBuilder::new().global_custom_args(args).build();
+    ///
+    /// let message = MessageBuilder::build().global_custom_args(args).finish();
+    ///
     /// assert_eq!(message.custom_args.get("foo").map(String::as_str), Some("bar"));
     /// assert_eq!(message.custom_args.get("bar").map(String::as_str), Some("baz"));
     /// ```
@@ -780,11 +867,16 @@ impl MessageBuilder {
 
     /// Sets the global "send at" timestamp for all personalizations of the message.
     ///
+    /// > Note:
+    /// > This trait uses a Unix timestamp. A handy Unix timestamp converter can be found at [unixtimestamp.com/](https://www.unixtimestamp.com/)
+    ///
     /// # Examples
     ///
     /// ```rust
-    /// # use azure_functions::send_grid::MessageBuilder;
-    /// let message = MessageBuilder::new().global_send_at(1555890183).build();
+    /// use azure_functions::send_grid::MessageBuilder;
+    ///
+    /// let message = MessageBuilder::build().global_send_at(1555890183).finish();
+    ///
     /// assert_eq!(message.send_at, Some(1555890183));
     /// ```
     pub fn global_send_at(mut self, timestamp: i64) -> MessageBuilder {
@@ -798,8 +890,10 @@ impl MessageBuilder {
     /// # Examples
     ///
     /// ```rust
-    /// # use azure_functions::send_grid::MessageBuilder;
-    /// let message = MessageBuilder::new().batch_id("HkJ5yLYULb7Rj8GKSx7u025ouWVlMgAi").build();
+    /// use azure_functions::send_grid::MessageBuilder;
+    ///
+    /// let message = MessageBuilder::build().batch_id("HkJ5yLYULb7Rj8GKSx7u025ouWVlMgAi").finish();
+    ///
     /// assert_eq!(message.batch_id.unwrap(), "HkJ5yLYULb7Rj8GKSx7u025ouWVlMgAi");
     /// ```
     pub fn batch_id<T>(mut self, id: T) -> MessageBuilder
@@ -811,32 +905,42 @@ impl MessageBuilder {
     }
 
     /// Consumes the builder and returns the SendGrid message.
-    pub fn build(self) -> SendGridMessage {
+    pub fn finish(self) -> SendGridMessage {
         self.0
     }
 
+    // PRIVATE: Appends a `to` email address to the SendGrid message addresses.
     fn append_to(&mut self, address: EmailAddress) {
         self.append_personalization();
         self.0.personalizations[0].to.push(address);
     }
 
+    // PRIVATE: Appends a `cc` email address to the SendGrid message addresses.
     fn append_cc(&mut self, address: EmailAddress) {
         self.append_personalization();
         self.0.personalizations[0].cc.push(address);
     }
 
+    // PRIVATE: Appends a `bcc` email address to the SendGrid message addresses.
     fn append_bcc(&mut self, address: EmailAddress) {
         self.append_personalization();
         self.0.personalizations[0].bcc.push(address);
     }
 
+    // PRIVATE: Instantiate personalizations for the SendGrid message if none exists.
     fn append_personalization(&mut self) {
-        if !self.0.personalizations.is_empty() {
-            return;
-        }
+        // if !self.0.personalizations.is_empty() {
+        //     return;
+        // }
 
-        self.0.personalizations.push(Personalization {
-            ..Default::default()
-        });
+        // @peterhuene, I think this more clearly demonstrates the logic. What do you think?
+        // Additionally, though it may not be worth the refactoring, changing this function name from
+        // `append_personalization` to `instantiate_personalization` or `initialize_personalization`
+        // may disambiguate this function from the other `append...` functions.
+        if self.0.personalizations.is_empty() {
+            self.0.personalizations.push(Personalization {
+                ..Default::default()
+            });
+        }
     }
 }

--- a/azure-functions/src/send_grid/message_builder.rs
+++ b/azure-functions/src/send_grid/message_builder.rs
@@ -79,7 +79,7 @@ impl MessageBuilder {
     where
         T: IntoIterator<Item = EmailAddress>,
     {
-        self.append_personalization();
+        self.initialize_personalization();
         self.0.personalizations[0].to.extend(addresses);
         self
     }
@@ -148,7 +148,7 @@ impl MessageBuilder {
     where
         T: IntoIterator<Item = EmailAddress>,
     {
-        self.append_personalization();
+        self.initialize_personalization();
         self.0.personalizations[0].cc.extend(addresses);
         self
     }
@@ -217,7 +217,7 @@ impl MessageBuilder {
     where
         T: IntoIterator<Item = EmailAddress>,
     {
-        self.append_personalization();
+        self.initialize_personalization();
         self.0.personalizations[0].bcc.extend(addresses);
         self
     }
@@ -237,7 +237,7 @@ impl MessageBuilder {
     where
         T: Into<String>,
     {
-        self.append_personalization();
+        self.initialize_personalization();
         self.0.personalizations[0].subject = Some(subject.into());
         self
     }
@@ -258,7 +258,7 @@ impl MessageBuilder {
         T: Into<String>,
         U: Into<String>,
     {
-        self.append_personalization();
+        self.initialize_personalization();
         self.0.personalizations[0]
             .headers
             .insert(key.into(), value.into());
@@ -286,7 +286,7 @@ impl MessageBuilder {
     where
         T: IntoIterator<Item = (String, String)>,
     {
-        self.append_personalization();
+        self.initialize_personalization();
         self.0.personalizations[0].headers.extend(headers);
         self
     }
@@ -307,7 +307,7 @@ impl MessageBuilder {
         T: Into<String>,
         U: Into<String>,
     {
-        self.append_personalization();
+        self.initialize_personalization();
         self.0.personalizations[0]
             .substitutions
             .insert(key.into(), value.into());
@@ -335,7 +335,7 @@ impl MessageBuilder {
     where
         T: IntoIterator<Item = (String, String)>,
     {
-        self.append_personalization();
+        self.initialize_personalization();
         self.0.personalizations[0]
             .substitutions
             .extend(substitutions);
@@ -356,7 +356,7 @@ impl MessageBuilder {
     /// ```
     pub fn template_data(mut self, data: Value) -> MessageBuilder {
         if let Value::Object(map) = data {
-            self.append_personalization();
+            self.initialize_personalization();
             self.0.personalizations[0].template_data = Some(map);
         } else {
             panic!("template data must be a JSON object");
@@ -381,7 +381,7 @@ impl MessageBuilder {
         T: Into<String>,
         U: Into<String>,
     {
-        self.append_personalization();
+        self.initialize_personalization();
         self.0.personalizations[0]
             .custom_args
             .insert(key.into(), value.into());
@@ -409,7 +409,7 @@ impl MessageBuilder {
     where
         T: IntoIterator<Item = (String, String)>,
     {
-        self.append_personalization();
+        self.initialize_personalization();
         self.0.personalizations[0].custom_args.extend(args);
         self
     }
@@ -429,7 +429,7 @@ impl MessageBuilder {
     /// assert_eq!(message.personalizations[0].send_at, Some(1555890183));
     /// ```
     pub fn send_at(mut self, timestamp: i64) -> MessageBuilder {
-        self.append_personalization();
+        self.initialize_personalization();
         self.0.personalizations[0].send_at = Some(timestamp);
         self
     }
@@ -834,7 +834,7 @@ impl MessageBuilder {
         T: Into<String>,
         U: Into<String>,
     {
-        self.append_personalization();
+        self.initialize_personalization();
         self.0.custom_args.insert(key.into(), value.into());
         self
     }
@@ -860,7 +860,7 @@ impl MessageBuilder {
     where
         T: IntoIterator<Item = (String, String)>,
     {
-        self.append_personalization();
+        self.initialize_personalization();
         self.0.custom_args.extend(args);
         self
     }
@@ -880,7 +880,7 @@ impl MessageBuilder {
     /// assert_eq!(message.send_at, Some(1555890183));
     /// ```
     pub fn global_send_at(mut self, timestamp: i64) -> MessageBuilder {
-        self.append_personalization();
+        self.initialize_personalization();
         self.0.send_at = Some(timestamp);
         self
     }
@@ -910,21 +910,21 @@ impl MessageBuilder {
     }
 
     fn append_to(&mut self, address: EmailAddress) {
-        self.append_personalization();
+        self.initialize_personalization();
         self.0.personalizations[0].to.push(address);
     }
 
     fn append_cc(&mut self, address: EmailAddress) {
-        self.append_personalization();
+        self.initialize_personalization();
         self.0.personalizations[0].cc.push(address);
     }
 
     fn append_bcc(&mut self, address: EmailAddress) {
-        self.append_personalization();
+        self.initialize_personalization();
         self.0.personalizations[0].bcc.push(address);
     }
 
-    fn append_personalization(&mut self) {
+    fn initialize_personalization(&mut self) {
         if self.0.personalizations.is_empty() {
             self.0.personalizations.push(Personalization {
                 ..Default::default()

--- a/examples/blob/src/functions/create_blob.rs
+++ b/examples/blob/src/functions/create_blob.rs
@@ -12,7 +12,7 @@ pub fn create_blob(req: HttpRequest) -> (HttpResponse, Blob) {
         HttpResponse::build()
             .status(Status::Created)
             .body("blob has been created.")
-            .into(),
+            .finish(),
         req.body().as_bytes().into(),
     )
 }

--- a/examples/http/src/functions/greet_with_json.rs
+++ b/examples/http/src/functions/greet_with_json.rs
@@ -28,5 +28,5 @@ pub fn greet_with_json(req: HttpRequest) -> HttpResponse {
     HttpResponse::build()
         .status(Status::BadRequest)
         .body("Invalid JSON request.")
-        .into()
+        .finish()
 }

--- a/examples/sendgrid/src/functions/send_email.rs
+++ b/examples/sendgrid/src/functions/send_email.rs
@@ -1,6 +1,5 @@
 use azure_functions::{
     bindings::{HttpRequest, HttpResponse, SendGridMessage},
-    send_grid::MessageBuilder,
     func,
 };
 
@@ -11,10 +10,10 @@ pub fn send_email(req: HttpRequest) -> (HttpResponse, SendGridMessage) {
 
     (
         "The email was sent.".into(),
-        MessageBuilder::new()
+        SendGridMessage::build()
             .to(params.get("to").unwrap().as_str())
             .subject(params.get("subject").unwrap().as_str())
             .content(params.get("content").unwrap().as_str())
-            .build(),
+            .finish(),
     )
 }


### PR DESCRIPTION
Draft solution to issue #282.

[Link](https://github.com/peterhuene/azure-functions-rs/issues/282)

Co-authored-by: Peter Huene
@peterhuene <pehuene@microsoft.com>

## What is the goal of this pull request?

[Issue 282](https://github.com/peterhuene/azure-functions-rs/issues/282) is an enhancement towards the milestone of v0.9.0. It brings the HttpResponse and SendGridMessage bindings into alignment with the following pattern:

``` rust
let message = SendGridMessage::build().
	// parameters for message
	.finish();
```

and 

``` rust
let response = HttpResponse::build().
	// parameters for response
	.finish();
```

The `.finish()` name was chosen by @peterhuene. Peter, can you reference where this choice came from?


## What work remains to be done?

- Documentation must pass all tests.
- Are there additional tests for this pattern that could be added?

## Do you consider it adequately tested?

**YES** | NO

It's as tested as it was before.

## Related Issues

## Notes