### PR TITLE
Break `azure-functions-sdk/commands/new.rs` into submodules

### DIFF
--- a/.clabot
+++ b/.clabot
@@ -7,6 +7,7 @@
     "allcontributors[bot]",
     "t-eckert",
     "rtyler",
-    "dmolokanov"
+    "dmolokanov",
+    "slyons"
   ]
 }

--- a/.clabot
+++ b/.clabot
@@ -6,6 +6,7 @@
     "dependabot-preview[bot]",
     "allcontributors[bot]",
     "t-eckert",
-    "rtyler"
+    "rtyler",
+    "dmolokanov"
   ]
 }

--- a/azure-functions-sdk/src/commands/new.rs
+++ b/azure-functions-sdk/src/commands/new.rs
@@ -17,7 +17,10 @@ use std::{
 use syn::{parse::Parser, parse_file, punctuated::Punctuated, Ident, Item, Token};
 
 mod blob;
+mod http;
+
 pub use self::blob::Blob;
+pub use self::http::Http;
 
 fn get_path_for_function(name: &str) -> Result<String, String> {
     if !Regex::new("^[a-zA-Z][a-zA-Z0-9_]*$")
@@ -210,59 +213,7 @@ impl<'a> From<&'a ArgMatches<'a>> for New<'a> {
     }
 }
 
-struct Http<'a> {
-    name: &'a str,
-    auth_level: &'a str,
-}
 
-impl<'a> Http<'a> {
-    pub fn create_subcommand<'b>() -> App<'a, 'b> {
-        SubCommand::with_name("http")
-            .about("Creates a new HTTP triggered Azure Function.")
-            .arg(
-                Arg::with_name("name")
-                    .long("name")
-                    .short("n")
-                    .value_name("NAME")
-                    .help("The name of the new Azure Function.")
-                    .required(true),
-            )
-            .arg(
-                Arg::with_name("auth-level")
-                    .long("auth-level")
-                    .value_name("LEVEL")
-                    .possible_values(&["anonymous", "function", "admin"])
-                    .help("The authentication level for the HTTP function. Default is 'function'."),
-            )
-    }
-
-    pub fn execute(&self, quiet: bool) -> Result<(), String> {
-        let data = json!({
-            "name": self.name,
-            "auth_level": self.auth_level
-        });
-
-        create_function(self.name, "http.rs", &data, quiet)
-    }
-}
-
-impl<'a> From<&'a ArgMatches<'a>> for Http<'a> {
-    fn from(args: &'a ArgMatches<'a>) -> Self {
-        Http {
-            name: args.value_of("name").unwrap(),
-            auth_level: match args.value_of("auth-level") {
-                Some(level) => {
-                    if level == "function" {
-                        ""
-                    } else {
-                        level
-                    }
-                }
-                None => "",
-            },
-        }
-    }
-}
 
 struct Queue<'a> {
     name: &'a str,

--- a/azure-functions-sdk/src/commands/new.rs
+++ b/azure-functions-sdk/src/commands/new.rs
@@ -19,10 +19,12 @@ use syn::{parse::Parser, parse_file, punctuated::Punctuated, Ident, Item, Token}
 mod blob;
 mod http;
 mod queue;
+mod timer;
 
 pub use self::blob::Blob;
 pub use self::http::Http;
 pub use self::queue::Queue;
+pub use self::timer::Timer;
 
 fn get_path_for_function(name: &str) -> Result<String, String> {
     if !Regex::new("^[a-zA-Z][a-zA-Z0-9_]*$")
@@ -211,52 +213,6 @@ impl<'a> From<&'a ArgMatches<'a>> for New<'a> {
             quiet: args.is_present("quiet"),
             color: args.value_of("color"),
             args,
-        }
-    }
-}
-
-struct Timer<'a> {
-    name: &'a str,
-    schedule: &'a str,
-}
-
-impl<'a> Timer<'a> {
-    pub fn create_subcommand<'b>() -> App<'a, 'b> {
-        SubCommand::with_name("timer")
-            .about("Creates a new timer triggered Azure Function.")
-            .arg(
-                Arg::with_name("name")
-                    .long("name")
-                    .short("n")
-                    .value_name("NAME")
-                    .help("The name of the new Azure Function.")
-                    .required(true),
-            )
-            .arg(
-                Arg::with_name("schedule")
-                    .long("schedule")
-                    .short("s")
-                    .value_name("SCHEDULE")
-                    .help("The timer schedule as a cron-expression.")
-                    .required(true),
-            )
-    }
-
-    pub fn execute(&self, quiet: bool) -> Result<(), String> {
-        let data = json!({
-            "name": self.name,
-            "schedule": self.schedule,
-        });
-
-        create_function(self.name, "timer.rs", &data, quiet)
-    }
-}
-
-impl<'a> From<&'a ArgMatches<'a>> for Timer<'a> {
-    fn from(args: &'a ArgMatches<'a>) -> Self {
-        Timer {
-            name: args.value_of("name").unwrap(),
-            schedule: args.value_of("schedule").unwrap(),
         }
     }
 }

