### PR TITLE
Implement DurableOrchestrationContext::call_activity_with_retry.

### DIFF
--- a/azure-functions/src/durable.rs
+++ b/azure-functions/src/durable.rs
@@ -20,10 +20,10 @@ mod orchestration_output;
 mod orchestration_state;
 mod select_all;
 
-pub(crate) use self::action_future::*;
+pub use self::action_future::*;
 pub use self::actions::*;
 pub use self::activity_output::*;
-pub use self::history::*;
+pub(crate) use self::history::*;
 pub use self::join_all::*;
 pub use self::orchestration_output::*;
 pub use self::orchestration_state::*;

--- a/azure-functions/src/durable/action_future.rs
+++ b/azure-functions/src/durable/action_future.rs
@@ -7,7 +7,8 @@ use std::{
     task::{Context, Poll},
 };
 
-pub(crate) struct ActionFuture<T> {
+/// Future returned by various `DurableOrchestrationContext` functions.
+pub struct ActionFuture<T> {
     result: Option<T>,
     state: Rc<RefCell<OrchestrationState>>,
     event_index: Option<usize>,

--- a/azure-functions/src/durable/actions.rs
+++ b/azure-functions/src/durable/actions.rs
@@ -9,18 +9,22 @@ pub struct RetryOptions {
     /// The first retry interval in milliseconds.
     #[serde(rename = "firstRetryIntervalInMilliseconds")]
     pub first_retry_interval_ms: i32,
+
     /// The maximum number of retry attempts.
     #[serde(rename = "maxNumberOfAttempts")]
     pub max_attempts: i32,
+
     /// The backoff coefficient used to determine rate of increase of backoff. Defaults to 1.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub backoff_coefficient: Option<f64>,
+
     /// The max retry interval in milliseconds.
     #[serde(
         rename = "maxRetryIntervalInMilliseconds",
         skip_serializing_if = "Option::is_none"
     )]
     pub max_retry_interval_ms: Option<i32>,
+
     /// The timeout for retries in milliseconds.
     #[serde(
         rename = "retryTimeoutInMilliseconds",

--- a/azure-functions/src/durable/actions.rs
+++ b/azure-functions/src/durable/actions.rs
@@ -2,10 +2,37 @@ use chrono::{DateTime, Utc};
 use serde::Serialize;
 use serde_json::Value;
 
-#[doc(hidden)]
+/// Defines retry policies that can be passed as parameters to various Durable Functions operations.
+#[derive(Debug, Clone, Default, Serialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct RetryOptions {
+    /// The first retry interval in milliseconds.
+    #[serde(rename = "firstRetryIntervalInMilliseconds")]
+    pub first_retry_interval_ms: i32,
+    /// The maximum number of retry attempts.
+    #[serde(rename = "maxNumberOfAttempts")]
+    pub max_attempts: i32,
+    /// The backoff coefficient used to determine rate of increase of backoff. Defaults to 1.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub backoff_coefficient: Option<f64>,
+    /// The max retry interval in milliseconds.
+    #[serde(
+        rename = "maxRetryIntervalInMilliseconds",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub max_retry_interval_ms: Option<i32>,
+    /// The timeout for retries in milliseconds.
+    #[serde(
+        rename = "retryTimeoutInMilliseconds",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub retry_timeout_ms: Option<i32>,
+}
+
+#[allow(dead_code)]
 #[derive(Debug, Clone, Serialize, PartialEq)]
 #[serde(tag = "actionType", rename_all = "camelCase")]
