### PR TITLE
Implement output for orchestration functions.

### DIFF
--- a/azure-functions-codegen/src/func.rs
+++ b/azure-functions-codegen/src/func.rs
@@ -24,6 +24,7 @@ use syn::{
 pub const OUTPUT_BINDING_PREFIX: &str = "output";
 const RETURN_BINDING_NAME: &str = "$return";
 const ORCHESTRATION_CONTEXT_TYPE: &str = "DurableOrchestrationContext";
+const ORCHESTRATION_OUTPUT_TYPE: &str = "OrchestrationOutput";
 const ACTIVITY_CONTEXT_TYPE: &str = "DurableActivityContext";
 const ACTIVITY_OUTPUT_TYPE: &str = "ActivityOutput";
 
@@ -78,10 +79,26 @@ fn validate_orchestration_function(func: &ItemFn) {
     }
 
     if let ReturnType::Type(_, ty) = &func.decl.output {
-        macro_panic(
-            ty.span(),
-            "orchestration functions cannot have return types",
-        );
+        match ty.as_ref() {
+            Type::Path(tp) => {
+                if last_segment_in_path(&tp.path).ident != ORCHESTRATION_OUTPUT_TYPE {
+                    macro_panic(
+                        tp.span(),
+                        format!(
+                            "orchestration functions must have a return type of `{}`",
+                            ORCHESTRATION_OUTPUT_TYPE
+                        ),
+                    );
+                }
+            }
+            _ => macro_panic(
+                ty.span(),
+                format!(
+                    "orchestration functions must have a return type of `{}`",
+                    ORCHESTRATION_OUTPUT_TYPE
+                ),
+            ),
+        }
     }
 }
 

--- a/azure-functions/src/bindings/durable_orchestration_context.rs
+++ b/azure-functions/src/bindings/durable_orchestration_context.rs
@@ -104,7 +104,7 @@ impl DurableOrchestrationContext {
             return ActionFuture(Some(Err(failed.reason.clone().unwrap_or_default())));
         }
 
-        return ActionFuture(None);
+        ActionFuture(None)
     }
 
     fn find_scheduled_activity(&self, activity_name: &str) -> Option<&HistoryEvent> {

--- a/azure-functions/src/durable/orchestration_output.rs
+++ b/azure-functions/src/durable/orchestration_output.rs
@@ -1,10 +1,10 @@
+use crate::durable::IntoValue;
 use serde_json::Value;
 
-/// # Orchestration Output
+/// Represents the output of a Durable Functions orchestration function.
 ///
-/// Type returned by Orchetrator Functions for Durable Functions
-
-struct OrchestrationOutput(serde_json::Value);
+/// Supports conversion from JSON-compatible types.
+pub struct OrchestrationOutput(Value);
 
 impl<T> From<T> for OrchestrationOutput
 where
@@ -15,8 +15,8 @@ where
     }
 }
 