--- a/azure-functions-sdk/src/commands/new.rs
+++ b/azure-functions-sdk/src/commands/new.rs
@@ -17,6 +17,7 @@ use std::{
 use syn::{parse::Parser, parse_file, punctuated::Punctuated, Ident, Item, Token};
 
 mod blob;
+mod cosmos_db;
 mod event_grid;
 mod event_hub;
 mod http;
@@ -24,6 +25,7 @@ mod queue;
 mod timer;
 
 pub use self::blob::Blob;
+pub use self::cosmos_db::CosmosDb;
 pub use self::event_grid::EventGrid;
 pub use self::event_hub::EventHub;
 pub use self::http::Http;
@@ -217,74 +219,6 @@ impl<'a> From<&'a ArgMatches<'a>> for New<'a> {
             quiet: args.is_present("quiet"),
             color: args.value_of("color"),
             args,
-        }
-    }
-}
-
-struct CosmosDb<'a> {
-    name: &'a str,
-    connection: &'a str,
-    database: &'a str,
-    collection: &'a str,
-}
-
-impl<'a> CosmosDb<'a> {
-    pub fn create_subcommand<'b>() -> App<'a, 'b> {
-        SubCommand::with_name("cosmos-db")
-            .about("Creates a new Cosmos DB triggered Azure Function.")
-            .arg(
-                Arg::with_name("name")
-                    .long("name")
-                    .short("n")
-                    .value_name("NAME")
-                    .help("The name of the new Azure Function.")
-                    .required(true),
-            )
-            .arg(
-                Arg::with_name("connection")
-                    .long("connection")
-                    .short("c")
-                    .value_name("CONNECTION")
-                    .help("The name of the connection setting to use for the Cosmos DB trigger.")
-                    .required(true),
-            )
-            .arg(
-                Arg::with_name("database")
-                    .long("database")
-                    .short("d")
-                    .value_name("DATABASE")
-                    .help("The name of the database to use for the Cosmos DB trigger.")
-                    .required(true),
-            )
-            .arg(
-                Arg::with_name("collection")
-                    .long("collection")
-                    .short("l")
-                    .value_name("COLLECTION")
-                    .help("The name of the collection to use for the Cosmos DB trigger.")
-                    .required(true),
-            )
-    }
-
-    pub fn execute(&self, quiet: bool) -> Result<(), String> {
-        let data = json!({
-            "name": self.name,
-            "connection": self.connection,
-            "database": self.database,
-            "collection": self.collection,
-        });
-
-        create_function(self.name, "cosmosdb.rs", &data, quiet)
-    }
-}
-
-impl<'a> From<&'a ArgMatches<'a>> for CosmosDb<'a> {
-    fn from(args: &'a ArgMatches<'a>) -> Self {
-        CosmosDb {
-            name: args.value_of("name").unwrap(),
-            connection: args.value_of("connection").unwrap(),
-            database: args.value_of("database").unwrap(),
-            collection: args.value_of("collection").unwrap(),
         }
     }
 }

--- a/azure-functions-sdk/src/commands/new.rs
+++ b/azure-functions-sdk/src/commands/new.rs
@@ -22,6 +22,7 @@ mod event_grid;
 mod event_hub;
 mod http;
 mod queue;
+mod service_bus;
 mod timer;
 
 pub use self::blob::Blob;
@@ -30,6 +31,7 @@ pub use self::event_grid::EventGrid;
 pub use self::event_hub::EventHub;
 pub use self::http::Http;
 pub use self::queue::Queue;
+pub use self::service_bus::ServiceBus;
 pub use self::timer::Timer;
 
 fn get_path_for_function(name: &str) -> Result<String, String> {
@@ -219,88 +221,6 @@ impl<'a> From<&'a ArgMatches<'a>> for New<'a> {
             quiet: args.is_present("quiet"),
             color: args.value_of("color"),
             args,
-        }
-    }
-}
-
-struct ServiceBus<'a> {
-    name: &'a str,
-    connection: &'a str,
-    queue: Option<&'a str>,
-    topic: Option<&'a str>,
-    subscription: Option<&'a str>,
-}
-
-impl<'a> ServiceBus<'a> {
-    pub fn create_subcommand<'b>() -> App<'a, 'b> {
-        SubCommand::with_name("service-bus")
-            .about("Creates a new Service Bus triggered Azure Function.")
-            .arg(
-                Arg::with_name("name")
-                    .long("name")
-                    .short("n")
-                    .value_name("NAME")
-                    .help("The name of the new Azure Function.")
-                    .required(true),
-            )
-            .arg(
-                Arg::with_name("connection")
-                    .long("connection")
-                    .short("c")
-                    .value_name("CONNECTION")
-                    .help("The name of the connection setting to use for the Service Bus trigger.")
-                    .required(true),
-            )
-            .arg(
-                Arg::with_name("queue")
-                    .long("queue")
-                    .short("q")
-                    .value_name("QUEUE")
-                    .help("The name of the queue to use for the Service Bus trigger.")
-                    .conflicts_with_all(&["topic", "subscription"])
-                    .required(true),
-            )
-            .arg(
-                Arg::with_name("topic")
-                    .long("topic")
-                    .short("t")
-                    .value_name("TOPIC")
-                    .help("The name of the topic to use for the Service Bus trigger.")
-                    .conflicts_with("queue")
-                    .required(true),
-            )
-            .arg(
-                Arg::with_name("subscription")
-                    .long("subscription")
-                    .short("s")
-                    .value_name("SUBSCRIPTION")
-                    .help("The name of the subscription to use for the Service Bus trigger.")
-                    .conflicts_with("queue")
-                    .required(true),
-            )
-    }
-
-    pub fn execute(&self, quiet: bool) -> Result<(), String> {
-        let data = json!({
-            "name": self.name,
-            "connection": self.connection,
-            "queue": self.queue,
-            "topic": self.topic,
-            "subscription": self.subscription
-        });
-
-        create_function(self.name, "servicebus.rs", &data, quiet)
-    }
-}
-
-impl<'a> From<&'a ArgMatches<'a>> for ServiceBus<'a> {
-    fn from(args: &'a ArgMatches<'a>) -> Self {
-        ServiceBus {
-            name: args.value_of("name").unwrap(),
-            connection: args.value_of("connection").unwrap(),
-            queue: args.value_of("queue"),
-            topic: args.value_of("topic"),
-            subscription: args.value_of("subscription"),
         }
     }
 }