-pub enum Action {
+pub(crate) enum Action {
     #[serde(rename_all = "camelCase")]
     CallActivity { function_name: String, input: Value },
 
@@ -44,14 +71,6 @@ pub enum Action {
 
     #[serde(rename_all = "camelCase")]
     WaitForExternalEvent { external_event_name: String },
-}
-
-#[doc(hidden)]
-#[derive(Debug, Clone, Serialize, PartialEq)]
-#[serde(rename_all = "camelCase")]
-pub struct RetryOptions {
-    first_retry_interval_in_milliseconds: i32,
-    max_number_of_attempts: i32,
 }
 
 #[cfg(test)]

--- a/azure-functions/src/durable/history.rs
+++ b/azure-functions/src/durable/history.rs
@@ -11,7 +11,7 @@ use serde_repr::Deserialize_repr;
 
 #[derive(Debug, Clone, Deserialize, PartialEq)]
 #[serde(rename_all = "PascalCase")]
-pub(crate) struct HistoryEvent {
+pub struct HistoryEvent {
     pub event_type: EventType,
 
     pub event_id: i32,
@@ -53,7 +53,7 @@ pub(crate) struct HistoryEvent {
 
 #[derive(Debug, Clone, Deserialize_repr, PartialEq)]
 #[repr(u8)]
-pub(crate) enum EventType {
+pub enum EventType {
     ExecutionStarted = 0,
     ExecutionCompleted = 1,
     ExecutionFailed = 2,

--- a/azure-functions/src/durable/history.rs
+++ b/azure-functions/src/durable/history.rs
@@ -9,50 +9,48 @@ use serde_repr::Deserialize_repr;
 // i.e conversion { EventType = 0, EventId = 1, ...} => ExecutionStarted(ExecutionStartedEvent)
 // in future we can implement manual translation
 
-#[doc(hidden)]
 #[derive(Debug, Clone, Deserialize, PartialEq)]
 #[serde(rename_all = "PascalCase")]
-pub struct HistoryEvent {
-    pub(crate) event_type: EventType,
+pub(crate) struct HistoryEvent {
+    pub event_type: EventType,
 
-    pub(crate) event_id: i32,
+    pub event_id: i32,
 
-    pub(crate) is_played: bool,
+    pub is_played: bool,
 
-    pub(crate) timestamp: DateTime<Utc>,
+    pub timestamp: DateTime<Utc>,
 
     #[serde(skip)]
-    pub(crate) is_processed: bool,
+    pub is_processed: bool,
 
     // EventRaised, ExecutionStarted, SubOrchestrationInstanceCreated, TaskScheduled
-    pub(crate) name: Option<String>,
+    pub name: Option<String>,
 
     // EventRaised, ExecutionStarted, SubOrchestrationInstanceCreated, TaskScheduled
-    pub(crate) input: Option<Value>,
+    pub input: Option<Value>,
 
     //SubOrchestrationInstanceCompleted, TaskCompleted
-    pub(crate) result: Option<String>,
+    pub result: Option<String>,
 
     // SubOrchestrationInstanceCompleted , SubOrchestrationInstanceFailed, TaskCompleted,TaskFailed
-    pub(crate) task_scheduled_id: Option<i32>,
+    pub task_scheduled_id: Option<i32>,
 
     // SubOrchestrationInstanceCreated
-    pub(crate) instance_id: Option<String>,
+    pub instance_id: Option<String>,
 
     //SubOrchestrationInstanceFailed, TaskFailed
-    pub(crate) reason: Option<String>,
+    pub reason: Option<String>,
 
     // SubOrchestrationInstanceFailed,TaskFailed
-    pub(crate) details: Option<String>,
+    pub details: Option<String>,
 
     //TimerCreated, TimerFired
-    pub(crate) fire_at: Option<DateTime<Utc>>,
+    pub fire_at: Option<DateTime<Utc>>,
 
     //TimerFired
-    pub(crate) timer_id: Option<i32>,
+    pub timer_id: Option<i32>,
 }
 
-#[doc(hidden)]
 #[derive(Debug, Clone, Deserialize_repr, PartialEq)]
 #[repr(u8)]
 pub(crate) enum EventType {


### PR DESCRIPTION
This commit implements the `call_activity_with_retry` method.

It refactors the code to return `ActionFuture` rather than `impl Future`.  This
will allow the `join_all` and `select_all` methods to use a mix of
`call_activity` and `call_activity_with_retry`, which is not possible if both
methods return `impl Future`.