### PR TITLE
Implement return values for activity functions.

### DIFF
--- a/azure-functions-codegen/src/func.rs
+++ b/azure-functions-codegen/src/func.rs
@@ -24,6 +24,8 @@ use syn::{
 pub const OUTPUT_BINDING_PREFIX: &str = "output";
 const RETURN_BINDING_NAME: &str = "$return";
 const ORCHESTRATION_CONTEXT_TYPE: &str = "DurableOrchestrationContext";
+const ACTIVITY_CONTEXT_TYPE: &str = "DurableActivityContext";
+const ACTIVITY_OUTPUT_TYPE: &str = "ActivityOutput";
 
 fn has_parameter_of_type(func: &ItemFn, type_name: &str) -> bool {
     func.decl.inputs.iter().any(|arg| {
@@ -80,6 +82,44 @@ fn validate_orchestration_function(func: &ItemFn) {
             ty.span(),
             "orchestration functions cannot have return types",
         );
+    }
+}
+
+fn validate_activity_function(func: &ItemFn) {
+    // Activity functions cannot have a $return binding
+    // Default, -> ActivityOutput, and -> (ActivityOutput, ...) are acceptable
+
+    fn validate_return_binding(ty: &Type) {
+        match ty {
+            Type::Tuple(tuple) => {
+                if let Some(first) = tuple.elems.iter().nth(0) {
+                    validate_return_binding(first)
+                }
+            }
+            Type::Paren(tp) => validate_return_binding(&*tp.elem),
+            Type::Path(tp) => {
+                if last_segment_in_path(&tp.path).ident != ACTIVITY_OUTPUT_TYPE {
+                    macro_panic(
+                        tp.span(),
+                        format!(
+                            "activity functions must have a return type of `{}`",
+                            ACTIVITY_OUTPUT_TYPE
+                        ),
+                    );
+                }
+            }
+            _ => macro_panic(
+                ty.span(),
+                format!(
+                    "activity functions must have a return type of `{}`",
+                    ACTIVITY_OUTPUT_TYPE
+                ),
+            ),
+        }
+    }
+
+    if let ReturnType::Type(_, ty) = &func.decl.output {
+        validate_return_binding(&*ty);
     }
 }
 
@@ -375,49 +415,48 @@ fn bind_output_type(
 fn bind_return_type(
     ret: &ReturnType,
     binding_args: &mut HashMap<String, (AttributeArgs, Span)>,
+    is_activity: bool,
 ) -> Vec<Binding> {
-    match ret {
-        ReturnType::Default => Vec::new(),
-        ReturnType::Type(_, ty) => {
-            if let Type::Tuple(tuple) = &**ty {
-                let mut bindings = vec![];
-                for (i, ty) in tuple.elems.iter().enumerate() {
-                    if let Type::Tuple(inner) = ty {
-                        if !inner.elems.is_empty() {
-                            macro_panic(
-                                ty.span(),
-                                "expected an Azure Functions output binding type",
-                            );
-                        }
-                        continue;
+    let mut bindings = Vec::new();
+
+    if let ReturnType::Type(_, ty) = ret {
+        if let Type::Tuple(tuple) = &**ty {
+            for (i, ty) in tuple.elems.iter().enumerate() {
+                if let Type::Tuple(inner) = ty {
+                    if !inner.elems.is_empty() {
+                        macro_panic(ty.span(), "expected an Azure Functions output binding type");
                     }
-                    if i == 0 {
+                    continue;
+                }
+                if i == 0 {
+                    if !is_activity {
                         bindings.push(bind_output_type(
                             &ty,
                             RETURN_BINDING_NAME,
                             binding_args,
                             true,
                         ));
-                    } else {
-                        bindings.push(bind_output_type(
-                            &ty,
-                            &format!("{}{}", OUTPUT_BINDING_PREFIX, i),
-                            binding_args,
-                            true,
-                        ));
                     }
+                } else {
+                    bindings.push(bind_output_type(
+                        &ty,
+                        &format!("{}{}", OUTPUT_BINDING_PREFIX, i),
+                        binding_args,
+                        true,
+                    ));
                 }
-                bindings
-            } else {
-                vec![bind_output_type(
-                    &ty,
-                    RETURN_BINDING_NAME,
-                    binding_args,
-                    true,
-                )]
             }
+        } else if !is_activity {
+            bindings.push(bind_output_type(
+                &ty,
+                RETURN_BINDING_NAME,
+                binding_args,
+                true,
+            ));
         }
     }
+
+    bindings
 }
 
 fn drain_binding_attributes(attrs: &mut Vec<Attribute>) -> HashMap<String, (AttributeArgs, Span)> {
@@ -471,9 +510,12 @@ pub fn func_impl(
     validate_function(&target);
 
     let is_orchestration = has_parameter_of_type(&target, ORCHESTRATION_CONTEXT_TYPE);
+    let is_activity = has_parameter_of_type(&target, ACTIVITY_CONTEXT_TYPE);
 
     if is_orchestration {
         validate_orchestration_function(&target);
+    } else if is_activity {
+        validate_activity_function(&target);
     }
 
     let mut func = Function::from(match syn::parse_macro_input::parse::<AttributeArgs>(args) {
@@ -508,7 +550,9 @@ pub fn func_impl(
     }
 
     if !is_orchestration {
-        for binding in bind_return_type(&target.decl.output, &mut binding_args).into_iter() {
+        for binding in
+            bind_return_type(&target.decl.output, &mut binding_args, is_activity).into_iter()
+        {
             if let Some(name) = binding.name() {
                 if !names.insert(name.to_string()) {
                     if let ReturnType::Type(_, ty) = &target.decl.output {
@@ -534,6 +578,11 @@ pub fn func_impl(
                         macro_panic(
                             v.span(),
                             "cannot bind to the return value of an orchestration function",
+                        )
+                    } else if is_activity {
+                        macro_panic(
+                            v.span(),
+                            "cannot bind to the return value of an activity function",
                         )
                     } else {
                         macro_panic(

--- a/azure-functions-codegen/src/func/invoker.rs
+++ b/azure-functions-codegen/src/func/invoker.rs
@@ -83,9 +83,9 @@ impl<'a> CommonInvokerTokens<'a> {
             .map(|(name, arg_type)| (name, Invoker::deref_arg_type(arg_type)))
     }
 
-    fn get_orchestration_state_arg(&self, trigger: &Ident) -> TokenStream {
+    fn get_execution_result_arg(&self, trigger: &Ident) -> TokenStream {
         if self.is_orchestration {
-            quote!(let __state = #trigger.as_ref().unwrap().execution_result();)
+            quote!(let __result = #trigger.as_ref().unwrap().execution_result();)
         } else {
             TokenStream::new()
         }
@@ -138,7 +138,7 @@ impl ToTokens for CommonInvokerTokens<'_> {
 
         let args_for_call = self.get_args_for_call();
 
-        let orchestration_state = self.get_orchestration_state_arg(trigger_arg);
+        let execution_result = self.get_execution_result_arg(trigger_arg);
 
         quote!(
             use azure_functions::{IntoVec, FromVec};
@@ -161,7 +161,7 @@ impl ToTokens for CommonInvokerTokens<'_> {
                 };
             }
 
-            #orchestration_state
+            #execution_result
 
             let __ret = #target(#(#args_for_call,)*);
         )
@@ -197,7 +197,7 @@ impl ToTokens for Invoker<'_> {
                     ::azure_functions::durable::orchestrate(
                         __req.invocation_id,
                         __ret,
-                        __state,
+                        __result,
                     )
                 }
             )

--- a/azure-functions-codegen/src/func/output_bindings.rs
+++ b/azure-functions-codegen/src/func/output_bindings.rs
@@ -15,7 +15,7 @@ impl<'a> OutputBindings<'a> {
             .map(|(name, _)| {
                 let name_str = to_camel_case(&name.to_string());
                 quote!(
-                    __output_data.push(::azure_functions::rpc::ParameterBinding{
+                    __res.output_data.push(::azure_functions::rpc::ParameterBinding{
                         name: #name_str.to_string(),
                         data: Some(#name.unwrap().into()),
                     });

--- a/azure-functions-sdk/src/templates/new/activity.rs.hbs
+++ b/azure-functions-sdk/src/templates/new/activity.rs.hbs
@@ -1,6 +1,6 @@
-use azure_functions::{bindings::DurableActivityContext, func};
+use azure_functions::{bindings::DurableActivityContext, durable::ActivityOutput, func};
 
 #[func]
-pub async fn {{name}}(context: DurableActivityContext) {
-    context.set_output("Hello from {{name}}!");
+pub async fn {{name}}(context: DurableActivityContext) -> ActivityOutput {
+    "Hello from {{name}}!".into()
 }

--- a/azure-functions/src/durable.rs
+++ b/azure-functions/src/durable.rs
@@ -38,10 +38,6 @@ pub struct ExecutionResult {
 }
 
 impl ExecutionResult {
-    fn mark_done(&mut self) {
-        self.done = true;
-    }
-
     pub(crate) fn add_action(&mut self, action: Action) {
         self.actions.push(action);
     }
@@ -80,7 +76,7 @@ pub fn orchestrate(
     match Future::poll(Box::pin(func).as_mut(), &mut Context::from_waker(&waker)) {
         Poll::Ready(_) => {
             // Orchestration has completed and the result is ready, return done with output
-            result.as_ref().borrow_mut().mark_done();
+            result.borrow_mut().done = true;
         }
         Poll::Pending => {
             // Orchestration has not yet completed

--- a/azure-functions/src/durable/activity_output.rs
+++ b/azure-functions/src/durable/activity_output.rs
@@ -1,11 +1,10 @@
 use crate::rpc::{typed_data::Data, TypedData};
 use serde_json::Value;
 
-/// # Activity Output
+/// Represents the output of a Durable Functions activity function.
 ///
-/// Type returned by Activity Functions for Durable Functions
-
-struct ActivityOutput(serde_json::Value);
+/// Supports conversion from JSON-compatible types.
+pub struct ActivityOutput(Value);
 
 impl<T> From<T> for ActivityOutput
 where

--- a/examples/durable-functions/src/functions/say_hello.rs
+++ b/examples/durable-functions/src/functions/say_hello.rs
@@ -1,13 +1,11 @@
-use azure_functions::{bindings::DurableActivityContext, func};
+use azure_functions::{bindings::DurableActivityContext, durable::ActivityOutput, func};
 
 #[func(name = "SayHello")]
-pub async fn say_hello(_context: DurableActivityContext) {
-    // context.set_output(format!(
+pub async fn say_hello(_context: DurableActivityContext) -> ActivityOutput {
+    // format!(
     //     "Hello {}!",
-    //     context
-    //         .get_input()
-    //         .as_str()
-    //         .expect("expected a string input")
-    // ));
+    //     context.input().as_str().expect("expected a string input")
+    // )
+    // .into()
     unimplemented!()
 }


### PR DESCRIPTION
## What is the goal of this pull request?

This PR implements a special return type, `ActivityOutput`, for activity
functions.

This return type signals to the code generation to set the RPC return value,
but to not emit any binding for `$return`.

## What does this pull request change?

Code generation for activity functions.

## What work remains to be done?

None.

## Do you consider it adequately tested?

No.  There's test coverage of the code generation only from the sample itself, at the moment.

## Related Issues

## Notes