-impl OrchestrationOutput {
-    pub(crate) fn to_value(self) -> Value {
+impl IntoValue for OrchestrationOutput {
+    fn into_value(self) -> Value {
         self.0
     }
 }
@@ -30,7 +30,7 @@ mod tests {
     fn it_converts_from_json() {
         let orchestration_output: OrchestrationOutput = json!({"foo": "bar"}).into();
 
-        let data: Value = orchestration_output.to_value();
+        let data: Value = orchestration_output.into_value();
         assert_eq!(data, json!({"foo": "bar"}));
     }
 
@@ -38,7 +38,7 @@ mod tests {
     fn it_converts_from_bool() {
         let orchestration_output: OrchestrationOutput = true.into();
 
-        let data: Value = orchestration_output.to_value();
+        let data: Value = orchestration_output.into_value();
         assert_eq!(data, json!(true));
     }
 
@@ -46,7 +46,7 @@ mod tests {
     fn it_converts_from_string() {
         let orchestration_output: OrchestrationOutput = "foo".into();
 
-        let data: Value = orchestration_output.to_value();
-        assert_eq!(data, json!("\"foo\"".to_string()));
+        let data: Value = orchestration_output.into_value();
+        assert_eq!(data, json!("foo"));
     }
 }

--- a/examples/durable-functions/src/functions/hello_world.rs
+++ b/examples/durable-functions/src/functions/hello_world.rs
@@ -1,17 +1,18 @@
-use azure_functions::{bindings::DurableOrchestrationContext, func};
+use azure_functions::{bindings::DurableOrchestrationContext, durable::OrchestrationOutput, func};
 use futures::future::join_all;
 
 #[func(name = "HelloWorld")]
-pub async fn hello_world(context: DurableOrchestrationContext) {
-    // context.set_output(
-    //     join_all(
-    //         [
-    //             context.call_activity("SayHello", "Tokyo"),
-    //             context.call_activity("SayHello", "London"),
-    //             context.call_activity("SayHello", "Seattle"),
-    //         ]
-    //         .into_iter(),
-    //     )
-    //     .await,
-    // );
+pub async fn hello_world(mut context: DurableOrchestrationContext) -> OrchestrationOutput {
+    // join_all(
+    //     [
+    //         context.call_activity("SayHello", "Tokyo"),
+    //         context.call_activity("SayHello", "London"),
+    //         context.call_activity("SayHello", "Seattle"),
+    //     ]
+    //     .into_iter(),
+    // )
+    // .await
+    // .map(|r| r.unwrap())
+    // .into()
+    unimplemented!()
 }

--- a/examples/durable-functions/src/functions/hello_world.rs
+++ b/examples/durable-functions/src/functions/hello_world.rs
@@ -1,13 +1,13 @@
 use azure_functions::{bindings::DurableOrchestrationContext, durable::OrchestrationOutput, func};
 use futures::future::join_all;
 
-#[func(name = "HelloWorld")]
+#[func]
 pub async fn hello_world(mut context: DurableOrchestrationContext) -> OrchestrationOutput {
     // join_all(
     //     [
-    //         context.call_activity("SayHello", "Tokyo"),
-    //         context.call_activity("SayHello", "London"),
-    //         context.call_activity("SayHello", "Seattle"),
+    //         context.call_activity("say_hello", "Tokyo"),
+    //         context.call_activity("say_hello", "London"),
+    //         context.call_activity("say_hello", "Seattle"),
     //     ]
     //     .into_iter(),
     // )

--- a/examples/durable-functions/src/functions/say_hello.rs
+++ b/examples/durable-functions/src/functions/say_hello.rs
@@ -1,6 +1,6 @@
 use azure_functions::{bindings::DurableActivityContext, durable::ActivityOutput, func};
 
-#[func(name = "SayHello")]
+#[func]
 pub async fn say_hello(_context: DurableActivityContext) -> ActivityOutput {
     // format!(
     //     "Hello {}!",

--- a/examples/durable-functions/src/functions/start.rs
+++ b/examples/durable-functions/src/functions/start.rs
@@ -5,7 +5,7 @@ use azure_functions::{
 
 #[func]
 pub async fn start(_req: HttpRequest, _client: DurableOrchestrationClient) -> HttpResponse {
-    // match client.start_new("HelloWorld").await {
+    // match client.start_new("hello_world").await {
     //     Ok(_) => "Orchestration started.".into(),
     //     Err(e) => format!("Failed to start orchestration: {}", e).into()
     // }


### PR DESCRIPTION
## What is the goal of this pull request?

This commit implements allowing an orchestration to return
`OrchestrationOutput` and having it end up in the orchestration's execution
result.

This is a much more natural interface than the previous `set_output` method.

## What does this pull request change?

Changes code generation for orchestration functions.

## What work remains to be done?

None.

## Do you consider it adequately tested?

No. There's test coverage of the code generation only from the sample itself, at the moment.

## Related Issues

## Notes