### PR TITLE
Implement current_time method

### DIFF
--- a/azure-functions/src/durable/actions.rs
+++ b/azure-functions/src/durable/actions.rs
@@ -1,4 +1,4 @@
-use chrono::{DateTime, FixedOffset};
+use chrono::{DateTime, Utc};
 use serde::Serialize;
 use serde_json::Value;
 
@@ -36,7 +36,7 @@ pub enum Action {
 
     #[serde(rename_all = "camelCase")]
     CreateTimer {
-        fire_at: DateTime<FixedOffset>,
+        fire_at: DateTime<Utc>,
 
         #[serde(rename = "isCancelled")]
         cancelled: bool,
@@ -57,7 +57,7 @@ pub struct RetryOptions {
 #[cfg(test)]
 mod tests {
     use crate::durable::{Action, RetryOptions};
-    use chrono::DateTime;
+    use chrono::{DateTime, Utc};
 
     macro_rules! it_converts_to_json {
         ($($name:ident: $value:expr,)*) => {
@@ -122,10 +122,10 @@ mod tests {
         create_timer_converts_to_json:
         (
            Action::CreateTimer {
-                fire_at: DateTime::parse_from_rfc3339("2019-07-18T06:22:27.016757+00:00").unwrap(),
+                fire_at: DateTime::<Utc>::from(DateTime::parse_from_rfc3339("2019-07-18T06:22:27.016757Z").unwrap()),
                 cancelled: true,
            },
-           r#"{"actionType":"createTimer","fireAt":"2019-07-18T06:22:27.016757+00:00","isCancelled":true}"#
+           r#"{"actionType":"createTimer","fireAt":"2019-07-18T06:22:27.016757Z","isCancelled":true}"#
         ),
         wait_for_external_event_converts_to_json:
         (

--- a/azure-functions/src/durable/history.rs
+++ b/azure-functions/src/durable/history.rs
@@ -1,4 +1,4 @@
-use chrono::{DateTime, FixedOffset};
+use chrono::{DateTime, Utc};
 use serde::Deserialize;
 use serde_json::Value;
 use serde_repr::Deserialize_repr;
@@ -20,7 +20,7 @@ pub struct HistoryEvent {
     #[serde(alias = "IsPlayed")]
     pub(crate) played: bool,
 
-    pub(crate) timestamp: DateTime<FixedOffset>,
+    pub(crate) timestamp: DateTime<Utc>,
 
     #[serde(default, alias = "IsProcessed")]
     pub(crate) processed: bool,
@@ -47,7 +47,7 @@ pub struct HistoryEvent {
     pub(crate) details: Option<String>,
 
     //TimerCreated, TimerFired
-    pub(crate) fire_at: Option<DateTime<FixedOffset>>,
+    pub(crate) fire_at: Option<DateTime<Utc>>,
 
     //TimerFired
     pub(crate) timer_id: Option<i32>,


### PR DESCRIPTION
## What is the goal of this pull request?
Implement `current_time` method for `DurableOrchestrationContext`
## What does this pull request change?
Initializes `current_time` field with the first `OrchestrationStarted` event in constructor.
Updates `current_time` field with the next `OrchestrationStarted` in history.
## What work remains to be done?
N/A
## Do you consider it adequately tested?
NO