--- a/azure-functions-sdk/src/commands/new.rs
+++ b/azure-functions-sdk/src/commands/new.rs
@@ -18,12 +18,14 @@ use syn::{parse::Parser, parse_file, punctuated::Punctuated, Ident, Item, Token}
 
 mod blob;
 mod event_grid;
+mod event_hub;
 mod http;
 mod queue;
 mod timer;
 
 pub use self::blob::Blob;
 pub use self::event_grid::EventGrid;
+pub use self::event_hub::EventHub;
 pub use self::http::Http;
 pub use self::queue::Queue;
 pub use self::timer::Timer;
@@ -215,62 +217,6 @@ impl<'a> From<&'a ArgMatches<'a>> for New<'a> {
             quiet: args.is_present("quiet"),
             color: args.value_of("color"),
             args,
-        }
-    }
-}
-
-struct EventHub<'a> {
-    name: &'a str,
-    connection: &'a str,
-    hub_name: &'a str,
-}
-
-impl<'a> EventHub<'a> {
-    pub fn create_subcommand<'b>() -> App<'a, 'b> {
-        SubCommand::with_name("event-hub")
-            .about("Creates a new Event Hub triggered Azure Function.")
-            .arg(
-                Arg::with_name("name")
-                    .long("name")
-                    .short("n")
-                    .value_name("NAME")
-                    .help("The name of the new Azure Function.")
-                    .required(true),
-            )
-            .arg(
-                Arg::with_name("connection")
-                    .long("connection")
-                    .short("c")
-                    .value_name("CONNECTION")
-                    .help("The name of the connection setting to use for the Event Hub trigger.")
-                    .required(true),
-            )
-            .arg(
-                Arg::with_name("hub_name")
-                    .long("hub-name")
-                    .short("h")
-                    .value_name("HUBNAME")
-                    .help("The name of the Event Hub."),
-            )
-    }
-
-    pub fn execute(&self, quiet: bool) -> Result<(), String> {
-        let data = json!({
-            "name": self.name,
-            "connection": self.connection,
-            "hub_name": self.hub_name,
-        });
-
-        create_function(self.name, "eventhub.rs", &data, quiet)
-    }
-}
-
-impl<'a> From<&'a ArgMatches<'a>> for EventHub<'a> {
-    fn from(args: &'a ArgMatches<'a>) -> Self {
-        EventHub {
-            name: args.value_of("name").unwrap(),
-            connection: args.value_of("connection").unwrap(),
-            hub_name: args.value_of("hub_name").unwrap_or(""),
         }
     }
 }

--- a/azure-functions-sdk/src/commands/new.rs
+++ b/azure-functions-sdk/src/commands/new.rs
@@ -16,6 +16,9 @@ use std::{
 };
 use syn::{parse::Parser, parse_file, punctuated::Punctuated, Ident, Item, Token};
 
+mod blob;
+pub use self::blob::Blob;
+
 fn get_path_for_function(name: &str) -> Result<String, String> {
     if !Regex::new("^[a-zA-Z][a-zA-Z0-9_]*$")
         .unwrap()
@@ -257,52 +260,6 @@ impl<'a> From<&'a ArgMatches<'a>> for Http<'a> {
                 }
                 None => "",
             },
-        }
-    }
-}
-
-struct Blob<'a> {
-    name: &'a str,
-    path: &'a str,
-}
-
-impl<'a> Blob<'a> {
-    pub fn create_subcommand<'b>() -> App<'a, 'b> {
-        SubCommand::with_name("blob")
-            .about("Creates a new blob triggered Azure Function.")
-            .arg(
-                Arg::with_name("name")
-                    .long("name")
-                    .short("n")
-                    .value_name("NAME")
-                    .help("The name of the new Azure Function.")
-                    .required(true),
-            )
-            .arg(
-                Arg::with_name("path")
-                    .long("path")
-                    .short("p")
-                    .value_name("PATH")
-                    .help("The blob storage path to monitor.")
-                    .required(true),
-            )
-    }
-
-    pub fn execute(&self, quiet: bool) -> Result<(), String> {
-        let data = json!({
-            "name": self.name,
-            "path": self.path
-        });
-
-        create_function(self.name, "blob.rs", &data, quiet)
-    }
-}
-
-impl<'a> From<&'a ArgMatches<'a>> for Blob<'a> {
-    fn from(args: &'a ArgMatches<'a>) -> Self {
-        Blob {
-            name: args.value_of("name").unwrap(),
-            path: args.value_of("path").unwrap(),
         }
     }
 }

