### PR TITLE
Serialize execution result to json

### DIFF
--- a/azure-functions/src/durable.rs
+++ b/azure-functions/src/durable.rs
@@ -12,10 +12,12 @@ use std::{
     task::{Context, Poll, RawWaker, RawWakerVTable, Waker},
 };
 
+mod actions;
 mod creation_urls;
 mod history;
 mod management_urls;
 
+pub use actions::*;
 pub use creation_urls::*;
 pub use history::*;
 pub use management_urls::*;
@@ -24,7 +26,7 @@ pub use management_urls::*;
 #[derive(Debug, Serialize, Deserialize, Default)]
 pub struct ExecutionResult {
     done: bool,
-    // TODO implements actions
+    actions: Vec<Action>
 }
 
 impl ExecutionResult {

--- a/azure-functions/src/durable.rs
+++ b/azure-functions/src/durable.rs
@@ -2,8 +2,8 @@
 use crate::rpc::{
     status_result::Status, typed_data::Data, InvocationResponse, StatusResult, TypedData,
 };
-use serde::{Deserialize, Serialize};
-use serde_json::to_string;
+use serde::Serialize;
+use serde_json::{to_string, Value};
 use std::{
     cell::RefCell,
     future::Future,
@@ -23,10 +23,13 @@ pub use history::*;
 pub use management_urls::*;
 
 #[doc(hidden)]
-#[derive(Debug, Serialize, Deserialize, Default)]
+#[derive(Debug, Serialize, Default)]
 pub struct ExecutionResult {
     done: bool,
-    actions: Vec<Action>
+    actions: Vec<Action>,
+    output: Option<bool>,
+    custom_status: Option<Value>,
+    error: Option<String>,
 }
 
 impl ExecutionResult {

--- a/azure-functions/src/durable.rs
+++ b/azure-functions/src/durable.rs
@@ -27,7 +27,7 @@ pub use management_urls::*;
 pub struct ExecutionResult {
     done: bool,
     actions: Vec<Action>,
-    output: Option<bool>,
+    output: Option<Value>,
     custom_status: Option<Value>,
     error: Option<String>,
 }

--- a/azure-functions/src/durable/actions.rs
+++ b/azure-functions/src/durable/actions.rs
@@ -1,0 +1,134 @@
+use chrono::{DateTime, FixedOffset};
+use serde::Serialize;
+use serde_json::Value;
+
+#[doc(hidden)]
+#[derive(Debug, Clone, Serialize, PartialEq)]
+#[serde(tag = "actionType", rename_all = "camelCase")]
+pub enum Action {
+    #[serde(rename_all = "camelCase")]
+    CallActivity { function_name: String, input: Value },
+
+    #[serde(rename_all = "camelCase")]
+    CallActivityWithRetry {
+        function_name: String,
+        retry_options: RetryOptions,
+        input: Value,
+    },
+
+    #[serde(rename_all = "camelCase")]
+    CallSubOrchestrator {
+        function_name: String,
+        instance_id: Option<String>,
+        input: Value,
+    },
+
+    #[serde(rename_all = "camelCase")]
+    CallSubOrchestratorWithRetry {
+        function_name: String,
+        retry_options: RetryOptions,
+        instance_id: Option<String>,
+        input: Value,
+    },
+
+    #[serde(rename_all = "camelCase")]
+    ContinueAsNew { input: Value },
+
+    #[serde(rename_all = "camelCase")]
+    CreateTimer {
+        fire_at: DateTime<FixedOffset>,
+        is_cancelled: bool,
+    },
+
+    #[serde(rename_all = "camelCase")]
+    WaitForExternalEvent { external_event_name: String },
+}
+
+#[doc(hidden)]
+#[derive(Debug, Clone, Serialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct RetryOptions {
+    first_retry_interval_in_milliseconds: i32,
+    max_number_of_attempts: i32,
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::durable::{Action, RetryOptions};
+    use chrono::DateTime;
+
+    macro_rules! it_converts_to_json {
+        ($($name:ident: $value:expr,)*) => {
+            $(
+                #[test]
+                fn $name() {
+                    let (action, expected) = $value;
+                    let json = serde_json::to_string(&action).unwrap();
+                    assert_eq!(expected, json);
+                }
+            )*
+            }
+        }
+    it_converts_to_json! {
+        call_activity_converts_to_json:
+        (
+            Action::CallActivity {
+                function_name: "hello".to_owned(),
+                input: "World".into(),
+            },
+            r#"{"actionType":"callActivity","functionName":"hello","input":"World"}"#
+        ),
+        call_activity_with_retry_converts_to_json:
+        (
+            Action::CallActivityWithRetry {
+                function_name: "hello".to_owned(),
+                retry_options: RetryOptions {
+                    first_retry_interval_in_milliseconds: 1000,
+                    max_number_of_attempts: 3,
+                },
+                input: "World".into(),
+            },
+            r#"{"actionType":"callActivityWithRetry","functionName":"hello","retryOptions":{"firstRetryIntervalInMilliseconds":1000,"maxNumberOfAttempts":3},"input":"World"}"#
+        ),
+        call_sub_orchestrator_converts_to_json:
+        (
+            Action::CallSubOrchestrator {
+                function_name: "hello".to_string(),
+                instance_id: Some("1231232144".to_string()),
+                input: "World".into()
+            },
+            r#"{"actionType":"callSubOrchestrator","functionName":"hello","instanceId":"1231232144","input":"World"}"#
+        ),
+        call_sub_orchestrator_with_retry_converts_to_json:
+        (
+            Action::CallSubOrchestratorWithRetry {
+                function_name: "hello".to_string(),
+                retry_options: RetryOptions {
+                    first_retry_interval_in_milliseconds: 1000,
+                    max_number_of_attempts: 3,
+                },
+                instance_id: Some("1231232144".to_string()),
+                input: "World".into()
+            },
+            r#"{"actionType":"callSubOrchestratorWithRetry","functionName":"hello","retryOptions":{"firstRetryIntervalInMilliseconds":1000,"maxNumberOfAttempts":3},"instanceId":"1231232144","input":"World"}"#
+        ),
+        continue_as_new_converts_to_json:
+        (
+            Action::ContinueAsNew { input: "World".into() },
+            r#"{"actionType":"continueAsNew","input":"World"}"#
+        ),
+        create_timer_converts_to_json:
+        (
+           Action::CreateTimer {
+                fire_at: DateTime::parse_from_rfc3339("2019-07-18T06:22:27.016757+00:00").unwrap(),
+                is_cancelled: true,
+           },
+           r#"{"actionType":"createTimer","fireAt":"2019-07-18T06:22:27.016757+00:00","isCancelled":true}"#
+        ),
+        wait_for_external_event_converts_to_json:
+        (
+            Action::WaitForExternalEvent { external_event_name: "SmsChallengeResponse".to_string() },
+            r#"{"actionType":"waitForExternalEvent","externalEventName":"SmsChallengeResponse"}"#
+        ),
+    }
+}


### PR DESCRIPTION
## What is the goal of this pull request?
Make execution context to serialize into `json`
## What does this pull request change?
Adds a list of actions and other fields necessary for `ExecutionResult` to be a valid response to the function execution result.
## What work remains to be done?
Additional tests?
## Do you consider it adequately tested?
YES