### PR TITLE
Add OrchestrationOutput

### DIFF
--- a/azure-functions/src/durable.rs
+++ b/azure-functions/src/durable.rs
@@ -17,7 +17,7 @@ mod activity_output;
 mod creation_urls;
 mod history;
 mod management_urls;
-mod orchestrator_output;
+mod orchestration_output;
 
 pub use actions::*;
 pub use creation_urls::*;
@@ -27,7 +27,7 @@ pub use management_urls::*;
 pub use self::activity_output::*;
 pub use self::creation_urls::*;
 pub use self::management_urls::*;
-pub use self::orchestrator_output::*;
+pub use self::orchestration_output::*;
 
 #[doc(hidden)]
 #[derive(Debug, Serialize, Default)]

--- a/azure-functions/src/durable.rs
+++ b/azure-functions/src/durable.rs
@@ -17,6 +17,7 @@ mod activity_output;
 mod creation_urls;
 mod history;
 mod management_urls;
+mod orchestrator_output;
 
 pub use actions::*;
 pub use creation_urls::*;
@@ -26,6 +27,7 @@ pub use management_urls::*;
 pub use self::activity_output::*;
 pub use self::creation_urls::*;
 pub use self::management_urls::*;
+pub use self::orchestrator_output::*;
 
 #[doc(hidden)]
 #[derive(Debug, Serialize, Default)]

--- a/azure-functions/src/durable/orchestration_output.rs
+++ b/azure-functions/src/durable/orchestration_output.rs
@@ -1,0 +1,56 @@
+use crate::rpc::{typed_data::Data, TypedData};
+use serde_json::Value;
+
+/// # Orchestration Output
+/// 
+/// Type returned by Orchetrator Functions for Durable Functions
+
+struct OrchestrationOutput(serde_json::Value);
+
+impl<T> From<T> for OrchestrationOutput
+where 
+    T: Into<Value>,
+{
+    fn from(t: T) -> Self {
+        OrchestrationOutput(t.into())
+    }
+}
+
+#[doc(hidden)]
+impl Into<TypedData> for OrchestrationOutput {
+    fn into(self) -> TypedData {
+        TypedData {
+            data: Some(Data::Json(self.0.to_string())),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn it_converts_from_json() {
+        let orchestration_output: OrchestrationOutput = json!({"foo": "bar"}).into();
+
+        let data: TypedData = activity_output.into();
+        assert_eq!(data.data, Some(Data::Json(r#"{"foo":"bar"}"#.to_string())));
+    }
+
+    #[test]
+    fn it_converts_from_bool() {
+        let orchestration_output: OrchestrationOutput = true.into();
+
+        let data: TypedData = Orchestration_output.into();
+        assert_eq!(data.data, Some(Data::Json(true.to_string())));
+    }
+
+    #[test]
+    fn it_converts_from_string() {
+        let orchestration_output: OrchestrationOutput = "foo".into();
+
+        let data: TypedData = orchestration_output.into();
+        assert_eq!(data.data, Some(Data::Json("\"foo\"".to_string())));
+    }
+}

--- a/azure-functions/src/durable/orchestration_output.rs
+++ b/azure-functions/src/durable/orchestration_output.rs
@@ -1,14 +1,13 @@
-use crate::rpc::{typed_data::Data, TypedData};
 use serde_json::Value;
 
 /// # Orchestration Output
-/// 
+///
 /// Type returned by Orchetrator Functions for Durable Functions
 
 struct OrchestrationOutput(serde_json::Value);
 
 impl<T> From<T> for OrchestrationOutput
-where 
+where
     T: Into<Value>,
 {
     fn from(t: T) -> Self {
@@ -16,12 +15,9 @@ where
     }
 }
 
-#[doc(hidden)]
-impl Into<TypedData> for OrchestrationOutput {
-    fn into(self) -> TypedData {
-        TypedData {
-            data: Some(Data::Json(self.0.to_string())),
-        }
+impl OrchestrationOutput {
+    pub(crate) fn to_value(self) -> Value {
+        self.0
     }
 }
 
@@ -34,23 +30,23 @@ mod tests {
     fn it_converts_from_json() {
         let orchestration_output: OrchestrationOutput = json!({"foo": "bar"}).into();
 
-        let data: TypedData = activity_output.into();
-        assert_eq!(data.data, Some(Data::Json(r#"{"foo":"bar"}"#.to_string())));
+        let data: Value = orchestration_output.to_value();
+        assert_eq!(data, json!({"foo": "bar"}));
     }
 
     #[test]
     fn it_converts_from_bool() {
         let orchestration_output: OrchestrationOutput = true.into();
 
-        let data: TypedData = Orchestration_output.into();
-        assert_eq!(data.data, Some(Data::Json(true.to_string())));
+        let data: Value = orchestration_output.to_value();
+        assert_eq!(data, json!(true));
     }
 
     #[test]
     fn it_converts_from_string() {
         let orchestration_output: OrchestrationOutput = "foo".into();
 
-        let data: TypedData = orchestration_output.into();
-        assert_eq!(data.data, Some(Data::Json("\"foo\"".to_string())));
+        let data: Value = orchestration_output.to_value();
+        assert_eq!(data, json!("\"foo\"".to_string()));
     }
 }


### PR DESCRIPTION
## What is the goal of this pull request?

Add OrchestrationOutput return type for Orchestrator Functions

## What does this pull request change?

Adds mod `orchestration_output` and exposes it in `durable`

## What work remains to be done?

Documentation

## Do you consider it adequately tested?

YES


This is essentially the same as the ActivityOutput type. Are there any changes worth making to this?