### PR TITLE
Make call_activity to mark events as processed

### DIFF
--- a/azure-functions/src/durable/actions.rs
+++ b/azure-functions/src/durable/actions.rs
@@ -37,7 +37,9 @@ pub enum Action {
     #[serde(rename_all = "camelCase")]
     CreateTimer {
         fire_at: DateTime<FixedOffset>,
-        is_cancelled: bool,
+
+        #[serde(rename = "isCancelled")]
+        cancelled: bool,
     },
 
     #[serde(rename_all = "camelCase")]
@@ -121,7 +123,7 @@ mod tests {
         (
            Action::CreateTimer {
                 fire_at: DateTime::parse_from_rfc3339("2019-07-18T06:22:27.016757+00:00").unwrap(),
-                is_cancelled: true,
+                cancelled: true,
            },
            r#"{"actionType":"createTimer","fireAt":"2019-07-18T06:22:27.016757+00:00","isCancelled":true}"#
         ),

--- a/azure-functions/src/durable/history.rs
+++ b/azure-functions/src/durable/history.rs
@@ -17,12 +17,13 @@ pub struct HistoryEvent {
 
     pub(crate) event_id: i32,
 
-    pub(crate) is_played: bool,
+    #[serde(alias = "IsPlayed")]
+    pub(crate) played: bool,
 
     pub(crate) timestamp: DateTime<FixedOffset>,
 
-    #[serde(default)]
-    pub(crate) is_processed: bool,
+    #[serde(default, alias = "IsProcessed")]
+    pub(crate) processed: bool,
 
     // EventRaised, ExecutionStarted, SubOrchestrationInstanceCreated, TaskScheduled
     pub(crate) name: Option<String>,


### PR DESCRIPTION
## What is the goal of this pull request?
Make call_activity to mark events as processed
## What does this pull request change?
Makes `call_activity` method to mark events processed
## What work remains to be done?
-
## Do you consider it adequately tested?
NO