### PR TITLE
Implement support for binding attributes on parameters.

### DIFF
--- a/azure-functions-codegen/src/lib.rs
+++ b/azure-functions-codegen/src/lib.rs
@@ -31,12 +31,12 @@ fn parse_attribute_args(attr: &Attribute) -> AttributeArgs {
         .unwrap()
 }
 
-fn attribute_args_from_name(name: &str, span: Span) -> AttributeArgs {
-    vec![NestedMeta::Meta(Meta::NameValue(MetaNameValue {
+fn create_name_attribute_arg(name: &str, span: Span) -> NestedMeta {
+    NestedMeta::Meta(Meta::NameValue(MetaNameValue {
         path: Ident::new("name", span).into(),
         eq_token: Eq { spans: [span] },
         lit: Lit::Str(LitStr::new(name, span)),
-    }))]
+    }))
 }
 
 /// Implements the `export!` macro.


### PR DESCRIPTION
This PR implements support for binding attributes on parameters.

For example:

```rust
pub fn foo(#[binding(route = "foo") req: HttpRequest) {
}
```

However, both `rustfmt` and `rls` (plus GitHub's source parser) do not yet
properly handle attributes on parameters.

The samples and documentation will be updated to specify the attributes on the
parameters themselves once there is broader support of the feature.

Closes #457.