--- a/azure-functions-sdk/src/commands/new.rs
+++ b/azure-functions-sdk/src/commands/new.rs
@@ -17,11 +17,13 @@ use std::{
 use syn::{parse::Parser, parse_file, punctuated::Punctuated, Ident, Item, Token};
 
 mod blob;
+mod event_grid;
 mod http;
 mod queue;
 mod timer;
 
 pub use self::blob::Blob;
+pub use self::event_grid::EventGrid;
 pub use self::http::Http;
 pub use self::queue::Queue;
 pub use self::timer::Timer;
@@ -213,41 +215,6 @@ impl<'a> From<&'a ArgMatches<'a>> for New<'a> {
             quiet: args.is_present("quiet"),
             color: args.value_of("color"),
             args,
-        }
-    }
-}
-
-struct EventGrid<'a> {
-    name: &'a str,
-}
-
-impl<'a> EventGrid<'a> {
-    pub fn create_subcommand<'b>() -> App<'a, 'b> {
-        SubCommand::with_name("event-grid")
-            .about("Creates a new Event Grid triggered Azure Function.")
-            .arg(
-                Arg::with_name("name")
-                    .long("name")
-                    .short("n")
-                    .value_name("NAME")
-                    .help("The name of the new Azure Function.")
-                    .required(true),
-            )
-    }
-
-    pub fn execute(&self, quiet: bool) -> Result<(), String> {
-        let data = json!({
-            "name": self.name,
-        });
-
-        create_function(self.name, "eventgrid.rs", &data, quiet)
-    }
-}
-
-impl<'a> From<&'a ArgMatches<'a>> for EventGrid<'a> {
-    fn from(args: &'a ArgMatches<'a>) -> Self {
-        EventGrid {
-            name: args.value_of("name").unwrap(),
         }
     }
 }

--- a/azure-functions-sdk/src/commands/new/blob.rs
+++ b/azure-functions-sdk/src/commands/new/blob.rs
@@ -1,0 +1,51 @@
+use crate::{
+    commands::new::create_function,
+};
+use clap::{App, Arg, ArgMatches, SubCommand};
+use serde_json::json;
+
+pub struct Blob<'a> {
+    name: &'a str,
+    path: &'a str,
+}
+
+impl<'a> Blob<'a> {
+    pub fn create_subcommand<'b>() -> App<'a, 'b> {
+        SubCommand::with_name("blob")
+            .about("Creates a new blob triggered Azure Function.")
+            .arg(
+                Arg::with_name("name")
+                    .long("name")
+                    .short("n")
+                    .value_name("NAME")
+                    .help("The name of the new Azure Function.")
+                    .required(true),
+            )
+            .arg(
+                Arg::with_name("path")
+                    .long("path")
+                    .short("p")
+                    .value_name("PATH")
+                    .help("The blob storage path to monitor.")
+                    .required(true),
+            )
+    }
+
+    pub fn execute(&self, quiet: bool) -> Result<(), String> {
+        let data = json!({
+            "name": self.name,
+            "path": self.path
+        });
+
+        create_function(self.name, "blob.rs", &data, quiet)
+    }
+}
+
+impl<'a> From<&'a ArgMatches<'a>> for Blob<'a> {
+    fn from(args: &'a ArgMatches<'a>) -> Self {
+        Blob {
+            name: args.value_of("name").unwrap(),
+            path: args.value_of("path").unwrap(),
+        }
+    }
+}

--- a/azure-functions-sdk/src/commands/new/blob.rs
+++ b/azure-functions-sdk/src/commands/new/blob.rs
@@ -1,6 +1,4 @@
-use crate::{
-    commands::new::create_function,
-};
+use crate::commands::new::create_function;
 use clap::{App, Arg, ArgMatches, SubCommand};
 use serde_json::json;
 

--- a/azure-functions-sdk/src/commands/new/cosmos_db.rs
+++ b/azure-functions-sdk/src/commands/new/cosmos_db.rs
@@ -1,0 +1,73 @@
+use crate::{
+    commands::new::create_function,
+};
+use clap::{App, Arg, ArgMatches, SubCommand};
+use serde_json::json;
+
+pub struct CosmosDb<'a> {
+    name: &'a str,
+    connection: &'a str,
+    database: &'a str,
+    collection: &'a str,
+}
+
+impl<'a> CosmosDb<'a> {
+    pub fn create_subcommand<'b>() -> App<'a, 'b> {
+        SubCommand::with_name("cosmos-db")
+            .about("Creates a new Cosmos DB triggered Azure Function.")
+            .arg(
+                Arg::with_name("name")
+                    .long("name")
+                    .short("n")
+                    .value_name("NAME")
+                    .help("The name of the new Azure Function.")
+                    .required(true),
+            )
+            .arg(
+                Arg::with_name("connection")
+                    .long("connection")
+                    .short("c")
+                    .value_name("CONNECTION")
+                    .help("The name of the connection setting to use for the Cosmos DB trigger.")
+                    .required(true),
+            )
+            .arg(
+                Arg::with_name("database")
+                    .long("database")
+                    .short("d")
+                    .value_name("DATABASE")
+                    .help("The name of the database to use for the Cosmos DB trigger.")
+                    .required(true),
+            )
+            .arg(
+                Arg::with_name("collection")
+                    .long("collection")
+                    .short("l")
+                    .value_name("COLLECTION")
+                    .help("The name of the collection to use for the Cosmos DB trigger.")
+                    .required(true),
+            )
+    }
+
+    pub fn execute(&self, quiet: bool) -> Result<(), String> {
+        let data = json!({
+            "name": self.name,
+            "connection": self.connection,
+            "database": self.database,
+            "collection": self.collection,
+        });
+
+        create_function(self.name, "cosmosdb.rs", &data, quiet)
+    }
+}
+
+impl<'a> From<&'a ArgMatches<'a>> for CosmosDb<'a> {
+    fn from(args: &'a ArgMatches<'a>) -> Self {
+        CosmosDb {
+            name: args.value_of("name").unwrap(),
+            connection: args.value_of("connection").unwrap(),
+            database: args.value_of("database").unwrap(),
+            collection: args.value_of("collection").unwrap(),
+        }
+    }
+}

