### PR TITLE
Use tower-request-modifier.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -70,6 +70,7 @@ dependencies = [
  "tokio-threadpool 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
  "tower-grpc 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tower-hyper 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tower-request-modifier 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tower-service 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tower-util 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "xml-rs 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1696,6 +1697,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tower-request-modifier"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "futures 0.1.28 (registry+https://github.com/rust-lang/crates.io-index)",
+ "http 0.1.17 (registry+https://github.com/rust-lang/crates.io-index)",
+ "tower-service 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "tower-service"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2030,6 +2041,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum tower-http-util 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "442ba79e23bda499cdaa5ee52b3776bf08cb84a1d5ca6d3d82bfd4f12c1eefc3"
 "checksum tower-hyper 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "727d28cf51fc34a92c4201b08d53790608cb6edc0d285dfca260e043fa6529a5"
 "checksum tower-layer 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0ddf07e10c07dcc8f41da6de036dc66def1a85b70eb8a385159e3908bb258328"
+"checksum tower-request-modifier 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "f6af257a01ba5f7a5c6190a70220cceebe832fa836e689cb8f73cb0e53112af5"
 "checksum tower-service 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "2cc0c98637d23732f8de6dfd16494c9f1559c3b9e20b4a46462c8f9b9e827bfa"
 "checksum tower-util 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4792342fac093db5d2558655055a89a04ca909663467a4310c7739d9f8b64698"
 "checksum try-lock 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "e604eb7b43c06650e854be16a2a03155743d3752dd1c943f6829e26b7a36e382"

--- a/azure-functions/Cargo.toml
+++ b/azure-functions/Cargo.toml
@@ -16,6 +16,7 @@ tower-hyper = "0.1.0"
 tower-grpc = "0.1.0"
 tower-service = "0.2.0"
 tower-util = "0.1.0"
+tower-request-modifier = "0.1.0"
 log = { version = "0.4.6", features = ["std"] }
 futures01 = { package = "futures", version = "0.1.28" }
 futures-preview = { version = "0.3.0-alpha.17", features = ["compat"], optional = true }


### PR DESCRIPTION
This commit replaces the custom service that was used to set the origin on the
gRPC requests with `tower-request-modifier`.

Fixes #333.