### PR TITLE
Deserialize orchestration context

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -74,6 +74,7 @@ dependencies = [
  "serde 1.0.97 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.97 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_repr 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "tempfile 3.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio 0.1.22 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-threadpool 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1399,6 +1400,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_repr"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "proc-macro2 0.4.30 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.6.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.15.39 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "service-bus-example"
 version = "0.1.0"
 dependencies = [
@@ -2251,6 +2262,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum serde 1.0.97 (registry+https://github.com/rust-lang/crates.io-index)" = "d46b3dfedb19360a74316866cef04687cd4d6a70df8e6a506c63512790769b72"
 "checksum serde_derive 1.0.97 (registry+https://github.com/rust-lang/crates.io-index)" = "c22a0820adfe2f257b098714323563dd06426502abbbce4f51b72ef544c5027f"
 "checksum serde_json 1.0.40 (registry+https://github.com/rust-lang/crates.io-index)" = "051c49229f282f7c6f3813f8286cc1e3323e8051823fce42c7ea80fe13521704"
+"checksum serde_repr 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "29a734c298df0346c4cd5919595981c266dabbf12dc747c85e1a95e96077a52b"
 "checksum sha-1 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)" = "23962131a91661d643c98940b20fcaffe62d776a823247be80a48fcb8b6fce68"
 "checksum slab 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c111b5bd5695e56cffe5129854aa230b39c93a305372fdbb2668ca2394eea9f8"
 "checksum smallvec 0.6.10 (registry+https://github.com/rust-lang/crates.io-index)" = "ab606a9c5e214920bb66c458cd7be8ef094f813f20fe77a54cc7dbfff220d4b7"

--- a/azure-functions-codegen/src/func/invoker.rs
+++ b/azure-functions-codegen/src/func/invoker.rs
@@ -85,7 +85,7 @@ impl<'a> CommonInvokerTokens<'a> {
 
     fn get_orchestration_state_arg(&self, trigger: &Ident) -> TokenStream {
         if self.is_orchestration {
-            quote!(let __state = #trigger.as_ref().unwrap().get_state();)
+            quote!(let __state = #trigger.as_ref().unwrap().execution_result();)
         } else {
             TokenStream::new()
         }

--- a/azure-functions-shared-codegen/src/binding.rs
+++ b/azure-functions-shared-codegen/src/binding.rs
@@ -319,9 +319,7 @@ impl Field {
         let ident = &self.ident;
         match &self.ty {
             FieldType::Direction => quote!(#ident: Default::default()),
-            FieldType::OptionalString | FieldType::OptionalBoolean | FieldType::OptionalInteger => {
-                quote!(#ident)
-            }
+            FieldType::OptionalString | FieldType::OptionalBoolean | FieldType::OptionalInteger => quote!(#ident),
             FieldType::StringArray => quote!(#ident: #ident.unwrap_or(Cow::Borrowed(&[]))),
             _ => quote!(#ident: #ident.unwrap()),
         }
@@ -330,23 +328,13 @@ impl Field {
     pub fn get_quotable_decl(&self) -> TokenStream {
         let ident = &self.ident;
         match self.ty {
-            FieldType::String => {
-                quote!(let #ident = crate::codegen::quotable::QuotableBorrowedStr(&self.#ident);)
-            }
-            FieldType::OptionalString => {
-                quote!(let #ident = crate::codegen::quotable::QuotableOption(self.#ident.as_ref().map(|x| crate::codegen::quotable::QuotableBorrowedStr(x)));)
-            }
+            FieldType::String => quote!(let #ident = crate::codegen::quotable::QuotableBorrowedStr(&self.#ident);),
+            FieldType::OptionalString => quote!(let #ident = crate::codegen::quotable::QuotableOption(self.#ident.as_ref().map(|x| crate::codegen::quotable::QuotableBorrowedStr(x)));),
             FieldType::Boolean => quote!(let #ident = self.#ident;),
-            FieldType::Direction => {
-                quote!(let #ident = crate::codegen::quotable::QuotableDirection(self.#ident);)
-            }
-            FieldType::StringArray => {
-                quote!(let #ident = crate::codegen::quotable::QuotableStrArray(self.#ident.as_ref());)
-            }
+            FieldType::Direction => quote!(let #ident = crate::codegen::quotable::QuotableDirection(self.#ident);),
+            FieldType::StringArray => quote!(let #ident = crate::codegen::quotable::QuotableStrArray(self.#ident.as_ref());),
             FieldType::Integer => quote!(let #ident = self.#ident),
-            FieldType::OptionalBoolean | FieldType::OptionalInteger => {
-                quote!(let #ident = crate::codegen::quotable::QuotableOption(self.#ident);)
-            }
+            FieldType::OptionalBoolean | FieldType::OptionalInteger => quote!(let #ident = crate::codegen::quotable::QuotableOption(self.#ident);),
         }
     }
 

--- a/azure-functions/Cargo.toml
+++ b/azure-functions/Cargo.toml
@@ -26,6 +26,7 @@ tokio-threadpool = "0.1.15"
 serde = "1.0.97"
 serde_json = "1.0.40"
 serde_derive = "1.0.97"
+serde_repr = "0.1.4"
 chrono = { version = "0.4.7", features = ["serde"] }
 xml-rs = "0.8.0"
 lazy_static = "1.3.0"

--- a/azure-functions/src/bindings/durable_orchestration_context.rs
+++ b/azure-functions/src/bindings/durable_orchestration_context.rs
@@ -1,8 +1,10 @@
 use crate::{
-    durable::OrchestrationState,
+    durable::ExecutionResult,
     rpc::{typed_data::Data, TypedData},
 };
-use serde_json::from_str;
+//use chrono::{DateTime, Utc};
+use serde::Deserialize;
+use serde_json::{from_str, Value};
 use std::{cell::RefCell, collections::HashMap, rc::Rc};
 
 /// Represents the Durable Functions orchestration context binding.
@@ -19,24 +21,54 @@ use std::{cell::RefCell, collections::HashMap, rc::Rc};
 /// TODO: IMPLEMENT
 #[derive(Debug)]
 pub struct DurableOrchestrationContext {
-    state: Rc<RefCell<OrchestrationState>>,
+    data: DurableOrchestrationContextData,
+    state: Rc<RefCell<ExecutionResult>>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct DurableOrchestrationContextData {
+    instance_id: String,
+    is_replaying: bool,
+    parent_instance_id: Option<String>,
+    input: Value,
+    history: Option<Value>,
 }
 
 impl DurableOrchestrationContext {
     #[doc(hidden)]
     pub fn new(data: TypedData, _metadata: HashMap<String, TypedData>) -> Self {
-        DurableOrchestrationContext {
-            state: Rc::new(RefCell::new(match &data.data {
-                Some(Data::String(s)) => {
-                    from_str(s).expect("failed to parse orchestration context data")
-                }
-                _ => panic!("expected JSON data for orchestration context data"),
-            })),
+        match &data.data {
+            Some(Data::String(s)) => DurableOrchestrationContext {
+                data: from_str(s).expect("failed to parse orchestration context data"),
+                state: Rc::new(RefCell::new(ExecutionResult::default())),
+            },
+            _ => panic!("expected JSON data for orchestration context data"),
         }
     }
 
+    /// Gets the instance ID of the currently executing orchestration.
+    pub fn instance_id(&self) -> &str {
+        &self.data.instance_id
+    }
+
+    /// Gets the parent instance ID of the currently executing sub-orchestration.
+    pub fn parent_instance_id(&self) -> Option<&str> {
+        self.data.parent_instance_id.as_ref().map(|id| &**id)
+    }
+
+    /// Gets a value indicating whether the orchestrator function is currently replaying itself.
+    pub fn is_replaying(&self) -> bool {
+        self.data.is_replaying
+    }
+
+    /// The JSON-serializeable input to pass to the orchestrator function.
+    pub fn input(&self) -> &Value {
+        &self.data.input
+    }
+
     #[doc(hidden)]
-    pub fn get_state(&self) -> Rc<RefCell<OrchestrationState>> {
+    pub fn execution_result(&self) -> Rc<RefCell<ExecutionResult>> {
         self.state.clone()
     }
 }
@@ -81,13 +113,42 @@ mod tests {
     use crate::rpc::typed_data::Data;
 
     #[test]
-    fn it_constructs() {
+    #[should_panic(expected = "expected JSON data for orchestration context data")]
+    fn new_panics_if_no_data_provided() {
+        let data = TypedData { data: None };
+
+        let _ = DurableOrchestrationContext::new(data, HashMap::new());
+    }
+
+    #[test]
+    #[should_panic(expected = "failed to parse orchestration context data")]
+    fn new_panics_if_no_json_provided() {
         let data = TypedData {
             data: Some(Data::String(r#"{ }"#.to_owned())),
         };
 
         let _ = DurableOrchestrationContext::new(data, HashMap::new());
+    }
 
-        // TODO: implement
+    #[test]
+    fn new_constructs_a_orchestration_context_without_history() {
+        let data = TypedData {
+            data: Some(Data::String(
+                r#"{
+                "instanceId":"49497890673e4a75ab380e7a956c607b",
+                "isReplaying":false,
+                "parentInstanceId":null,
+                "input": []
+            }"#
+                .to_owned(),
+            )),
+        };
+
+        let context = DurableOrchestrationContext::new(data, HashMap::new());
+        assert_eq!(context.instance_id(), "49497890673e4a75ab380e7a956c607b");
+        assert_eq!(context.parent_instance_id(), None);
+        assert!(!context.is_replaying());
+        assert_eq!(context.data.history, None);
+        assert_eq!(context.input(), &serde_json::Value::Array(vec![]))
     }
 }

--- a/azure-functions/src/bindings/durable_orchestration_context.rs
+++ b/azure-functions/src/bindings/durable_orchestration_context.rs
@@ -125,6 +125,7 @@ mod tests {
 
     #[test]
     #[should_panic(expected = "failed to parse orchestration context data")]
+    fn new_panics_if_no_json_provided() {
         let data = TypedData {
             data: Some(Data::String(r#"{ }"#.to_owned())),
         };

--- a/azure-functions/src/bindings/durable_orchestration_context.rs
+++ b/azure-functions/src/bindings/durable_orchestration_context.rs
@@ -170,7 +170,24 @@ mod tests {
                         "IsPlayed":false,
                         "Timestamp":"2019-07-18T06:22:27.016757Z"
                     }
-                 ],
+
+                 ,
+                  {
+                     "OrchestrationInstance":{
+                        "InstanceId":"49497890673e4a75ab380e7a956c607b",
+                        "ExecutionId":"5d2025984bef476bbaacefaa499a4f5f"
+                     },
+                     "EventType":0,
+                     "ParentInstance":null,
+                     "Name":"HelloWorld",
+                     "Version":"",
+                     "Input":"{}",
+                     "Tags":null,
+                     "EventId":-1,
+                     "IsPlayed":false,
+                     "Timestamp":"2019-07-18T06:22:26.626966Z"
+                  }
+                  ],
                 "instanceId":"49497890673e4a75ab380e7a956c607b",
                 "isReplaying":false,
                 "parentInstanceId":null,
@@ -195,7 +212,30 @@ mod tests {
                     timestamp: DateTime::parse_from_rfc3339("2019-07-18T06:22:27.016757Z").unwrap(),
                     is_processed: false,
                     name: None,
-                    input: None
+                    input: None,
+                    result: None,
+                    task_scheduled_id: None,
+                    instance_id: None,
+                    reason: None,
+                    details: None,
+                    fire_at: None,
+                    timer_id: None
+                },
+                HistoryEvent {
+                    event_type:EventType::ExecutionStarted,
+                    event_id: -1,
+                    is_played: false,
+                    timestamp: DateTime::parse_from_rfc3339("2019-07-18T06:22:26.626966Z").unwrap(),
+                    is_processed: false,
+                    name: Some("HelloWorld".to_owned()),
+                    input: Some("{}".to_owned()),
+                    result: None,
+                    task_scheduled_id: None,
+                    instance_id: None,
+                    reason: None,
+                    details: None,
+                    fire_at: None,
+                    timer_id: None
                 }
             ])
         );

--- a/azure-functions/src/bindings/durable_orchestration_context.rs
+++ b/azure-functions/src/bindings/durable_orchestration_context.rs
@@ -23,7 +23,7 @@ use crate::{
 #[derive(Debug)]
 pub struct DurableOrchestrationContext {
     data: DurableOrchestrationContextData,
-    state: Rc<RefCell<ExecutionResult>>,
+    result: Rc<RefCell<ExecutionResult>>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -42,7 +42,7 @@ impl DurableOrchestrationContext {
         match &data.data {
             Some(Data::String(s)) => DurableOrchestrationContext {
                 data: from_str(s).expect("failed to parse orchestration context data"),
-                state: Rc::new(RefCell::new(ExecutionResult::default())),
+                result: Rc::new(RefCell::new(ExecutionResult::default())),
             },
             _ => panic!("expected JSON data for orchestration context data"),
         }
@@ -70,7 +70,7 @@ impl DurableOrchestrationContext {
 
     #[doc(hidden)]
     pub fn execution_result(&self) -> Rc<RefCell<ExecutionResult>> {
-        self.state.clone()
+        self.result.clone()
     }
 }
 
@@ -111,9 +111,9 @@ impl DurableOrchestrationContext {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::durable::{EventType, HistoryEvent};
     use crate::rpc::typed_data::Data;
     use chrono::DateTime;
-    use crate::durable::{HistoryEvent, EventType};
 
     #[test]
     #[should_panic(expected = "expected JSON data for orchestration context data")]
@@ -206,7 +206,7 @@ mod tests {
             context.data.history,
             Some(vec![
                 HistoryEvent {
-                    event_type:EventType::OrchestratorStarted,
+                    event_type: EventType::OrchestratorStarted,
                     event_id: -1,
                     is_played: false,
                     timestamp: DateTime::parse_from_rfc3339("2019-07-18T06:22:27.016757Z").unwrap(),
@@ -222,7 +222,7 @@ mod tests {
                     timer_id: None
                 },
                 HistoryEvent {
-                    event_type:EventType::ExecutionStarted,
+                    event_type: EventType::ExecutionStarted,
                     event_id: -1,
                     is_played: false,
                     timestamp: DateTime::parse_from_rfc3339("2019-07-18T06:22:26.626966Z").unwrap(),

--- a/azure-functions/src/durable.rs
+++ b/azure-functions/src/durable.rs
@@ -14,9 +14,11 @@ use std::{
 
 mod creation_urls;
 mod management_urls;
+mod history;
 
-pub use self::creation_urls::*;
-pub use self::management_urls::*;
+pub use creation_urls::*;
+pub use management_urls::*;
+pub use history::*;
 
 #[doc(hidden)]
 #[derive(Debug, Serialize, Deserialize, Default)]

--- a/azure-functions/src/durable.rs
+++ b/azure-functions/src/durable.rs
@@ -19,12 +19,13 @@ pub use self::creation_urls::*;
 pub use self::management_urls::*;
 
 #[doc(hidden)]
-#[derive(Debug, Serialize, Deserialize)]
-pub struct OrchestrationState {
+#[derive(Debug, Serialize, Deserialize, Default)]
+pub struct ExecutionResult {
     done: bool,
+    // TODO implements actions
 }
 
-impl OrchestrationState {
+impl ExecutionResult {
     fn mark_done(&mut self) {
         self.done = true;
     }
@@ -51,7 +52,7 @@ unsafe fn waker_drop(_: *const ()) {}
 pub fn orchestrate(
     id: String,
     func: impl Future<Output = ()>,
-    state: Rc<RefCell<OrchestrationState>>,
+    state: Rc<RefCell<ExecutionResult>>,
 ) -> InvocationResponse {
     let waker = unsafe {
         Waker::from_raw(RawWaker::new(

--- a/azure-functions/src/durable.rs
+++ b/azure-functions/src/durable.rs
@@ -13,12 +13,12 @@ use std::{
 };
 
 mod creation_urls;
-mod management_urls;
 mod history;
+mod management_urls;
 
 pub use creation_urls::*;
-pub use management_urls::*;
 pub use history::*;
+pub use management_urls::*;
 
 #[doc(hidden)]
 #[derive(Debug, Serialize, Deserialize, Default)]

--- a/azure-functions/src/durable/history.rs
+++ b/azure-functions/src/durable/history.rs
@@ -51,9 +51,10 @@ pub struct HistoryEvent {
     pub(crate) timer_id: Option<i32>,
 }
 
+#[doc(hidden)]
 #[derive(Debug, Clone, Deserialize_repr, PartialEq)]
 #[repr(u8)]
-pub enum EventType {
+pub(crate) enum EventType {
     ExecutionStarted = 0,
     ExecutionCompleted = 1,
     ExecutionFailed = 2,

--- a/azure-functions/src/durable/history.rs
+++ b/azure-functions/src/durable/history.rs
@@ -2,18 +2,53 @@ use chrono::{DateTime, FixedOffset};
 use serde::Deserialize;
 use serde_repr::Deserialize_repr;
 
+// TODO refactor this to make enum HistoryEvent that for each value it will have its own struct
+// enum HistoryEvent { ExecutionStarted(ExecutionStartedEvent), ... }
+// serde now doesn't support elegant conversion from json to tagged enums with custom tag value out of the box.
+// i.e conversion { EventType = 0, EventId = 1, ...} => ExecutionStarted(ExecutionStartedEvent)
+// in future we can implement manual translation
+
 #[doc(hidden)]
 #[derive(Debug, Clone, Deserialize, PartialEq)]
 #[serde(rename_all = "PascalCase")]
 pub struct HistoryEvent {
     pub(crate) event_type: EventType,
+
     pub(crate) event_id: i32,
+
     pub(crate) is_played: bool,
+
     pub(crate) timestamp: DateTime<FixedOffset>,
+
     #[serde(default)]
     pub(crate) is_processed: bool,
+
+    // EventRaised, ExecutionStarted, SubOrchestrationInstanceCreated, TaskScheduled
     pub(crate) name: Option<String>,
+
+    // EventRaised, ExecutionStarted, SubOrchestrationInstanceCreated, TaskScheduled
     pub(crate) input: Option<String>,
+
+    //SubOrchestrationInstanceCompleted, TaskCompleted
+    pub(crate) result: Option<String>,
+
+    // SubOrchestrationInstanceCompleted , SubOrchestrationInstanceFailed, TaskCompleted,TaskFailed
+    pub(crate) task_scheduled_id: Option<i32>,
+
+    // SubOrchestrationInstanceCreated
+    pub(crate) instance_id: Option<String>,
+
+    //SubOrchestrationInstanceFailed, TaskFailed
+    pub(crate) reason: Option<String>,
+
+    // SubOrchestrationInstanceFailed,TaskFailed
+    pub(crate) details: Option<String>,
+
+    //TimerCreated, TimerFired
+    pub(crate) fire_at: Option<DateTime<FixedOffset>>,
+
+    //TimerFired
+    pub(crate) timer_id: Option<i32>,
 }
 
 #[derive(Debug, Clone, Deserialize_repr, PartialEq)]
@@ -34,8 +69,12 @@ pub enum EventType {
     OrchestratorStarted = 12,
     OrchestratorCompleted = 13,
     EventSent = 14,
+    // not supported in js
     EventRaised = 15,
+    // not supported in js
     ContinueAsNew = 16,
+    // not supported in js
     GenericEvent = 17,
+    // not supported in js
     HistoryState = 18,
 }

--- a/azure-functions/src/durable/history.rs
+++ b/azure-functions/src/durable/history.rs
@@ -1,0 +1,41 @@
+use chrono::{DateTime, FixedOffset};
+use serde::Deserialize;
+use serde_repr::Deserialize_repr;
+
+#[doc(hidden)]
+#[derive(Debug, Clone, Deserialize, PartialEq)]
+#[serde(rename_all = "PascalCase")]
+pub struct HistoryEvent {
+    pub(crate) event_type: EventType,
+    pub(crate) event_id: i32,
+    pub(crate) is_played: bool,
+    pub(crate) timestamp: DateTime<FixedOffset>,
+    #[serde(default)]
+    pub(crate) is_processed: bool,
+    pub(crate) name: Option<String>,
+    pub(crate) input: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize_repr, PartialEq)]
+#[repr(u8)]
+pub enum EventType {
+    ExecutionStarted = 0,
+    ExecutionCompleted = 1,
+    ExecutionFailed = 2,
+    ExecutionTerminated = 3,
+    TaskScheduled = 4,
+    TaskCompleted = 5,
+    TaskFailed = 6,
+    SubOrchestrationInstanceCreated = 7,
+    SubOrchestrationInstanceCompleted = 8,
+    SubOrchestrationInstanceFailed = 9,
+    TimerCreated = 10,
+    TimerFired = 11,
+    OrchestratorStarted = 12,
+    OrchestratorCompleted = 13,
+    EventSent = 14,
+    EventRaised = 15,
+    ContinueAsNew = 16,
+    GenericEvent = 17,
+    HistoryState = 18,
+}


### PR DESCRIPTION
## What is the goal of this pull request?
Add support of conversion from `json` to `DurableOrchestrationContext`
## What does this pull request change?
Parses context binding from `json` to rust struct and initializes `DurableOrchestrationContext`
## What work remains to be done?
Implement custom conversion to get elegant structure of history events
## Do you consider it adequately tested?
YES