--- a/azure-functions-sdk/src/commands/new/cosmos_db.rs
+++ b/azure-functions-sdk/src/commands/new/cosmos_db.rs
@@ -1,6 +1,4 @@
-use crate::{
-    commands::new::create_function,
-};
+use crate::commands::new::create_function;
 use clap::{App, Arg, ArgMatches, SubCommand};
 use serde_json::json;
 

--- a/azure-functions-sdk/src/commands/new/event_grid.rs
+++ b/azure-functions-sdk/src/commands/new/event_grid.rs
@@ -1,0 +1,40 @@
+use crate::{
+    commands::new::create_function,
+};
+use clap::{App, Arg, ArgMatches, SubCommand};
+use serde_json::json;
+
+pub struct EventGrid<'a> {
+    name: &'a str,
+}
+
+impl<'a> EventGrid<'a> {
+    pub fn create_subcommand<'b>() -> App<'a, 'b> {
+        SubCommand::with_name("event-grid")
+            .about("Creates a new Event Grid triggered Azure Function.")
+            .arg(
+                Arg::with_name("name")
+                    .long("name")
+                    .short("n")
+                    .value_name("NAME")
+                    .help("The name of the new Azure Function.")
+                    .required(true),
+            )
+    }
+
+    pub fn execute(&self, quiet: bool) -> Result<(), String> {
+        let data = json!({
+            "name": self.name,
+        });
+
+        create_function(self.name, "eventgrid.rs", &data, quiet)
+    }
+}
+
+impl<'a> From<&'a ArgMatches<'a>> for EventGrid<'a> {
+    fn from(args: &'a ArgMatches<'a>) -> Self {
+        EventGrid {
+            name: args.value_of("name").unwrap(),
+        }
+    }
+}

--- a/azure-functions-sdk/src/commands/new/event_grid.rs
+++ b/azure-functions-sdk/src/commands/new/event_grid.rs
@@ -1,6 +1,4 @@
-use crate::{
-    commands::new::create_function,
-};
+use crate::commands::new::create_function;
 use clap::{App, Arg, ArgMatches, SubCommand};
 use serde_json::json;
 

--- a/azure-functions-sdk/src/commands/new/event_hub.rs
+++ b/azure-functions-sdk/src/commands/new/event_hub.rs
@@ -1,0 +1,61 @@
+use crate::{
+    commands::new::create_function,
+};
+use clap::{App, Arg, ArgMatches, SubCommand};
+use serde_json::json;
+
+pub struct EventHub<'a> {
+    name: &'a str,
+    connection: &'a str,
+    hub_name: &'a str,
+}
+
+impl<'a> EventHub<'a> {
+    pub fn create_subcommand<'b>() -> App<'a, 'b> {
+        SubCommand::with_name("event-hub")
+            .about("Creates a new Event Hub triggered Azure Function.")
+            .arg(
+                Arg::with_name("name")
+                    .long("name")
+                    .short("n")
+                    .value_name("NAME")
+                    .help("The name of the new Azure Function.")
+                    .required(true),
+            )
+            .arg(
+                Arg::with_name("connection")
+                    .long("connection")
+                    .short("c")
+                    .value_name("CONNECTION")
+                    .help("The name of the connection setting to use for the Event Hub trigger.")
+                    .required(true),
+            )
+            .arg(
+                Arg::with_name("hub_name")
+                    .long("hub-name")
+                    .short("h")
+                    .value_name("HUBNAME")
+                    .help("The name of the Event Hub."),
+            )
+    }
+
+    pub fn execute(&self, quiet: bool) -> Result<(), String> {
+        let data = json!({
+            "name": self.name,
+            "connection": self.connection,
+            "hub_name": self.hub_name,
+        });
+
+        create_function(self.name, "eventhub.rs", &data, quiet)
+    }
+}
+
+impl<'a> From<&'a ArgMatches<'a>> for EventHub<'a> {
+    fn from(args: &'a ArgMatches<'a>) -> Self {
+        EventHub {
+            name: args.value_of("name").unwrap(),
+            connection: args.value_of("connection").unwrap(),
+            hub_name: args.value_of("hub_name").unwrap_or(""),
+        }
+    }
+}

--- a/azure-functions-sdk/src/commands/new/event_hub.rs
+++ b/azure-functions-sdk/src/commands/new/event_hub.rs
@@ -1,6 +1,4 @@
-use crate::{
-    commands::new::create_function,
-};
+use crate::commands::new::create_function;
 use clap::{App, Arg, ArgMatches, SubCommand};
 use serde_json::json;
 

