### PR TITLE
Implement DurableOrchestrationContext.continue_as_new.

### DIFF
--- a/azure-functions/src/durable/actions.rs
+++ b/azure-functions/src/durable/actions.rs
@@ -63,7 +63,10 @@ pub(crate) enum Action {
     },
 
     #[serde(rename_all = "camelCase")]
-    ContinueAsNew { input: Value },
+    ContinueAsNew {
+        input: Value,
+        preserve_unprocessed_events: bool,
+    },
 
     #[serde(rename_all = "camelCase")]
     CreateTimer {
@@ -141,8 +144,8 @@ mod tests {
         ),
         continue_as_new_converts_to_json:
         (
-            Action::ContinueAsNew { input: "World".into() },
-            r#"{"actionType":"continueAsNew","input":"World"}"#
+            Action::ContinueAsNew { input: "World".into(), preserve_unprocessed_events: true, },
+            r#"{"actionType":"continueAsNew","input":"World","preserveUnprocessedEvents":true}"#
         ),
         create_timer_converts_to_json:
         (

--- a/azure-functions/src/durable/history.rs
+++ b/azure-functions/src/durable/history.rs
@@ -71,7 +71,6 @@ pub enum EventType {
     EventSent = 14,
     // not supported in js
     EventRaised = 15,
-    // not supported in js
     ContinueAsNew = 16,
     // not supported in js
     GenericEvent = 17,

--- a/azure-functions/src/durable/orchestration_state.rs
+++ b/azure-functions/src/durable/orchestration_state.rs
@@ -26,7 +26,7 @@ impl OrchestrationState {
         let started_index = history
             .iter()
             .position(|event| event.event_type == EventType::OrchestratorStarted)
-            .expect("failed to find orchestration started event");
+            .expect("failed to find orchestrator started event");
 
         let completed_index = history[started_index..]
             .iter()
@@ -42,7 +42,10 @@ impl OrchestrationState {
     }
 
     pub(crate) fn is_replaying(&self) -> bool {
-        self.completed_index.is_some()
+        match self.completed_index {
+            Some(i) => self.history.len() != (i + 1),
+            None => false,
+        }
     }
 
     pub(crate) fn current_time(&self) -> DateTime<Utc> {
@@ -143,7 +146,7 @@ mod tests {
     use serde_json::json;
 
     #[test]
-    #[should_panic(expected = "failed to find orchestration started event")]
+    #[should_panic(expected = "failed to find orchestrator started event")]
     fn it_requires_an_orchestration_start_event() {
         OrchestrationState::new(Vec::new());
     }

--- a/examples/durable-functions/src/functions/looping.rs
+++ b/examples/durable-functions/src/functions/looping.rs
@@ -1,0 +1,22 @@
+use azure_functions::{bindings::DurableOrchestrationContext, durable::OrchestrationOutput, func};
+use log::warn;
+use serde_json::Value;
+
+#[func]
+pub async fn looping(context: DurableOrchestrationContext) -> OrchestrationOutput {
+    let value = context.input.as_i64().expect("expected a number for input");
+
+    if !context.is_replaying() {
+        warn!("The current value is: {}.", value);
+    }
+
+    if value < 10 {
+        return context.continue_as_new(value + 1, true);
+    }
+
+    if !context.is_replaying() {
+        warn!("Loop has completed.");
+    }
+
+    Value::Null.into()
+}

--- a/examples/durable-functions/src/functions/mod.rs
+++ b/examples/durable-functions/src/functions/mod.rs
@@ -2,8 +2,10 @@
 
 mod call_hello_world;
 mod hello_world;
+mod looping;
 mod say_hello;
 mod start;
+mod start_looping;
 
 // Export the Azure Functions here.
 azure_functions::export! {
@@ -11,4 +13,6 @@ azure_functions::export! {
     hello_world::hello_world,
     say_hello::say_hello,
     start::start,
+    looping::looping,
+    start_looping::start_looping,
 }

--- a/examples/durable-functions/src/functions/start_looping.rs
+++ b/examples/durable-functions/src/functions/start_looping.rs
@@ -1,0 +1,12 @@
+use azure_functions::{
+    bindings::{DurableOrchestrationClient, HttpRequest, HttpResponse},
+    func,
+};
+
+#[func]
+pub async fn start_looping(_req: HttpRequest, client: DurableOrchestrationClient) -> HttpResponse {
+    match client.start_new("looping", None, 0).await {
+        Ok(_) => "Orchestration started.".into(),
+        Err(e) => format!("Failed to start orchestration: {}", e).into(),
+    }
+}


### PR DESCRIPTION
This PR implements the `continue_as_new` method for
`DurableOrchestrationContext`.

The `continue_as_new` method enables looping in orchestration functions.