### PR TITLE
Add `activity_output`

### DIFF
--- a/azure-functions/src/durable.rs
+++ b/azure-functions/src/durable.rs
@@ -23,6 +23,10 @@ pub use creation_urls::*;
 pub use history::*;
 pub use management_urls::*;
 
+pub use self::activity_output::*;
+pub use self::creation_urls::*;
+pub use self::management_urls::*;
+
 #[doc(hidden)]
 #[derive(Debug, Serialize, Default)]
 pub struct ExecutionResult {

--- a/azure-functions/src/durable.rs
+++ b/azure-functions/src/durable.rs
@@ -13,6 +13,7 @@ use std::{
 };
 
 mod actions;
+mod activity_output;
 mod creation_urls;
 mod history;
 mod management_urls;

--- a/azure-functions/src/durable/activity_output.rs
+++ b/azure-functions/src/durable/activity_output.rs
@@ -1,0 +1,25 @@
+use serde_json::Value;
+
+/// # Activity Output
+/// 
+/// Type returned by Activity Functions for Durable Functions
+
+struct ActivityOutput(serde_json::Value);
+
+impl<T> From<T> for ActivityOutput
+where
+    T: Into<Value>,
+{
+    fn from(t: T) -> Self {
+        ActivityOutput(t.into())
+    }
+}
+
+#[doc(hidden)]
+impl Into<TypedData> for ActivityOutput {
+    fn into(self) -> TypedData {
+        TypedData {
+            data: Some(Data::Json(self.0.to_string())),
+        }
+    }
+}

--- a/azure-functions/src/durable/activity_output.rs
+++ b/azure-functions/src/durable/activity_output.rs
@@ -1,7 +1,8 @@
+use crate::rpc::{typed_data::Data, TypedData};
 use serde_json::Value;
 
 /// # Activity Output
-/// 
+///
 /// Type returned by Activity Functions for Durable Functions
 
 struct ActivityOutput(serde_json::Value);
@@ -21,5 +22,35 @@ impl Into<TypedData> for ActivityOutput {
         TypedData {
             data: Some(Data::Json(self.0.to_string())),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn it_converts_from_json() {
+        let activity_output: ActivityOutput = json!({ "foo": "bar" }).into();
+
+        let data: TypedData = activity_output.into();
+        assert_eq!(data.data, Some(Data::Json(r#"{"foo":"bar"}"#.to_string())));
+    }
+
+    #[test]
+    fn it_converts_from_bool() {
+        let activity_output: ActivityOutput = true.into();
+
+        let data: TypedData = activity_output.into();
+        assert_eq!(data.data, Some(Data::Json(true.to_string())));
+    }
+
+    #[test]
+    fn it_converts_from_string() {
+        let activity_output: ActivityOutput = "foo".into();
+
+        let data: TypedData = activity_output.into();
+        assert_eq!(data.data, Some(Data::Json("\"foo\"".to_string())));
     }
 }


### PR DESCRIPTION
## What is the goal of this pull request?

Add a type returned by Activity Functions.

## What does this pull request change?

Creates a new file `azure-functions/src/durable/activity_output.rs` with the ActivityOutput type.

## What work remains to be done?

Add test, docs, flesh out if this is the right approach.

## Do you consider it adequately tested?

NO, I should add some unit tests while we draft this.