--- a/azure-functions-sdk/src/commands/new/http.rs
+++ b/azure-functions-sdk/src/commands/new/http.rs
@@ -1,0 +1,59 @@
+use crate::{
+    commands::new::create_function,
+};
+use clap::{App, Arg, ArgMatches, SubCommand};
+use serde_json::json;
+
+pub struct Http<'a> {
+    name: &'a str,
+    auth_level: &'a str,
+}
+
+impl<'a> Http<'a> {
+    pub fn create_subcommand<'b>() -> App<'a, 'b> {
+        SubCommand::with_name("http")
+            .about("Creates a new HTTP triggered Azure Function.")
+            .arg(
+                Arg::with_name("name")
+                    .long("name")
+                    .short("n")
+                    .value_name("NAME")
+                    .help("The name of the new Azure Function.")
+                    .required(true),
+            )
+            .arg(
+                Arg::with_name("auth-level")
+                    .long("auth-level")
+                    .value_name("LEVEL")
+                    .possible_values(&["anonymous", "function", "admin"])
+                    .help("The authentication level for the HTTP function. Default is 'function'."),
+            )
+    }
+
+    pub fn execute(&self, quiet: bool) -> Result<(), String> {
+        let data = json!({
+            "name": self.name,
+            "auth_level": self.auth_level
+        });
+
+        create_function(self.name, "http.rs", &data, quiet)
+    }
+}
+
+impl<'a> From<&'a ArgMatches<'a>> for Http<'a> {
+    fn from(args: &'a ArgMatches<'a>) -> Self {
+        Http {
+            name: args.value_of("name").unwrap(),
+            auth_level: match args.value_of("auth-level") {
+                Some(level) => {
+                    if level == "function" {
+                        ""
+                    } else {
+                        level
+                    }
+                }
+                None => "",
+            },
+        }
+    }
+}

--- a/azure-functions-sdk/src/commands/new/http.rs
+++ b/azure-functions-sdk/src/commands/new/http.rs
@@ -1,6 +1,4 @@
-use crate::{
-    commands::new::create_function,
-};
+use crate::commands::new::create_function;
 use clap::{App, Arg, ArgMatches, SubCommand};
 use serde_json::json;
 

--- a/azure-functions-sdk/src/commands/new/queue.rs
+++ b/azure-functions-sdk/src/commands/new/queue.rs
@@ -1,0 +1,79 @@
+use crate::{
+    commands::new::create_function,
+};
+use clap::{App, Arg, ArgMatches, SubCommand};
+use regex::Regex;
+use serde_json::json;
+
+pub struct Queue<'a> {
+    name: &'a str,
+    queue_name: &'a str,
+}
+
+impl<'a> Queue<'a> {
+    pub fn create_subcommand<'b>() -> App<'a, 'b> {
+        SubCommand::with_name("queue")
+            .about("Creates a new queue triggered Azure Function.")
+            .arg(
+                Arg::with_name("name")
+                    .long("name")
+                    .short("n")
+                    .value_name("NAME")
+                    .help("The name of the new Azure Function.")
+                    .required(true),
+            )
+            .arg(
+                Arg::with_name("queue_name")
+                    .long("queue-name")
+                    .short("q")
+                    .value_name("QUEUE")
+                    .help("The name of the storage queue to monitor.")
+                    .required(true),
+            )
+    }
+
+    pub fn execute(&self, quiet: bool) -> Result<(), String> {
+        Queue::validate_queue_name(self.queue_name)?;
+
+        let data = json!({
+            "name": self.name,
+            "queue_name": self.queue_name
+        });
+
+        create_function(self.name, "queue.rs", &data, quiet)
+    }
+
+    fn validate_queue_name(name: &str) -> Result<(), String> {
+        if name.len() < 3 {
+            return Err(format!(
+                "queue name '{}' must be at least 3 characters.",
+                name
+            ));
+        }
+
+        if name.len() > 63 {
+            return Err(format!(
+                "queue name '{}' cannot be more than 63 characters.",
+                name
+            ));
+        }
+
+        if !Regex::new("^[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]$")
+            .unwrap()
+            .is_match(name)
+        {
+            return Err(format!("queue name '{}' must start and end with a letter or number and can only contain letters, numbers, and hyphens.", name));
+        }
+
+        Ok(())
+    }
+}
+
+impl<'a> From<&'a ArgMatches<'a>> for Queue<'a> {
+    fn from(args: &'a ArgMatches<'a>) -> Self {
+        Queue {
+            name: args.value_of("name").unwrap(),
+            queue_name: args.value_of("queue_name").unwrap(),
+        }
+    }
+}

--- a/azure-functions-sdk/src/commands/new/queue.rs
+++ b/azure-functions-sdk/src/commands/new/queue.rs
@@ -1,6 +1,4 @@
-use crate::{
-    commands::new::create_function,
-};
+use crate::commands::new::create_function;
 use clap::{App, Arg, ArgMatches, SubCommand};
 use regex::Regex;
 use serde_json::json;

