### PR TITLE
Change `export!` macro to take function paths.

### DIFF
--- a/azure-functions-codegen/src/lib.rs
+++ b/azure-functions-codegen/src/lib.rs
@@ -41,12 +41,11 @@ fn attribute_args_from_name(name: &str, span: Span) -> AttributeArgs {
 
 /// Implements the `export!` macro.
 ///
-/// The `export!` macro is used to export a list of modules as Azure Functions.
+/// The `export!` macro is used to export a list of Rust functions as Azure Functions.
 ///
-/// This macro expects a comma-separated list of module names that implement a
-/// function of the same name with the `#[func]` attribute applied.
+/// This macro expects a comma-separated list of Rust functions with the `#[func]` attribute applied.
 ///
-/// A `EXPORTS` constant is declared by the macro.
+/// An `EXPORTS` constant is declared by the macro.
 ///
 /// # Examples
 ///
@@ -54,7 +53,7 @@ fn attribute_args_from_name(name: &str, span: Span) -> AttributeArgs {
 /// mod example;
 ///
 /// azure_functions::export! {
-///     example
+///     example::function
 /// }
 ///
 /// fn main() {

--- a/azure-functions-sdk/src/templates/new-app/functions_mod.rs.hbs
+++ b/azure-functions-sdk/src/templates/new-app/functions_mod.rs.hbs
@@ -6,6 +6,6 @@
 {{/if~}}
 // Export the Azure Functions here.
 azure_functions::export! { {{~#each exports}}
-    {{this}},{{else~}}{{/each~}}{{~#if exports}}
+    {{this}}::{{this}},{{else~}}{{/each~}}{{~#if exports}}
 {{/if~}}
 }

--- a/azure-functions/src/lib.rs
+++ b/azure-functions/src/lib.rs
@@ -136,10 +136,10 @@ pub trait FromVec<T> {
 /// # Examples
 ///
 /// ```rust,ignore
-/// mod my_function;
+/// mod example;
 ///
 /// azure_functions::export! {
-///     my_function,
+///     example::function,
 /// }
 ///
 /// fn main() {

--- a/examples/blob/src/functions/mod.rs
+++ b/examples/blob/src/functions/mod.rs
@@ -7,8 +7,8 @@ mod print_blob;
 
 // Export the Azure Functions here.
 azure_functions::export! {
-    blob_watcher,
-    copy_blob,
-    create_blob,
-    print_blob,
+    blob_watcher::blob_watcher,
+    copy_blob::copy_blob,
+    create_blob::create_blob,
+    print_blob::print_blob,
 }

--- a/examples/cosmosdb/src/functions/mod.rs
+++ b/examples/cosmosdb/src/functions/mod.rs
@@ -7,8 +7,8 @@ mod read_document;
 
 // Export the Azure Functions here.
 azure_functions::export! {
-    create_document,
-    log_documents,
-    query_documents,
-    read_document,
+    create_document::create_document,
+    log_documents::log_documents,
+    query_documents::query_documents,
+    read_document::read_document,
 }

--- a/examples/event-grid/src/functions/mod.rs
+++ b/examples/event-grid/src/functions/mod.rs
@@ -4,5 +4,5 @@ mod log_event;
 
 // Export the Azure Functions here.
 azure_functions::export! {
-    log_event
+    log_event::log_event
 }

--- a/examples/event-hub/src/functions/mod.rs
+++ b/examples/event-hub/src/functions/mod.rs
@@ -5,6 +5,6 @@ mod log_event;
 
 // Export the Azure Functions here.
 azure_functions::export! {
-    create_event,
-    log_event,
+    create_event::create_event,
+    log_event::log_event,
 }

--- a/examples/generic/src/functions/mod.rs
+++ b/examples/generic/src/functions/mod.rs
@@ -7,8 +7,8 @@ mod read_document;
 
 // Export the Azure Functions here.
 azure_functions::export! {
-    create_document,
-    log_documents,
-    query_documents,
-    read_document,
+    create_document::create_document,
+    log_documents::log_documents,
+    query_documents::query_documents,
+    read_document::read_document,
 }

--- a/examples/http/src/functions/mod.rs
+++ b/examples/http/src/functions/mod.rs
@@ -8,14 +8,14 @@ mod greet_with_json;
 // Export the Azure Functions here.
 #[cfg(feature = "unstable")]
 azure_functions::export! {
-    greet,
-    greet_async,
-    greet_with_json,
+    greet::greet,
+    greet_async::greet_async,
+    greet_with_json::greet_with_json,
 }
 
 // Export the Azure Functions here.
 #[cfg(not(feature = "unstable"))]
 azure_functions::export! {
-    greet,
-    greet_with_json,
+    greet::greet,
+    greet_with_json::greet_with_json,
 }

--- a/examples/queue/src/functions/mod.rs
+++ b/examples/queue/src/functions/mod.rs
@@ -5,6 +5,6 @@ mod queue_with_output;
 
 // Export the Azure Functions here.
 azure_functions::export! {
-    queue,
-    queue_with_output,
+    queue::queue,
+    queue_with_output::queue_with_output,
 }

--- a/examples/sendgrid/src/functions/mod.rs
+++ b/examples/sendgrid/src/functions/mod.rs
@@ -4,5 +4,5 @@ mod send_email;
 
 // Export the Azure Functions here.
 azure_functions::export! {
-    send_email,
+    send_email::send_email,
 }

--- a/examples/service-bus/src/functions/mod.rs
+++ b/examples/service-bus/src/functions/mod.rs
@@ -7,8 +7,8 @@ mod log_topic_message;
 
 // Export the Azure Functions here.
 azure_functions::export! {
-    create_queue_message,
-    create_topic_message,
-    log_queue_message,
-    log_topic_message,
+    create_queue_message::create_queue_message,
+    create_topic_message::create_topic_message,
+    log_queue_message::log_queue_message,
+    log_topic_message::log_topic_message,
 }

--- a/examples/signalr/src/functions/mod.rs
+++ b/examples/signalr/src/functions/mod.rs
@@ -7,8 +7,8 @@ mod send_message;
 
 // Export the Azure Functions here.
 azure_functions::export! {
-    add_to_group,
-    negotiate,
-    remove_from_group,
-    send_message,
+    add_to_group::add_to_group,
+    negotiate::negotiate,
+    remove_from_group::remove_from_group,
+    send_message::send_message,
 }

--- a/examples/table/src/functions/mod.rs
+++ b/examples/table/src/functions/mod.rs
@@ -5,6 +5,6 @@ mod read_row;
 
 // Export the Azure Functions here.
 azure_functions::export! {
-    create_row,
-    read_row,
+    create_row::create_row,
+    read_row::read_row,
 }

--- a/examples/timer/src/functions/mod.rs
+++ b/examples/timer/src/functions/mod.rs
@@ -4,5 +4,5 @@ mod timer;
 
 // Export the Azure Functions here.
 azure_functions::export! {
-    timer,
+    timer::timer,
 }

--- a/examples/twilio/src/functions/mod.rs
+++ b/examples/twilio/src/functions/mod.rs
@@ -4,5 +4,5 @@ mod send_sms;
 
 // Export the Azure Functions here.
 azure_functions::export! {
-    send_sms,
+    send_sms::send_sms,
 }


### PR DESCRIPTION
This commit changes the `export!` macro to take function paths instead of
module names.

This will allow users to define multiple Azure Functions in a single module.

It is a breaking change that will be rolled into the previous breaking change.
