### PR TITLE
`--name` should work both as a positional arg and as an option arg

### DIFF
--- a/azure-functions-sdk/src/commands/new/blob.rs
+++ b/azure-functions-sdk/src/commands/new/blob.rs
@@ -48,9 +48,10 @@ impl<'a> Blob<'a> {
 impl<'a> From<&'a ArgMatches<'a>> for Blob<'a> {
     fn from(args: &'a ArgMatches<'a>) -> Self {
         Blob {
-            name: args.value_of("positional-name")
-                    .unwrap_or_else(|| args.value_of("name")
-                    .unwrap_or("Default fallback - never reached")),
+            name: args.value_of("positional-name").unwrap_or_else(|| {
+                args.value_of("name")
+                    .unwrap_or("Default fallback - never reached")
+            }),
             path: args.value_of("path").unwrap(),
         }
     }

--- a/azure-functions-sdk/src/commands/new/blob.rs
+++ b/azure-functions-sdk/src/commands/new/blob.rs
@@ -12,12 +12,18 @@ impl<'a> Blob<'a> {
         SubCommand::with_name("blob")
             .about("Creates a new blob triggered Azure Function.")
             .arg(
+                Arg::with_name("positional-name")
+                    .value_name("NAME")
+                    .help("The name of the new Azure Function. You may specify this as --name <NAME> instead.")
+                    .conflicts_with("name")
+                    .required(true),
+            )
+            .arg(
                 Arg::with_name("name")
                     .long("name")
                     .short("n")
                     .value_name("NAME")
-                    .help("The name of the new Azure Function.")
-                    .required(true),
+                    .help("The name of the new Azure Function. You may specify this as <NAME> instead (i.e., without typing --name).")
             )
             .arg(
                 Arg::with_name("path")
@@ -42,7 +48,9 @@ impl<'a> Blob<'a> {
 impl<'a> From<&'a ArgMatches<'a>> for Blob<'a> {
     fn from(args: &'a ArgMatches<'a>) -> Self {
         Blob {
-            name: args.value_of("name").unwrap(),
+            name: args.value_of("positional-name")
+                    .unwrap_or_else(|| args.value_of("name")
+                    .unwrap_or("Default fallback - never reached")),
             path: args.value_of("path").unwrap(),
         }
     }

--- a/azure-functions-sdk/src/commands/new/blob.rs
+++ b/azure-functions-sdk/src/commands/new/blob.rs
@@ -48,10 +48,9 @@ impl<'a> Blob<'a> {
 impl<'a> From<&'a ArgMatches<'a>> for Blob<'a> {
     fn from(args: &'a ArgMatches<'a>) -> Self {
         Blob {
-            name: args.value_of("positional-name").unwrap_or_else(|| {
-                args.value_of("name")
-                    .expect("A NAME argument is needed")
-            }),
+            name: args
+                .value_of("positional-name")
+                .unwrap_or_else(|| args.value_of("name").expect("A NAME argument is needed")),
             path: args.value_of("path").unwrap(),
         }
     }

--- a/azure-functions-sdk/src/commands/new/blob.rs
+++ b/azure-functions-sdk/src/commands/new/blob.rs
@@ -50,7 +50,7 @@ impl<'a> From<&'a ArgMatches<'a>> for Blob<'a> {
         Blob {
             name: args.value_of("positional-name").unwrap_or_else(|| {
                 args.value_of("name")
-                    .unwrap_or("Default fallback - never reached")
+                    .expect("A NAME argument is needed")
             }),
             path: args.value_of("path").unwrap(),
         }

--- a/azure-functions-sdk/src/commands/new/cosmos_db.rs
+++ b/azure-functions-sdk/src/commands/new/cosmos_db.rs
@@ -68,9 +68,10 @@ impl<'a> CosmosDb<'a> {
 impl<'a> From<&'a ArgMatches<'a>> for CosmosDb<'a> {
     fn from(args: &'a ArgMatches<'a>) -> Self {
         CosmosDb {
-            name: args.value_of("positional-name")
-                    .unwrap_or_else(|| args.value_of("name")
-                    .unwrap_or("Default fallback - never reached")),
+            name: args.value_of("positional-name").unwrap_or_else(|| {
+                args.value_of("name")
+                    .unwrap_or("Default fallback - never reached")
+            }),
             connection: args.value_of("connection").unwrap(),
             database: args.value_of("database").unwrap(),
             collection: args.value_of("collection").unwrap(),

--- a/azure-functions-sdk/src/commands/new/cosmos_db.rs
+++ b/azure-functions-sdk/src/commands/new/cosmos_db.rs
@@ -14,12 +14,18 @@ impl<'a> CosmosDb<'a> {
         SubCommand::with_name("cosmos-db")
             .about("Creates a new Cosmos DB triggered Azure Function.")
             .arg(
+                Arg::with_name("positional-name")
+                    .value_name("NAME")
+                    .help("The name of the new Azure Function. You may specify this as --name <NAME> instead.")
+                    .conflicts_with("name")
+                    .required(true),
+            )
+            .arg(
                 Arg::with_name("name")
                     .long("name")
                     .short("n")
                     .value_name("NAME")
-                    .help("The name of the new Azure Function.")
-                    .required(true),
+                    .help("The name of the new Azure Function. You may specify this as <NAME> instead (i.e., without typing --name).")
             )
             .arg(
                 Arg::with_name("connection")
@@ -62,7 +68,9 @@ impl<'a> CosmosDb<'a> {
 impl<'a> From<&'a ArgMatches<'a>> for CosmosDb<'a> {
     fn from(args: &'a ArgMatches<'a>) -> Self {
         CosmosDb {
-            name: args.value_of("name").unwrap(),
+            name: args.value_of("positional-name")
+                    .unwrap_or_else(|| args.value_of("name")
+                    .unwrap_or("Default fallback - never reached")),
             connection: args.value_of("connection").unwrap(),
             database: args.value_of("database").unwrap(),
             collection: args.value_of("collection").unwrap(),

--- a/azure-functions-sdk/src/commands/new/cosmos_db.rs
+++ b/azure-functions-sdk/src/commands/new/cosmos_db.rs
@@ -68,10 +68,9 @@ impl<'a> CosmosDb<'a> {
 impl<'a> From<&'a ArgMatches<'a>> for CosmosDb<'a> {
     fn from(args: &'a ArgMatches<'a>) -> Self {
         CosmosDb {
-            name: args.value_of("positional-name").unwrap_or_else(|| {
-                args.value_of("name")
-                    .expect("A NAME argument is needed")
-            }),
+            name: args
+                .value_of("positional-name")
+                .unwrap_or_else(|| args.value_of("name").expect("A NAME argument is needed")),
             connection: args.value_of("connection").unwrap(),
             database: args.value_of("database").unwrap(),
             collection: args.value_of("collection").unwrap(),

--- a/azure-functions-sdk/src/commands/new/cosmos_db.rs
+++ b/azure-functions-sdk/src/commands/new/cosmos_db.rs
@@ -70,7 +70,7 @@ impl<'a> From<&'a ArgMatches<'a>> for CosmosDb<'a> {
         CosmosDb {
             name: args.value_of("positional-name").unwrap_or_else(|| {
                 args.value_of("name")
-                    .unwrap_or("Default fallback - never reached")
+                    .expect("A NAME argument is needed")
             }),
             connection: args.value_of("connection").unwrap(),
             database: args.value_of("database").unwrap(),

--- a/azure-functions-sdk/src/commands/new/event_grid.rs
+++ b/azure-functions-sdk/src/commands/new/event_grid.rs
@@ -38,10 +38,9 @@ impl<'a> EventGrid<'a> {
 impl<'a> From<&'a ArgMatches<'a>> for EventGrid<'a> {
     fn from(args: &'a ArgMatches<'a>) -> Self {
         EventGrid {
-            name: args.value_of("positional-name").unwrap_or_else(|| {
-                args.value_of("name")
-                    .expect("A NAME argument is needed")
-            }),
+            name: args
+                .value_of("positional-name")
+                .unwrap_or_else(|| args.value_of("name").expect("A NAME argument is needed")),
         }
     }
 }

--- a/azure-functions-sdk/src/commands/new/event_grid.rs
+++ b/azure-functions-sdk/src/commands/new/event_grid.rs
@@ -11,12 +11,18 @@ impl<'a> EventGrid<'a> {
         SubCommand::with_name("event-grid")
             .about("Creates a new Event Grid triggered Azure Function.")
             .arg(
+                Arg::with_name("positional-name")
+                    .value_name("NAME")
+                    .help("The name of the new Azure Function. You may specify this as --name <NAME> instead.")
+                    .conflicts_with("name")
+                    .required(true),
+            )
+            .arg(
                 Arg::with_name("name")
                     .long("name")
                     .short("n")
                     .value_name("NAME")
-                    .help("The name of the new Azure Function.")
-                    .required(true),
+                    .help("The name of the new Azure Function. You may specify this as <NAME> instead (i.e., without typing --name).")
             )
     }
 
@@ -32,7 +38,9 @@ impl<'a> EventGrid<'a> {
 impl<'a> From<&'a ArgMatches<'a>> for EventGrid<'a> {
     fn from(args: &'a ArgMatches<'a>) -> Self {
         EventGrid {
-            name: args.value_of("name").unwrap(),
+            name: args.value_of("positional-name")
+                    .unwrap_or_else(|| args.value_of("name")
+                    .unwrap_or("Default fallback - never reached")),
         }
     }
 }

--- a/azure-functions-sdk/src/commands/new/event_grid.rs
+++ b/azure-functions-sdk/src/commands/new/event_grid.rs
@@ -40,7 +40,7 @@ impl<'a> From<&'a ArgMatches<'a>> for EventGrid<'a> {
         EventGrid {
             name: args.value_of("positional-name").unwrap_or_else(|| {
                 args.value_of("name")
-                    .unwrap_or("Default fallback - never reached")
+                    .expect("A NAME argument is needed")
             }),
         }
     }

--- a/azure-functions-sdk/src/commands/new/event_grid.rs
+++ b/azure-functions-sdk/src/commands/new/event_grid.rs
@@ -38,9 +38,10 @@ impl<'a> EventGrid<'a> {
 impl<'a> From<&'a ArgMatches<'a>> for EventGrid<'a> {
     fn from(args: &'a ArgMatches<'a>) -> Self {
         EventGrid {
-            name: args.value_of("positional-name")
-                    .unwrap_or_else(|| args.value_of("name")
-                    .unwrap_or("Default fallback - never reached")),
+            name: args.value_of("positional-name").unwrap_or_else(|| {
+                args.value_of("name")
+                    .unwrap_or("Default fallback - never reached")
+            }),
         }
     }
 }

--- a/azure-functions-sdk/src/commands/new/event_hub.rs
+++ b/azure-functions-sdk/src/commands/new/event_hub.rs
@@ -13,12 +13,18 @@ impl<'a> EventHub<'a> {
         SubCommand::with_name("event-hub")
             .about("Creates a new Event Hub triggered Azure Function.")
             .arg(
+                Arg::with_name("positional-name")
+                    .value_name("NAME")
+                    .help("The name of the new Azure Function. You may specify this as --name <NAME> instead.")
+                    .conflicts_with("name")
+                    .required(true),
+            )
+            .arg(
                 Arg::with_name("name")
                     .long("name")
                     .short("n")
                     .value_name("NAME")
-                    .help("The name of the new Azure Function.")
-                    .required(true),
+                    .help("The name of the new Azure Function. You may specify this as <NAME> instead (i.e., without typing --name).")
             )
             .arg(
                 Arg::with_name("connection")
@@ -51,7 +57,9 @@ impl<'a> EventHub<'a> {
 impl<'a> From<&'a ArgMatches<'a>> for EventHub<'a> {
     fn from(args: &'a ArgMatches<'a>) -> Self {
         EventHub {
-            name: args.value_of("name").unwrap(),
+            name: args.value_of("positional-name")
+                    .unwrap_or_else(|| args.value_of("name")
+                    .unwrap_or("Default fallback - never reached")),
             connection: args.value_of("connection").unwrap(),
             hub_name: args.value_of("hub_name").unwrap_or(""),
         }

--- a/azure-functions-sdk/src/commands/new/event_hub.rs
+++ b/azure-functions-sdk/src/commands/new/event_hub.rs
@@ -57,10 +57,9 @@ impl<'a> EventHub<'a> {
 impl<'a> From<&'a ArgMatches<'a>> for EventHub<'a> {
     fn from(args: &'a ArgMatches<'a>) -> Self {
         EventHub {
-            name: args.value_of("positional-name").unwrap_or_else(|| {
-                args.value_of("name")
-                    .expect("A NAME argument is needed")
-            }),
+            name: args
+                .value_of("positional-name")
+                .unwrap_or_else(|| args.value_of("name").expect("A NAME argument is needed")),
             connection: args.value_of("connection").unwrap(),
             hub_name: args.value_of("hub_name").unwrap_or(""),
         }

--- a/azure-functions-sdk/src/commands/new/event_hub.rs
+++ b/azure-functions-sdk/src/commands/new/event_hub.rs
@@ -59,7 +59,7 @@ impl<'a> From<&'a ArgMatches<'a>> for EventHub<'a> {
         EventHub {
             name: args.value_of("positional-name").unwrap_or_else(|| {
                 args.value_of("name")
-                    .unwrap_or("Default fallback - never reached")
+                    .expect("A NAME argument is needed")
             }),
             connection: args.value_of("connection").unwrap(),
             hub_name: args.value_of("hub_name").unwrap_or(""),

--- a/azure-functions-sdk/src/commands/new/event_hub.rs
+++ b/azure-functions-sdk/src/commands/new/event_hub.rs
@@ -57,9 +57,10 @@ impl<'a> EventHub<'a> {
 impl<'a> From<&'a ArgMatches<'a>> for EventHub<'a> {
     fn from(args: &'a ArgMatches<'a>) -> Self {
         EventHub {
-            name: args.value_of("positional-name")
-                    .unwrap_or_else(|| args.value_of("name")
-                    .unwrap_or("Default fallback - never reached")),
+            name: args.value_of("positional-name").unwrap_or_else(|| {
+                args.value_of("name")
+                    .unwrap_or("Default fallback - never reached")
+            }),
             connection: args.value_of("connection").unwrap(),
             hub_name: args.value_of("hub_name").unwrap_or(""),
         }

--- a/azure-functions-sdk/src/commands/new/http.rs
+++ b/azure-functions-sdk/src/commands/new/http.rs
@@ -49,7 +49,7 @@ impl<'a> From<&'a ArgMatches<'a>> for Http<'a> {
         Http {
             name: args.value_of("positional-name").unwrap_or_else(|| {
                 args.value_of("name")
-                    .unwrap_or("Default fallback - never reached")
+                    .expect("A NAME argument is needed")
             }),
             auth_level: match args.value_of("auth-level") {
                 Some(level) => {

--- a/azure-functions-sdk/src/commands/new/http.rs
+++ b/azure-functions-sdk/src/commands/new/http.rs
@@ -47,9 +47,10 @@ impl<'a> Http<'a> {
 impl<'a> From<&'a ArgMatches<'a>> for Http<'a> {
     fn from(args: &'a ArgMatches<'a>) -> Self {
         Http {
-            name: args.value_of("positional-name")
-                    .unwrap_or_else(|| args.value_of("name")
-                    .unwrap_or("Default fallback - never reached")),
+            name: args.value_of("positional-name").unwrap_or_else(|| {
+                args.value_of("name")
+                    .unwrap_or("Default fallback - never reached")
+            }),
             auth_level: match args.value_of("auth-level") {
                 Some(level) => {
                     if level == "function" {

--- a/azure-functions-sdk/src/commands/new/http.rs
+++ b/azure-functions-sdk/src/commands/new/http.rs
@@ -47,10 +47,9 @@ impl<'a> Http<'a> {
 impl<'a> From<&'a ArgMatches<'a>> for Http<'a> {
     fn from(args: &'a ArgMatches<'a>) -> Self {
         Http {
-            name: args.value_of("positional-name").unwrap_or_else(|| {
-                args.value_of("name")
-                    .expect("A NAME argument is needed")
-            }),
+            name: args
+                .value_of("positional-name")
+                .unwrap_or_else(|| args.value_of("name").expect("A NAME argument is needed")),
             auth_level: match args.value_of("auth-level") {
                 Some(level) => {
                     if level == "function" {

--- a/azure-functions-sdk/src/commands/new/http.rs
+++ b/azure-functions-sdk/src/commands/new/http.rs
@@ -12,12 +12,18 @@ impl<'a> Http<'a> {
         SubCommand::with_name("http")
             .about("Creates a new HTTP triggered Azure Function.")
             .arg(
+                Arg::with_name("positional-name")
+                    .value_name("NAME")
+                    .help("The name of the new Azure Function. You may specify this as --name <NAME> instead.")
+                    .conflicts_with("name")
+                    .required(true),
+            )
+            .arg(
                 Arg::with_name("name")
                     .long("name")
                     .short("n")
                     .value_name("NAME")
-                    .help("The name of the new Azure Function.")
-                    .required(true),
+                    .help("The name of the new Azure Function. You may specify this as <NAME> instead (i.e., without typing --name).")
             )
             .arg(
                 Arg::with_name("auth-level")
@@ -41,7 +47,9 @@ impl<'a> Http<'a> {
 impl<'a> From<&'a ArgMatches<'a>> for Http<'a> {
     fn from(args: &'a ArgMatches<'a>) -> Self {
         Http {
-            name: args.value_of("name").unwrap(),
+            name: args.value_of("positional-name")
+                    .unwrap_or_else(|| args.value_of("name")
+                    .unwrap_or("Default fallback - never reached")),
             auth_level: match args.value_of("auth-level") {
                 Some(level) => {
                     if level == "function" {

--- a/azure-functions-sdk/src/commands/new/queue.rs
+++ b/azure-functions-sdk/src/commands/new/queue.rs
@@ -76,10 +76,9 @@ impl<'a> Queue<'a> {
 impl<'a> From<&'a ArgMatches<'a>> for Queue<'a> {
     fn from(args: &'a ArgMatches<'a>) -> Self {
         Queue {
-            name: args.value_of("positional-name").unwrap_or_else(|| {
-                args.value_of("name")
-                    .expect("A NAME argument is needed")
-            }),
+            name: args
+                .value_of("positional-name")
+                .unwrap_or_else(|| args.value_of("name").expect("A NAME argument is needed")),
             queue_name: args.value_of("queue_name").unwrap(),
         }
     }

--- a/azure-functions-sdk/src/commands/new/queue.rs
+++ b/azure-functions-sdk/src/commands/new/queue.rs
@@ -78,7 +78,7 @@ impl<'a> From<&'a ArgMatches<'a>> for Queue<'a> {
         Queue {
             name: args.value_of("positional-name").unwrap_or_else(|| {
                 args.value_of("name")
-                    .unwrap_or("Default fallback - never reached")
+                    .expect("A NAME argument is needed")
             }),
             queue_name: args.value_of("queue_name").unwrap(),
         }

--- a/azure-functions-sdk/src/commands/new/queue.rs
+++ b/azure-functions-sdk/src/commands/new/queue.rs
@@ -13,12 +13,18 @@ impl<'a> Queue<'a> {
         SubCommand::with_name("queue")
             .about("Creates a new queue triggered Azure Function.")
             .arg(
+                Arg::with_name("positional-name")
+                    .value_name("NAME")
+                    .help("The name of the new Azure Function. You may specify this as --name <NAME> instead.")
+                    .conflicts_with("name")
+                    .required(true),
+            )
+            .arg(
                 Arg::with_name("name")
                     .long("name")
                     .short("n")
                     .value_name("NAME")
-                    .help("The name of the new Azure Function.")
-                    .required(true),
+                    .help("The name of the new Azure Function. You may specify this as <NAME> instead (i.e., without typing --name).")
             )
             .arg(
                 Arg::with_name("queue_name")
@@ -70,7 +76,9 @@ impl<'a> Queue<'a> {
 impl<'a> From<&'a ArgMatches<'a>> for Queue<'a> {
     fn from(args: &'a ArgMatches<'a>) -> Self {
         Queue {
-            name: args.value_of("name").unwrap(),
+            name: args.value_of("positional-name")
+                    .unwrap_or_else(|| args.value_of("name")
+                    .unwrap_or("Default fallback - never reached")),
             queue_name: args.value_of("queue_name").unwrap(),
         }
     }

--- a/azure-functions-sdk/src/commands/new/queue.rs
+++ b/azure-functions-sdk/src/commands/new/queue.rs
@@ -76,9 +76,10 @@ impl<'a> Queue<'a> {
 impl<'a> From<&'a ArgMatches<'a>> for Queue<'a> {
     fn from(args: &'a ArgMatches<'a>) -> Self {
         Queue {
-            name: args.value_of("positional-name")
-                    .unwrap_or_else(|| args.value_of("name")
-                    .unwrap_or("Default fallback - never reached")),
+            name: args.value_of("positional-name").unwrap_or_else(|| {
+                args.value_of("name")
+                    .unwrap_or("Default fallback - never reached")
+            }),
             queue_name: args.value_of("queue_name").unwrap(),
         }
     }

--- a/azure-functions-sdk/src/commands/new/service_bus.rs
+++ b/azure-functions-sdk/src/commands/new/service_bus.rs
@@ -81,9 +81,10 @@ impl<'a> ServiceBus<'a> {
 impl<'a> From<&'a ArgMatches<'a>> for ServiceBus<'a> {
     fn from(args: &'a ArgMatches<'a>) -> Self {
         ServiceBus {
-            name: args.value_of("positional-name")
-                    .unwrap_or_else(|| args.value_of("name")
-                    .unwrap_or("Default fallback - never reached")),
+            name: args.value_of("positional-name").unwrap_or_else(|| {
+                args.value_of("name")
+                    .unwrap_or("Default fallback - never reached")
+            }),
             connection: args.value_of("connection").unwrap(),
             queue: args.value_of("queue"),
             topic: args.value_of("topic"),

--- a/azure-functions-sdk/src/commands/new/service_bus.rs
+++ b/azure-functions-sdk/src/commands/new/service_bus.rs
@@ -15,12 +15,18 @@ impl<'a> ServiceBus<'a> {
         SubCommand::with_name("service-bus")
             .about("Creates a new Service Bus triggered Azure Function.")
             .arg(
+                Arg::with_name("positional-name")
+                    .value_name("NAME")
+                    .help("The name of the new Azure Function. You may specify this as --name <NAME> instead.")
+                    .conflicts_with("name")
+                    .required(true),
+            )
+            .arg(
                 Arg::with_name("name")
                     .long("name")
                     .short("n")
                     .value_name("NAME")
-                    .help("The name of the new Azure Function.")
-                    .required(true),
+                    .help("The name of the new Azure Function. You may specify this as <NAME> instead (i.e., without typing --name).")
             )
             .arg(
                 Arg::with_name("connection")
@@ -75,7 +81,9 @@ impl<'a> ServiceBus<'a> {
 impl<'a> From<&'a ArgMatches<'a>> for ServiceBus<'a> {
     fn from(args: &'a ArgMatches<'a>) -> Self {
         ServiceBus {
-            name: args.value_of("name").unwrap(),
+            name: args.value_of("positional-name")
+                    .unwrap_or_else(|| args.value_of("name")
+                    .unwrap_or("Default fallback - never reached")),
             connection: args.value_of("connection").unwrap(),
             queue: args.value_of("queue"),
             topic: args.value_of("topic"),

--- a/azure-functions-sdk/src/commands/new/service_bus.rs
+++ b/azure-functions-sdk/src/commands/new/service_bus.rs
@@ -83,7 +83,7 @@ impl<'a> From<&'a ArgMatches<'a>> for ServiceBus<'a> {
         ServiceBus {
             name: args.value_of("positional-name").unwrap_or_else(|| {
                 args.value_of("name")
-                    .unwrap_or("Default fallback - never reached")
+                    .expect("A NAME argument is needed")
             }),
             connection: args.value_of("connection").unwrap(),
             queue: args.value_of("queue"),

--- a/azure-functions-sdk/src/commands/new/service_bus.rs
+++ b/azure-functions-sdk/src/commands/new/service_bus.rs
@@ -81,10 +81,9 @@ impl<'a> ServiceBus<'a> {
 impl<'a> From<&'a ArgMatches<'a>> for ServiceBus<'a> {
     fn from(args: &'a ArgMatches<'a>) -> Self {
         ServiceBus {
-            name: args.value_of("positional-name").unwrap_or_else(|| {
-                args.value_of("name")
-                    .expect("A NAME argument is needed")
-            }),
+            name: args
+                .value_of("positional-name")
+                .unwrap_or_else(|| args.value_of("name").expect("A NAME argument is needed")),
             connection: args.value_of("connection").unwrap(),
             queue: args.value_of("queue"),
             topic: args.value_of("topic"),

--- a/azure-functions-sdk/src/commands/new/timer.rs
+++ b/azure-functions-sdk/src/commands/new/timer.rs
@@ -48,9 +48,10 @@ impl<'a> Timer<'a> {
 impl<'a> From<&'a ArgMatches<'a>> for Timer<'a> {
     fn from(args: &'a ArgMatches<'a>) -> Self {
         Timer {
-            name: args.value_of("positional-name")
-                    .unwrap_or_else(|| args.value_of("name")
-                    .unwrap_or("Default fallback - never reached")),
+            name: args.value_of("positional-name").unwrap_or_else(|| {
+                args.value_of("name")
+                    .unwrap_or("Default fallback - never reached")
+            }),
             schedule: args.value_of("schedule").unwrap(),
         }
     }

--- a/azure-functions-sdk/src/commands/new/timer.rs
+++ b/azure-functions-sdk/src/commands/new/timer.rs
@@ -50,7 +50,7 @@ impl<'a> From<&'a ArgMatches<'a>> for Timer<'a> {
         Timer {
             name: args.value_of("positional-name").unwrap_or_else(|| {
                 args.value_of("name")
-                    .unwrap_or("Default fallback - never reached")
+                    .expect("A NAME argument is needed")
             }),
             schedule: args.value_of("schedule").unwrap(),
         }

--- a/azure-functions-sdk/src/commands/new/timer.rs
+++ b/azure-functions-sdk/src/commands/new/timer.rs
@@ -12,12 +12,18 @@ impl<'a> Timer<'a> {
         SubCommand::with_name("timer")
             .about("Creates a new timer triggered Azure Function.")
             .arg(
+                Arg::with_name("positional-name")
+                    .value_name("NAME")
+                    .help("The name of the new Azure Function. You may specify this as --name <NAME> instead.")
+                    .conflicts_with("name")
+                    .required(true),
+            )
+            .arg(
                 Arg::with_name("name")
                     .long("name")
                     .short("n")
                     .value_name("NAME")
-                    .help("The name of the new Azure Function.")
-                    .required(true),
+                    .help("The name of the new Azure Function. You may specify this as <NAME> instead (i.e., without typing --name).")
             )
             .arg(
                 Arg::with_name("schedule")
@@ -42,7 +48,9 @@ impl<'a> Timer<'a> {
 impl<'a> From<&'a ArgMatches<'a>> for Timer<'a> {
     fn from(args: &'a ArgMatches<'a>) -> Self {
         Timer {
-            name: args.value_of("name").unwrap(),
+            name: args.value_of("positional-name")
+                    .unwrap_or_else(|| args.value_of("name")
+                    .unwrap_or("Default fallback - never reached")),
             schedule: args.value_of("schedule").unwrap(),
         }
     }

--- a/azure-functions-sdk/src/commands/new/timer.rs
+++ b/azure-functions-sdk/src/commands/new/timer.rs
@@ -48,10 +48,9 @@ impl<'a> Timer<'a> {
 impl<'a> From<&'a ArgMatches<'a>> for Timer<'a> {
     fn from(args: &'a ArgMatches<'a>) -> Self {
         Timer {
-            name: args.value_of("positional-name").unwrap_or_else(|| {
-                args.value_of("name")
-                    .expect("A NAME argument is needed")
-            }),
+            name: args
+                .value_of("positional-name")
+                .unwrap_or_else(|| args.value_of("name").expect("A NAME argument is needed")),
             schedule: args.value_of("schedule").unwrap(),
         }
     }

--- a/azure-functions-sdk/src/commands/new/utils.rs
+++ b/azure-functions-sdk/src/commands/new/utils.rs
@@ -1,6 +1,4 @@
-use crate::{
-    util::{create_from_template, print_failure, print_running, print_success},
-};
+use crate::util::{create_from_template, print_failure, print_running, print_success};
 use regex::Regex;
 use serde_json::{json, Value};
 use std::{

--- a/azure-functions-shared-codegen/src/binding.rs
+++ b/azure-functions-shared-codegen/src/binding.rs
@@ -318,9 +318,7 @@ impl Field {
         let ident = &self.ident;
         match &self.ty {
             FieldType::Direction => quote!(#ident: Default::default()),
-            FieldType::OptionalString | FieldType::OptionalBoolean | FieldType::OptionalInteger => {
-                quote!(#ident)
-            }
+            FieldType::OptionalString | FieldType::OptionalBoolean | FieldType::OptionalInteger => quote!(#ident),
             FieldType::StringArray => quote!(#ident: #ident.unwrap_or(Cow::Borrowed(&[]))),
             _ => quote!(#ident: #ident.unwrap()),
         }
@@ -329,23 +327,13 @@ impl Field {
     pub fn get_quotable_decl(&self) -> TokenStream {
         let ident = &self.ident;
         match self.ty {
-            FieldType::String => {
-                quote!(let #ident = crate::codegen::quotable::QuotableBorrowedStr(&self.#ident);)
-            }
-            FieldType::OptionalString => {
-                quote!(let #ident = crate::codegen::quotable::QuotableOption(self.#ident.as_ref().map(|x| crate::codegen::quotable::QuotableBorrowedStr(x)));)
-            }
+            FieldType::String => quote!(let #ident = crate::codegen::quotable::QuotableBorrowedStr(&self.#ident);),
+            FieldType::OptionalString => quote!(let #ident = crate::codegen::quotable::QuotableOption(self.#ident.as_ref().map(|x| crate::codegen::quotable::QuotableBorrowedStr(x)));),
             FieldType::Boolean => quote!(let #ident = self.#ident;),
-            FieldType::Direction => {
-                quote!(let #ident = crate::codegen::quotable::QuotableDirection(self.#ident);)
-            }
-            FieldType::StringArray => {
-                quote!(let #ident = crate::codegen::quotable::QuotableStrArray(self.#ident.as_ref());)
-            }
+            FieldType::Direction => quote!(let #ident = crate::codegen::quotable::QuotableDirection(self.#ident);),
+            FieldType::StringArray => quote!(let #ident = crate::codegen::quotable::QuotableStrArray(self.#ident.as_ref());),
             FieldType::Integer => quote!(let #ident = self.#ident),
-            FieldType::OptionalBoolean | FieldType::OptionalInteger => {
-                quote!(let #ident = crate::codegen::quotable::QuotableOption(self.#ident);)
-            }
+            FieldType::OptionalBoolean | FieldType::OptionalInteger => quote!(let #ident = crate::codegen::quotable::QuotableOption(self.#ident);),
         }
     }
 

--- a/azure-functions-shared/src/lib.rs
+++ b/azure-functions-shared/src/lib.rs
@@ -13,7 +13,7 @@ pub mod codegen;
 pub mod util;
 
 #[doc(hidden)]
-#[allow(renamed_and_removed_lints)]
+#[allow(clippy::type_repetition_in_bounds)]
 pub mod rpc {
     use azure_functions_shared_codegen::generated_mod;
 


### PR DESCRIPTION
This is enabled by creating a separate, `required`, positional arg and making it conflict with the original optional arg. I applied this change to each subcommand of `cargo func new`.

## What is the goal of this pull request?

It addresses https://github.com/peterhuene/azure-functions-rs/issues/374

## What does this pull request change?

A user creating a new Azure Function can leave out the `--name` option while doing so. They must still provide a name, as before.

## What work remains to be done?

None.

## Do you consider it adequately tested?

Yes - I reinstalled the SDK with `cargo install`, then tested new behaviour with these commands:

1. `cargo func new help http`
1. `cargo func new http abc --auth-level anonymous`
1. `cargo func new http --auth-level anonymous abc`
1. `cargo func new http --auth-level anonymous --name abc`

## Related Issues

None

## Notes

N.A.