--- a/azure-functions-sdk/src/commands/new/service_bus.rs
+++ b/azure-functions-sdk/src/commands/new/service_bus.rs
@@ -1,6 +1,4 @@
-use crate::{
-    commands::new::create_function,
-};
+use crate::commands::new::create_function;
 use clap::{App, Arg, ArgMatches, SubCommand};
 use serde_json::json;
 

--- a/azure-functions-sdk/src/commands/new/service_bus.rs
+++ b/azure-functions-sdk/src/commands/new/service_bus.rs
@@ -1,0 +1,87 @@
+use crate::{
+    commands::new::create_function,
+};
+use clap::{App, Arg, ArgMatches, SubCommand};
+use serde_json::json;
+
+pub struct ServiceBus<'a> {
+    name: &'a str,
+    connection: &'a str,
+    queue: Option<&'a str>,
+    topic: Option<&'a str>,
+    subscription: Option<&'a str>,
+}
+
+impl<'a> ServiceBus<'a> {
+    pub fn create_subcommand<'b>() -> App<'a, 'b> {
+        SubCommand::with_name("service-bus")
+            .about("Creates a new Service Bus triggered Azure Function.")
+            .arg(
+                Arg::with_name("name")
+                    .long("name")
+                    .short("n")
+                    .value_name("NAME")
+                    .help("The name of the new Azure Function.")
+                    .required(true),
+            )
+            .arg(
+                Arg::with_name("connection")
+                    .long("connection")
+                    .short("c")
+                    .value_name("CONNECTION")
+                    .help("The name of the connection setting to use for the Service Bus trigger.")
+                    .required(true),
+            )
+            .arg(
+                Arg::with_name("queue")
+                    .long("queue")
+                    .short("q")
+                    .value_name("QUEUE")
+                    .help("The name of the queue to use for the Service Bus trigger.")
+                    .conflicts_with_all(&["topic", "subscription"])
+                    .required(true),
+            )
+            .arg(
+                Arg::with_name("topic")
+                    .long("topic")
+                    .short("t")
+                    .value_name("TOPIC")
+                    .help("The name of the topic to use for the Service Bus trigger.")
+                    .conflicts_with("queue")
+                    .required(true),
+            )
+            .arg(
+                Arg::with_name("subscription")
+                    .long("subscription")
+                    .short("s")
+                    .value_name("SUBSCRIPTION")
+                    .help("The name of the subscription to use for the Service Bus trigger.")
+                    .conflicts_with("queue")
+                    .required(true),
+            )
+    }
+
+    pub fn execute(&self, quiet: bool) -> Result<(), String> {
+        let data = json!({
+            "name": self.name,
+            "connection": self.connection,
+            "queue": self.queue,
+            "topic": self.topic,
+            "subscription": self.subscription
+        });
+
+        create_function(self.name, "servicebus.rs", &data, quiet)
+    }
+}
+
+impl<'a> From<&'a ArgMatches<'a>> for ServiceBus<'a> {
+    fn from(args: &'a ArgMatches<'a>) -> Self {
+        ServiceBus {
+            name: args.value_of("name").unwrap(),
+            connection: args.value_of("connection").unwrap(),
+            queue: args.value_of("queue"),
+            topic: args.value_of("topic"),
+            subscription: args.value_of("subscription"),
+        }
+    }
+}

--- a/azure-functions-sdk/src/commands/new/timer.rs
+++ b/azure-functions-sdk/src/commands/new/timer.rs
@@ -1,6 +1,4 @@
-use crate::{
-    commands::new::create_function,
-};
+use crate::commands::new::create_function;
 use clap::{App, Arg, ArgMatches, SubCommand};
 use serde_json::json;
 

--- a/azure-functions-sdk/src/commands/new/timer.rs
+++ b/azure-functions-sdk/src/commands/new/timer.rs
@@ -1,0 +1,51 @@
+use crate::{
+    commands::new::create_function,
+};
+use clap::{App, Arg, ArgMatches, SubCommand};
+use serde_json::json;
+
+pub struct Timer<'a> {
+    name: &'a str,
+    schedule: &'a str,
+}
+
+impl<'a> Timer<'a> {
+    pub fn create_subcommand<'b>() -> App<'a, 'b> {
+        SubCommand::with_name("timer")
+            .about("Creates a new timer triggered Azure Function.")
+            .arg(
+                Arg::with_name("name")
+                    .long("name")
+                    .short("n")
+                    .value_name("NAME")
+                    .help("The name of the new Azure Function.")
+                    .required(true),
+            )
+            .arg(
+                Arg::with_name("schedule")
+                    .long("schedule")
+                    .short("s")
+                    .value_name("SCHEDULE")
+                    .help("The timer schedule as a cron-expression.")
+                    .required(true),
+            )
+    }
+
+    pub fn execute(&self, quiet: bool) -> Result<(), String> {
+        let data = json!({
+            "name": self.name,
+            "schedule": self.schedule,
+        });
+
+        create_function(self.name, "timer.rs", &data, quiet)
+    }
+}
+
+impl<'a> From<&'a ArgMatches<'a>> for Timer<'a> {
+    fn from(args: &'a ArgMatches<'a>) -> Self {
+        Timer {
+            name: args.value_of("name").unwrap(),
+            schedule: args.value_of("schedule").unwrap(),
+        }
+    }
+}

--- a/azure-functions-sdk/src/commands/new/utils.rs
+++ b/azure-functions-sdk/src/commands/new/utils.rs
@@ -1,0 +1,189 @@
+use crate::{
+    util::{create_from_template, print_failure, print_running, print_success},
+};
+use regex::Regex;
+use serde_json::{json, Value};
+use std::{
+    fmt::Write,
+    fs::{remove_file, File},
+    io::Read,
+    path::Path,
+};
+use syn::{parse_file, Expr, ExprArray, Item};
+
+fn get_path_for_function(name: &str) -> Result<String, String> {
+    if !Regex::new("^[a-zA-Z][a-zA-Z0-9_]*$")
+        .unwrap()
+        .is_match(name)
+    {
+        return Err("Function name must start with a letter and only contain letters, numbers, and underscores.".to_string());
+    }
+
+    if name.len() > 127 {
+        return Err("Function names cannot exceed 127 characters.".to_string());
+    }
+
+    if !Path::new("src/functions").is_dir() {
+        return Err("Directory 'src/functions' does not exist.".to_string());
+    }
+
+    let path = format!("src/functions/{}.rs", name);
+    if Path::new(&path).exists() {
+        return Err(format!("'{}' already exists.", path));
+    }
+
+    Ok(path)
+}
+
+fn create_function(name: &str, template: &str, data: &Value, quiet: bool) -> Result<(), String> {
+    let path = get_path_for_function(name)?;
+
+    if !quiet {
+        print_running(&format!("creating {}.", path.cyan()));
+    }
+
+    create_from_template(&TEMPLATES, template, "", &path, data)
+        .map(|_| {
+            if !quiet {
+                print_success();
+            }
+        })
+        .map_err(|e| {
+            if !quiet {
+                print_failure();
+            }
+            e
+        })?;
+
+    if !quiet {
+        print_running(&format!(
+            "exporting function {} in {}.",
+            name.cyan(),
+            "src/functions/mod.rs".cyan()
+        ));
+    }
+
+    export_function(name)
+        .map(|_| {
+            if !quiet {
+                print_success();
+            }
+        })
+        .map_err(|e| {
+            if !quiet {
+                print_failure();
+            }
+            remove_file(path).expect("failed to delete source file");
+            e
+        })?;
+
+    Ok(())
+}
+
+fn format_path(path: &syn::Path) -> String {
+    let mut formatted = String::new();
+    if path.leading_colon.is_some() {
+        formatted.push_str("::");
+    }
+
+    let mut first = true;
+    for segment in &path.segments {
+        if first {
+            first = false;
+        } else {
+            formatted.push_str("::");
+        }
+
+        write!(formatted, "{}", segment.ident).unwrap();
+    }
+
+    formatted
+}
+
+fn parse_array_elements(array: &ExprArray, functions: &mut Vec<String>) -> bool {
+    for elem in &array.elems {
+        match elem {
+            Expr::Reference(r) => match &*r.expr {
+                Expr::Path(p) => {
+                    functions.push(format_path(&p.path));
+                }
+                _ => {
+                    return false;
+                }
+            },
+            _ => {
+                return false;
+            }
+        }
+    }
+
+    true
+}
+
+fn export_function(name: &str) -> Result<(), String> {
+    let mut file =
+        File::open("src/functions/mod.rs").map_err(|_| "'src/functions/mod.rs' does not exist.")?;
+
+    let mut source = String::new();
+    file.read_to_string(&mut source)
+        .map_err(|_| "failed to read 'src/functions/mod.rs'.")?;
+
+    let ast = parse_file(&source).map_err(|_| "failed to parse 'src/functions/mod.rs'.")?;
+
+    let mut modules = Vec::new();
+    let mut exports = None;
+
+    for item in ast.items {
+        match item {
+            Item::Mod(m) => {
+                modules.push(m.ident.to_string());
+            }
+            Item::Const(c) => {
+                if exports.is_some() {
+                    return Err(
+                        "multiple 'EXPORTS' constants found in 'src/functions/mod.rs'.".to_string(),
+                    );
+                }
+
+                if c.ident == "EXPORTS" {
+                    exports = Some(c);
+                }
+            }
+            _ => {}
+        }
+    }
+
+    let mut functions = Vec::new();
+
+    let found = match &exports {
+        None => false,
+        Some(exports) => match &*exports.expr {
+            Expr::Reference(r) => match &*r.expr {
+                Expr::Array(a) => parse_array_elements(a, &mut functions),
+                _ => false,
+            },
+            _ => false,
+        },
+    };
+
+    if !found {
+        return Err("failed to find 'EXPORTS' constant in 'src/functions/mod.rs'.".to_string());
+    }
+
+    modules.push(name.to_string());
+    modules.sort();
+
+    functions.push(format!("{}::{}_FUNCTION", name, name.to_uppercase()));
+    functions.sort();
+
+    create_from_template(
+        &TEMPLATES,
+        "functions_mod.rs",
+        "",
+        "src/functions/mod.rs",
+        &json!({
+            "modules": modules,
+            "functions": functions
+        }),
+    )
+}


### PR DESCRIPTION
## What is the goal of this pull request?

To address #372

## What does this pull request change?

It pulls out the subcommands in new.rs into submodules of their own. This involved pub-exporting the relevant structs and declaring and using the submodules from new.rs.

## What work remains to be done?

Nothing else

## Do you consider it adequately tested?

Ran cargo build successfully.

## Related Issues

## Notes
