### PR TITLE
Reimplement http types

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,8 @@ jobs:
     - name: Install Rust
       uses: actions-rs/toolchain@v1
       with:
-        toolchain: stable
+        # Use nightly until rustfmt works for attributes on parameters
+        toolchain: nightly
         default: true
         components: rustfmt
     - name: Run rustfmt

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -85,6 +85,7 @@ dependencies = [
  "lazy_static 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.4.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "matches 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "prost-types 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "semver 0.9.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.102 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.41 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ use azure_functions::{
 pub fn greet(req: HttpRequest) -> HttpResponse {
     format!(
         "Hello from Rust, {}!\n",
-        req.query_params().get("name").map_or("stranger", |x| x)
+        req.query_params.get("name").map_or("stranger", |x| x)
     )
     .into()
 }
@@ -67,7 +67,7 @@ pub async fn greet_async(req: HttpRequest) -> HttpResponse {
     // Use ready().await to simply demonstrate the async/await feature
     ready(format!(
         "Hello from Rust, {}!\n",
-        req.query_params().get("name").map_or("stranger", |x| x)
+        req.query_params.get("name").map_or("stranger", |x| x)
     ))
     .await
     .into()

--- a/azure-functions-codegen/src/export.rs
+++ b/azure-functions-codegen/src/export.rs
@@ -17,7 +17,7 @@ impl Parse for PathVec {
     fn parse(input: ParseStream) -> parse::Result<Self> {
         let paths = Punctuated::<Path, Token![,]>::parse_terminated(input)?;
 
-        Ok(PathVec(paths.into_iter().collect()))
+        Ok(Self(paths.into_iter().collect()))
     }
 }
 
@@ -36,7 +36,7 @@ impl From<TokenStream> for PathVec {
             return Self::default();
         }
 
-        parse::<PathVec>(stream)
+        parse::<Self>(stream)
             .map_err(|e| macro_panic(Span::call_site(), e.to_string()))
             .unwrap()
     }

--- a/azure-functions-codegen/src/lib.rs
+++ b/azure-functions-codegen/src/lib.rs
@@ -3,6 +3,9 @@
 //! This crate supports the code generation for the `azure-functions` crate.
 #![recursion_limit = "128"]
 #![deny(unused_extern_crates)]
+#![warn(clippy::use_self)]
+#![warn(clippy::option_map_unwrap_or)]
+#![warn(clippy::option_map_unwrap_or_else)]
 #![cfg_attr(feature = "unstable", feature(proc_macro_diagnostic))]
 extern crate proc_macro;
 

--- a/azure-functions-durable/src/lib.rs
+++ b/azure-functions-durable/src/lib.rs
@@ -1,6 +1,10 @@
 //! # Durable Functions HTTP client for Rust.
 
 #![deny(missing_docs)]
+#![deny(unused_extern_crates)]
+#![warn(clippy::use_self)]
+#![warn(clippy::option_map_unwrap_or)]
+#![warn(clippy::option_map_unwrap_or_else)]
 
 mod client;
 mod endpoint;

--- a/azure-functions-sdk/src/main.rs
+++ b/azure-functions-sdk/src/main.rs
@@ -50,6 +50,9 @@
 //! ```
 #![deny(missing_docs)]
 #![deny(unused_extern_crates)]
+#![warn(clippy::use_self)]
+#![warn(clippy::option_map_unwrap_or)]
+#![warn(clippy::option_map_unwrap_or_else)]
 
 mod commands;
 mod util;

--- a/azure-functions-sdk/src/templates/new/blob.rs.hbs
+++ b/azure-functions-sdk/src/templates/new/blob.rs.hbs
@@ -4,8 +4,9 @@ use azure_functions::{
 };
 
 #[func]
-#[binding(name = "trigger", path = "{{path}}")]
-pub fn {{name}}(trigger: BlobTrigger) {
+pub fn {{name}}(
+    #[binding(path = "{{path}}")] trigger: BlobTrigger
+) {
     // trigger.path has the path to the blob that triggered the function
     // trigger.blob has the contents of the blob
 }

--- a/azure-functions-sdk/src/templates/new/eventhub.rs.hbs
+++ b/azure-functions-sdk/src/templates/new/eventhub.rs.hbs
@@ -4,11 +4,8 @@ use azure_functions::{
 };
 
 #[func]
-{{#if hub_name~}}
-#[binding(name = "trigger", connection = "{{connection}}", event_hub_name = "{{hub_name}}")]
-{{else~}}
-#[binding(name = "trigger", connection = "{{connection}}")]
-{{/if~}}
-pub fn {{name}}(trigger: EventHubTrigger) {
+pub fn {{name}}(
+    #[binding(connection = "{{connection}}"{{#if hub_name}}, event_hub_name = "{{hub_name}}"{{/if}})] trigger: EventHubTrigger
+) {
     // trigger.message contains the message posted to the Event Hub
 }

--- a/azure-functions-sdk/src/templates/new/http.rs.hbs
+++ b/azure-functions-sdk/src/templates/new/http.rs.hbs
@@ -5,8 +5,13 @@ use azure_functions::{
 
 #[func]
 {{#if auth_level~}}
-#[binding(name = "req", auth_level = "{{auth_level}}")]
-{{/if~}}
+pub fn {{name}}(
+    #[binding(auth_level = "{{auth_level}}")] req: HttpRequest
+) -> HttpResponse {
+    "Hello from Rust!".into()
+}
+{{else~}}
 pub fn {{name}}(req: HttpRequest) -> HttpResponse {
     "Hello from Rust!".into()
 }
+{{/if~}}

--- a/azure-functions-sdk/src/templates/new/queue.rs.hbs
+++ b/azure-functions-sdk/src/templates/new/queue.rs.hbs
@@ -4,7 +4,8 @@ use azure_functions::{
 };
 
 #[func]
-#[binding(name = "trigger", queue_name = "{{queue_name}}")]
-pub fn {{name}}(trigger: QueueTrigger) {
+pub fn {{name}}(
+    #[binding(queue_name = "{{queue_name}}")] trigger: QueueTrigger
+) {
     // trigger.message contains the message posted to the queue
 }

--- a/azure-functions-sdk/src/templates/new/servicebus.rs.hbs
+++ b/azure-functions-sdk/src/templates/new/servicebus.rs.hbs
@@ -1,11 +1,8 @@
 use azure_functions::{bindings::ServiceBusTrigger, func};
 
 #[func]
-{{#if queue~}}
-#[binding(name = "trigger", connection = "{{connection}}", queue_name = "{{queue}}")]
-{{else~}}
-#[binding(name = "trigger", connection = "{{connection}}", topic_name = "{{topic}}", subscription_name = "{{subscription}}")]
-{{/if~}}
-pub fn {{name}}(trigger: ServiceBusTrigger) {
+pub fn {{name}}(
+    #[binding(connection = "{{connection}}", {{#if queue}}queue_name = "{{queue}}"{{else}}topic_name = "{{topic}}", subscription_name = "{{subscription}}"{{/if}})] trigger: ServiceBusTrigger
+) {
     // trigger.message contains the posted message
 }

--- a/azure-functions-sdk/src/templates/new/timer.rs.hbs
+++ b/azure-functions-sdk/src/templates/new/timer.rs.hbs
@@ -4,7 +4,8 @@ use azure_functions::{
 };
 
 #[func]
-#[binding(name = "trigger", schedule = "{{schedule}}")]
-pub fn {{name}}(trigger: TimerInfo) {
+pub fn {{name}}(
+    #[binding(schedule = "{{schedule}}")] trigger: TimerInfo
+) {
     // function will execute at the scheduled interval
 }

--- a/azure-functions-shared-codegen/src/binding.rs
+++ b/azure-functions-shared-codegen/src/binding.rs
@@ -81,7 +81,7 @@ impl From<AttributeArgs> for BindingArguments {
             );
         }
 
-        BindingArguments {
+        Self {
             name: name.unwrap(),
             direction,
             validate,
@@ -120,7 +120,7 @@ impl From<AttributeArgs> for FieldArguments {
             true
         });
 
-        FieldArguments {
+        Self {
             name,
             camel_case_value,
             values,
@@ -160,14 +160,14 @@ impl From<&TypePath> for FieldType {
         type_name.retain(|c| c != ' ');
 
         match type_name.as_ref() {
-            "Cow<'static,str>" => FieldType::String,
-            "Option<Cow<'static,str>>" => FieldType::OptionalString,
-            "bool" => FieldType::Boolean,
-            "Option<bool>" => FieldType::OptionalBoolean,
-            "Direction" => FieldType::Direction,
-            "Cow<'static,[Cow<'static,str>]>" => FieldType::StringArray,
-            "i64" => FieldType::Integer,
-            "Option<i64>" => FieldType::OptionalInteger,
+            "Cow<'static,str>" => Self::String,
+            "Option<Cow<'static,str>>" => Self::OptionalString,
+            "bool" => Self::Boolean,
+            "Option<bool>" => Self::OptionalBoolean,
+            "Direction" => Self::Direction,
+            "Cow<'static,[Cow<'static,str>]>" => Self::StringArray,
+            "i64" => Self::Integer,
+            "Option<i64>" => Self::OptionalInteger,
             _ => macro_panic(
                 tp.span(),
                 format!("field type '{}' is not supported for a binding", type_name),
@@ -374,7 +374,7 @@ impl From<&syn::Field> for Field {
             args = Some(parse_attribute_args(&attr));
         }
 
-        Field {
+        Self {
             ident: field.ident.as_ref().unwrap().clone(),
             args: args.map(Into::into),
             ty: match &field.ty {

--- a/azure-functions-shared-codegen/src/lib.rs
+++ b/azure-functions-shared-codegen/src/lib.rs
@@ -2,6 +2,9 @@
 //!
 //! This crate supports code generation for the `azure-functions-shared` crate.
 #![deny(unused_extern_crates)]
+#![warn(clippy::use_self)]
+#![warn(clippy::option_map_unwrap_or)]
+#![warn(clippy::option_map_unwrap_or_else)]
 #![recursion_limit = "128"]
 #![cfg_attr(feature = "unstable", feature(proc_macro_diagnostic))]
 extern crate proc_macro;

--- a/azure-functions-shared/cache/azure_functions_rpc_messages.rs
+++ b/azure-functions-shared/cache/azure_functions_rpc_messages.rs
@@ -346,6 +346,22 @@ pub struct InvocationRequest {
     /// binding metadata from trigger
     #[prost(map = "string, message", tag = "4")]
     pub trigger_metadata: ::std::collections::HashMap<std::string::String, TypedData>,
+    /// Populates activityId, tracestate and tags from host
+    #[prost(message, optional, tag = "5")]
+    pub trace_context: ::std::option::Option<RpcTraceContext>,
+}
+/// Host sends ActivityId, traceStateString and Tags from host
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct RpcTraceContext {
+    /// This corresponds to Activity.Current?.Id
+    #[prost(string, tag = "1")]
+    pub trace_parent: std::string::String,
+    /// This corresponds to Activity.Current?.TraceStateString
+    #[prost(string, tag = "2")]
+    pub trace_state: std::string::String,
+    /// This corresponds to Activity.Current?.Tags
+    #[prost(map = "string, string", tag = "3")]
+    pub attributes: ::std::collections::HashMap<std::string::String, std::string::String>,
 }
 /// Host requests worker to cancel invocation
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -378,7 +394,7 @@ pub struct InvocationResponse {
 /// Used to encapsulate data which could be a variety of types
 #[derive(Clone, PartialEq, ::prost::Message)]
 pub struct TypedData {
-    #[prost(oneof = "typed_data::Data", tags = "1, 2, 3, 4, 5, 6, 7")]
+    #[prost(oneof = "typed_data::Data", tags = "1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11")]
     pub data: ::std::option::Option<typed_data::Data>,
 }
 pub mod typed_data {
@@ -398,7 +414,39 @@ pub mod typed_data {
         Int(i64),
         #[prost(double, tag = "7")]
         Double(f64),
+        #[prost(message, tag = "8")]
+        CollectionBytes(super::CollectionBytes),
+        #[prost(message, tag = "9")]
+        CollectionString(super::CollectionString),
+        #[prost(message, tag = "10")]
+        CollectionDouble(super::CollectionDouble),
+        #[prost(message, tag = "11")]
+        CollectionSint64(super::CollectionSInt64),
     }
+}
+/// Used to encapsulate collection string
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct CollectionString {
+    #[prost(string, repeated, tag = "1")]
+    pub string: ::std::vec::Vec<std::string::String>,
+}
+/// Used to encapsulate collection bytes
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct CollectionBytes {
+    #[prost(bytes, repeated, tag = "1")]
+    pub bytes: ::std::vec::Vec<std::vec::Vec<u8>>,
+}
+/// Used to encapsulate collection double
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct CollectionDouble {
+    #[prost(double, repeated, tag = "1")]
+    pub double: ::std::vec::Vec<f64>,
+}
+/// Used to encapsulate collection sint64
+#[derive(Clone, PartialEq, ::prost::Message)]
+pub struct CollectionSInt64 {
+    #[prost(sint64, repeated, tag = "1")]
+    pub sint64: ::std::vec::Vec<i64>,
 }
 /// Used to describe a given binding on invocation
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -466,6 +514,9 @@ pub struct RpcLog {
     /// json serialized property bag, or could use a type scheme like map<string, TypedData>
     #[prost(string, tag = "7")]
     pub properties: std::string::String,
+    /// Category of the log. Either user(default) or system.
+    #[prost(enumeration = "rpc_log::RpcLogCategory", tag = "8")]
+    pub log_category: i32,
 }
 pub mod rpc_log {
     /// Matching ILogger semantics
@@ -482,6 +533,13 @@ pub mod rpc_log {
         Critical = 5,
         None = 6,
     }
+    /// Category of the log. Defaults to User if not specified.
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, ::prost::Enumeration)]
+    #[repr(i32)]
+    pub enum RpcLogCategory {
+        User = 0,
+        System = 1,
+    }
 }
 /// Encapsulates an Exception
 #[derive(Clone, PartialEq, ::prost::Message)]
@@ -492,7 +550,7 @@ pub struct RpcException {
     /// Stack trace for the exception
     #[prost(string, tag = "1")]
     pub stack_trace: std::string::String,
-    /// Textual message describing hte exception
+    /// Textual message describing the exception
     #[prost(string, tag = "2")]
     pub message: std::string::String,
 }

--- a/azure-functions-shared/src/codegen/bindings.rs
+++ b/azure-functions-shared/src/codegen/bindings.rs
@@ -63,7 +63,7 @@ pub enum Direction {
 
 impl Default for Direction {
     fn default() -> Self {
-        Direction::In
+        Self::In
     }
 }
 
@@ -100,75 +100,75 @@ pub enum Binding {
 impl Binding {
     pub fn name(&self) -> Option<&str> {
         match self {
-            Binding::HttpTrigger(b) => Some(&b.name),
-            Binding::Http(b) => Some(&b.name),
-            Binding::TimerTrigger(b) => Some(&b.name),
-            Binding::QueueTrigger(b) => Some(&b.name),
-            Binding::Queue(b) => Some(&b.name),
-            Binding::BlobTrigger(b) => Some(&b.name),
-            Binding::Blob(b) => Some(&b.name),
-            Binding::Table(b) => Some(&b.name),
-            Binding::EventGridTrigger(b) => Some(&b.name),
-            Binding::EventHubTrigger(b) => Some(&b.name),
-            Binding::EventHub(b) => Some(&b.name),
-            Binding::CosmosDbTrigger(b) => Some(&b.name),
-            Binding::CosmosDb(b) => Some(&b.name),
-            Binding::SignalRConnectionInfo(b) => Some(&b.name),
-            Binding::SignalR(b) => Some(&b.name),
-            Binding::ServiceBusTrigger(b) => Some(&b.name),
-            Binding::ServiceBus(b) => Some(&b.name),
-            Binding::TwilioSms(b) => Some(&b.name),
-            Binding::SendGrid(b) => Some(&b.name),
-            Binding::GenericTrigger(b) => Some(&b.name),
-            Binding::Generic(b) => Some(&b.name),
-            Binding::DurableClient(b) => Some(&b.name),
-            Binding::OrchestrationTrigger(b) => Some(&b.name),
-            Binding::ActivityTrigger(b) => Some(&b.name),
+            Self::HttpTrigger(b) => Some(&b.name),
+            Self::Http(b) => Some(&b.name),
+            Self::TimerTrigger(b) => Some(&b.name),
+            Self::QueueTrigger(b) => Some(&b.name),
+            Self::Queue(b) => Some(&b.name),
+            Self::BlobTrigger(b) => Some(&b.name),
+            Self::Blob(b) => Some(&b.name),
+            Self::Table(b) => Some(&b.name),
+            Self::EventGridTrigger(b) => Some(&b.name),
+            Self::EventHubTrigger(b) => Some(&b.name),
+            Self::EventHub(b) => Some(&b.name),
+            Self::CosmosDbTrigger(b) => Some(&b.name),
+            Self::CosmosDb(b) => Some(&b.name),
+            Self::SignalRConnectionInfo(b) => Some(&b.name),
+            Self::SignalR(b) => Some(&b.name),
+            Self::ServiceBusTrigger(b) => Some(&b.name),
+            Self::ServiceBus(b) => Some(&b.name),
+            Self::TwilioSms(b) => Some(&b.name),
+            Self::SendGrid(b) => Some(&b.name),
+            Self::GenericTrigger(b) => Some(&b.name),
+            Self::Generic(b) => Some(&b.name),
+            Self::DurableClient(b) => Some(&b.name),
+            Self::OrchestrationTrigger(b) => Some(&b.name),
+            Self::ActivityTrigger(b) => Some(&b.name),
         }
     }
 
     pub fn binding_type(&self) -> Option<&str> {
         match self {
-            Binding::HttpTrigger(_) => Some(HttpTrigger::binding_type()),
-            Binding::Http(_) => Some(HttpTrigger::binding_type()),
-            Binding::TimerTrigger(_) => Some(TimerTrigger::binding_type()),
-            Binding::QueueTrigger(_) => Some(QueueTrigger::binding_type()),
-            Binding::Queue(_) => Some(Queue::binding_type()),
-            Binding::BlobTrigger(_) => Some(BlobTrigger::binding_type()),
-            Binding::Blob(_) => Some(Blob::binding_type()),
-            Binding::Table(_) => Some(Table::binding_type()),
-            Binding::EventGridTrigger(_) => Some(EventGridTrigger::binding_type()),
-            Binding::EventHubTrigger(_) => Some(EventHubTrigger::binding_type()),
-            Binding::EventHub(_) => Some(EventHub::binding_type()),
-            Binding::CosmosDbTrigger(_) => Some(CosmosDbTrigger::binding_type()),
-            Binding::CosmosDb(_) => Some(CosmosDb::binding_type()),
-            Binding::SignalRConnectionInfo(_) => Some(SignalRConnectionInfo::binding_type()),
-            Binding::SignalR(_) => Some(SignalR::binding_type()),
-            Binding::ServiceBusTrigger(_) => Some(ServiceBusTrigger::binding_type()),
-            Binding::ServiceBus(_) => Some(ServiceBus::binding_type()),
-            Binding::TwilioSms(_) => Some(TwilioSms::binding_type()),
-            Binding::SendGrid(_) => Some(SendGrid::binding_type()),
-            Binding::GenericTrigger(b) => Some(b.binding_type()),
-            Binding::Generic(b) => Some(b.binding_type()),
-            Binding::DurableClient(_) => Some(DurableClient::binding_type()),
-            Binding::OrchestrationTrigger(_) => Some(OrchestrationTrigger::binding_type()),
-            Binding::ActivityTrigger(_) => Some(ActivityTrigger::binding_type()),
+            Self::HttpTrigger(_) => Some(HttpTrigger::binding_type()),
+            Self::Http(_) => Some(HttpTrigger::binding_type()),
+            Self::TimerTrigger(_) => Some(TimerTrigger::binding_type()),
+            Self::QueueTrigger(_) => Some(QueueTrigger::binding_type()),
+            Self::Queue(_) => Some(Queue::binding_type()),
+            Self::BlobTrigger(_) => Some(BlobTrigger::binding_type()),
+            Self::Blob(_) => Some(Blob::binding_type()),
+            Self::Table(_) => Some(Table::binding_type()),
+            Self::EventGridTrigger(_) => Some(EventGridTrigger::binding_type()),
+            Self::EventHubTrigger(_) => Some(EventHubTrigger::binding_type()),
+            Self::EventHub(_) => Some(EventHub::binding_type()),
+            Self::CosmosDbTrigger(_) => Some(CosmosDbTrigger::binding_type()),
+            Self::CosmosDb(_) => Some(CosmosDb::binding_type()),
+            Self::SignalRConnectionInfo(_) => Some(SignalRConnectionInfo::binding_type()),
+            Self::SignalR(_) => Some(SignalR::binding_type()),
+            Self::ServiceBusTrigger(_) => Some(ServiceBusTrigger::binding_type()),
+            Self::ServiceBus(_) => Some(ServiceBus::binding_type()),
+            Self::TwilioSms(_) => Some(TwilioSms::binding_type()),
+            Self::SendGrid(_) => Some(SendGrid::binding_type()),
+            Self::GenericTrigger(b) => Some(b.binding_type()),
+            Self::Generic(b) => Some(b.binding_type()),
+            Self::DurableClient(_) => Some(DurableClient::binding_type()),
+            Self::OrchestrationTrigger(_) => Some(OrchestrationTrigger::binding_type()),
+            Self::ActivityTrigger(_) => Some(ActivityTrigger::binding_type()),
         }
     }
 
     pub fn is_trigger(&self) -> bool {
         match self {
-            Binding::HttpTrigger(_)
-            | Binding::TimerTrigger(_)
-            | Binding::QueueTrigger(_)
-            | Binding::BlobTrigger(_)
-            | Binding::EventGridTrigger(_)
-            | Binding::EventHubTrigger(_)
-            | Binding::CosmosDbTrigger(_)
-            | Binding::ServiceBusTrigger(_)
-            | Binding::GenericTrigger(_)
-            | Binding::OrchestrationTrigger(_)
-            | Binding::ActivityTrigger(_) => true,
+            Self::HttpTrigger(_)
+            | Self::TimerTrigger(_)
+            | Self::QueueTrigger(_)
+            | Self::BlobTrigger(_)
+            | Self::EventGridTrigger(_)
+            | Self::EventHubTrigger(_)
+            | Self::CosmosDbTrigger(_)
+            | Self::ServiceBusTrigger(_)
+            | Self::GenericTrigger(_)
+            | Self::OrchestrationTrigger(_)
+            | Self::ActivityTrigger(_) => true,
             _ => false,
         }
     }
@@ -177,68 +177,64 @@ impl Binding {
 impl ToTokens for Binding {
     fn to_tokens(&self, tokens: &mut TokenStream) {
         match self {
-            Binding::HttpTrigger(b) => {
+            Self::HttpTrigger(b) => {
                 quote!(::azure_functions::codegen::bindings::Binding::HttpTrigger(#b))
             }
-            Binding::Http(b) => quote!(::azure_functions::codegen::bindings::Binding::Http(#b)),
-            Binding::TimerTrigger(b) => {
+            Self::Http(b) => quote!(::azure_functions::codegen::bindings::Binding::Http(#b)),
+            Self::TimerTrigger(b) => {
                 quote!(::azure_functions::codegen::bindings::Binding::TimerTrigger(#b))
             }
-            Binding::QueueTrigger(b) => {
+            Self::QueueTrigger(b) => {
                 quote!(::azure_functions::codegen::bindings::Binding::QueueTrigger(#b))
             }
-            Binding::Queue(b) => quote!(::azure_functions::codegen::bindings::Binding::Queue(#b)),
-            Binding::BlobTrigger(b) => {
+            Self::Queue(b) => quote!(::azure_functions::codegen::bindings::Binding::Queue(#b)),
+            Self::BlobTrigger(b) => {
                 quote!(::azure_functions::codegen::bindings::Binding::BlobTrigger(#b))
             }
-            Binding::Blob(b) => quote!(::azure_functions::codegen::bindings::Binding::Blob(#b)),
-            Binding::Table(b) => quote!(::azure_functions::codegen::bindings::Binding::Table(#b)),
-            Binding::EventGridTrigger(b) => {
+            Self::Blob(b) => quote!(::azure_functions::codegen::bindings::Binding::Blob(#b)),
+            Self::Table(b) => quote!(::azure_functions::codegen::bindings::Binding::Table(#b)),
+            Self::EventGridTrigger(b) => {
                 quote!(::azure_functions::codegen::bindings::Binding::EventGridTrigger(#b))
             }
-            Binding::EventHubTrigger(b) => {
+            Self::EventHubTrigger(b) => {
                 quote!(::azure_functions::codegen::bindings::Binding::EventHubTrigger(#b))
             }
-            Binding::EventHub(b) => {
+            Self::EventHub(b) => {
                 quote!(::azure_functions::codegen::bindings::Binding::EventHub(#b))
             }
-            Binding::CosmosDbTrigger(b) => {
+            Self::CosmosDbTrigger(b) => {
                 quote!(::azure_functions::codegen::bindings::Binding::CosmosDbTrigger(#b))
             }
-            Binding::CosmosDb(b) => {
+            Self::CosmosDb(b) => {
                 quote!(::azure_functions::codegen::bindings::Binding::CosmosDb(#b))
             }
-            Binding::SignalRConnectionInfo(b) => {
+            Self::SignalRConnectionInfo(b) => {
                 quote!(::azure_functions::codegen::bindings::Binding::SignalRConnectionInfo(#b))
             }
-            Binding::SignalR(b) => {
-                quote!(::azure_functions::codegen::bindings::Binding::SignalR(#b))
-            }
-            Binding::ServiceBusTrigger(b) => {
+            Self::SignalR(b) => quote!(::azure_functions::codegen::bindings::Binding::SignalR(#b)),
+            Self::ServiceBusTrigger(b) => {
                 quote!(::azure_functions::codegen::bindings::Binding::ServiceBusTrigger(#b))
             }
-            Binding::ServiceBus(b) => {
+            Self::ServiceBus(b) => {
                 quote!(::azure_functions::codegen::bindings::Binding::ServiceBus(#b))
             }
-            Binding::TwilioSms(b) => {
+            Self::TwilioSms(b) => {
                 quote!(::azure_functions::codegen::bindings::Binding::TwilioSms(#b))
             }
-            Binding::SendGrid(b) => {
+            Self::SendGrid(b) => {
                 quote!(::azure_functions::codegen::bindings::Binding::SendGrid(#b))
             }
-            Binding::GenericTrigger(b) => {
+            Self::GenericTrigger(b) => {
                 quote!(::azure_functions::codegen::bindings::Binding::GenericTrigger(#b))
             }
-            Binding::Generic(b) => {
-                quote!(::azure_functions::codegen::bindings::Binding::Generic(#b))
-            }
-            Binding::DurableClient(b) => {
+            Self::Generic(b) => quote!(::azure_functions::codegen::bindings::Binding::Generic(#b)),
+            Self::DurableClient(b) => {
                 quote!(::azure_functions::codegen::bindings::Binding::DurableClient(#b))
             }
-            Binding::OrchestrationTrigger(b) => {
+            Self::OrchestrationTrigger(b) => {
                 quote!(::azure_functions::codegen::bindings::Binding::OrchestrationTrigger(#b))
             }
-            Binding::ActivityTrigger(b) => {
+            Self::ActivityTrigger(b) => {
                 quote!(::azure_functions::codegen::bindings::Binding::ActivityTrigger(#b))
             }
         }

--- a/azure-functions-shared/src/codegen/bindings/generic.rs
+++ b/azure-functions-shared/src/codegen/bindings/generic.rs
@@ -97,7 +97,7 @@ impl From<(AttributeArgs, Span)> for Generic {
             );
         }
 
-        Generic {
+        Self {
             ty: Cow::from(ty.unwrap()),
             direction: Direction::In,
             name: Cow::from(name.unwrap()),

--- a/azure-functions-shared/src/codegen/function.rs
+++ b/azure-functions-shared/src/codegen/function.rs
@@ -122,7 +122,7 @@ impl From<AttributeArgs> for Function {
             true
         });
 
-        Function {
+        Self {
             name: name.unwrap_or(Cow::Borrowed("")),
             disabled: disabled.unwrap_or(false),
             bindings: Cow::Owned(Vec::new()),

--- a/azure-functions-shared/src/codegen/value.rs
+++ b/azure-functions-shared/src/codegen/value.rs
@@ -17,9 +17,9 @@ impl Serialize for Value {
         S: Serializer,
     {
         match self {
-            Value::String(s) => serializer.serialize_str(s),
-            Value::Integer(i) => serializer.serialize_i64(*i),
-            Value::Boolean(b) => serializer.serialize_bool(*b),
+            Self::String(s) => serializer.serialize_str(s),
+            Self::Integer(i) => serializer.serialize_i64(*i),
+            Self::Boolean(b) => serializer.serialize_bool(*b),
         }
     }
 }
@@ -27,12 +27,12 @@ impl Serialize for Value {
 impl ToTokens for Value {
     fn to_tokens(&self, tokens: &mut TokenStream) {
         match self {
-            Value::String(s) => {
+            Self::String(s) => {
                 let s = QuotableBorrowedStr(s);
                 quote!(::azure_functions::codegen::Value::String(#s))
             }
-            Value::Integer(i) => quote!(::azure_functions::codegen::Value::Integer(#i)),
-            Value::Boolean(b) => quote!(::azure_functions::codegen::Value::Boolean(#b)),
+            Self::Integer(i) => quote!(::azure_functions::codegen::Value::Integer(#i)),
+            Self::Boolean(b) => quote!(::azure_functions::codegen::Value::Boolean(#b)),
         }
         .to_tokens(tokens);
     }

--- a/azure-functions-shared/src/lib.rs
+++ b/azure-functions-shared/src/lib.rs
@@ -5,6 +5,9 @@
 #![cfg_attr(feature = "unstable", feature(proc_macro_diagnostic))]
 #![deny(missing_docs)]
 #![deny(unused_extern_crates)]
+#![warn(clippy::use_self)]
+#![warn(clippy::option_map_unwrap_or)]
+#![warn(clippy::option_map_unwrap_or_else)]
 #![allow(clippy::large_enum_variant)]
 
 #[doc(hidden)]

--- a/azure-functions/Cargo.toml
+++ b/azure-functions/Cargo.toml
@@ -32,6 +32,7 @@ fs_extra = "1.1.0"
 semver = "0.9.0"
 sha1 = "0.6.0"
 uuid = { version = "0.8.1", features = ["v5"] }
+prost-types = "0.5"
 
 [features]
 unstable = ["azure-functions-codegen/unstable", "azure-functions-shared/unstable"]

--- a/azure-functions/src/backtrace.rs
+++ b/azure-functions/src/backtrace.rs
@@ -7,9 +7,9 @@ pub struct Backtrace {
 }
 
 impl Backtrace {
-    pub fn new() -> Backtrace {
-        if !Backtrace::is_enabled() {
-            return Backtrace {
+    pub fn new() -> Self {
+        if !Self::is_enabled() {
+            return Self {
                 inner: Vec::<BacktraceFrame>::new().into(),
             };
         }
@@ -52,7 +52,7 @@ impl Backtrace {
             })
             .collect();
 
-        Backtrace {
+        Self {
             inner: frames.into(),
         }
     }
@@ -66,7 +66,7 @@ impl fmt::Display for Backtrace {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         use std::fmt::Debug;
 
-        if !Backtrace::is_enabled() {
+        if !Self::is_enabled() {
             return write!(
                 f,
                 "\nNote: run with `RUST_BACKTRACE=1` environment variable to display a backtrace."

--- a/azure-functions/src/bindings/blob_trigger.rs
+++ b/azure-functions/src/bindings/blob_trigger.rs
@@ -32,9 +32,10 @@ const METADATA_KEY: &str = "Metadata";
 /// use log::info;
 ///
 /// #[func]
-/// #[binding(name = "trigger", path = "example/")]
-/// pub fn print_blob(trigger: BlobTrigger) {
-///     info!("Blob (as string): {}", trigger.blob.as_str().unwrap());
+/// pub fn print_blob(
+///     #[binding(path = "example/")] trigger: BlobTrigger
+/// ) {
+///     info!("Blob (as string): {}", trigger.blob.to_str().unwrap());
 /// }
 /// ```
 #[derive(Debug)]
@@ -54,7 +55,7 @@ pub struct BlobTrigger {
 impl BlobTrigger {
     #[doc(hidden)]
     pub fn new(data: TypedData, mut metadata: HashMap<String, TypedData>) -> Self {
-        BlobTrigger {
+        Self {
             blob: data.into(),
             path: metadata
                 .remove(PATH_KEY)

--- a/azure-functions/src/bindings/cosmos_db_trigger.rs
+++ b/azure-functions/src/bindings/cosmos_db_trigger.rs
@@ -60,7 +60,7 @@ impl CosmosDbTrigger {
     pub fn new(data: TypedData, _metadata: HashMap<String, TypedData>) -> Self {
         let value = convert_from(&data).expect("expected JSON document data");
         match value {
-            Value::Array(array) => CosmosDbTrigger { documents: array },
+            Value::Array(array) => Self { documents: array },
             _ => panic!("expected a JSON array for Cosmos DB trigger data"),
         }
     }

--- a/azure-functions/src/bindings/durable_activity_context.rs
+++ b/azure-functions/src/bindings/durable_activity_context.rs
@@ -42,7 +42,7 @@ pub struct DurableActivityContext {
 impl DurableActivityContext {
     #[doc(hidden)]
     pub fn new(data: TypedData, mut metadata: HashMap<String, TypedData>) -> Self {
-        DurableActivityContext {
+        Self {
             input: match data.data {
                 Some(Data::String(s)) => Value::String(s),
                 Some(Data::Json(s)) => from_str(&s).unwrap_or_default(),

--- a/azure-functions/src/bindings/durable_orchestration_client.rs
+++ b/azure-functions/src/bindings/durable_orchestration_client.rs
@@ -173,14 +173,14 @@ impl From<TypedData> for DurableOrchestrationClient {
             _ => panic!("expected string data for durable orchestration client"),
         };
 
-        DurableOrchestrationClient {
+        Self {
             client: Client::new(&data.management_urls.status_query_url),
         }
     }
 }
 
-impl<'a> Into<Body<'a>> for OrchestrationData {
-    fn into(self) -> Body<'a> {
+impl Into<Body> for OrchestrationData {
+    fn into(self) -> Body {
         to_value(&self).unwrap().into()
     }
 }

--- a/azure-functions/src/bindings/durable_orchestration_context.rs
+++ b/azure-functions/src/bindings/durable_orchestration_context.rs
@@ -83,7 +83,7 @@ impl DurableOrchestrationContext {
                 let data: BindingData =
                     from_str(s).expect("failed to parse orchestration context data");
 
-                DurableOrchestrationContext {
+                Self {
                     instance_id: data.instance_id,
                     parent_instance_id: data.parent_instance_id,
                     input: data.input,

--- a/azure-functions/src/bindings/event_hub_trigger.rs
+++ b/azure-functions/src/bindings/event_hub_trigger.rs
@@ -36,8 +36,9 @@ const SYSTEM_PROPERTIES_KEY: &str = "SystemProperties";
 /// use log::info;
 ///
 /// #[func]
-/// #[binding(name = "trigger", connection = "my_connection")]
-/// pub fn log_event(trigger: EventHubTrigger) {
+/// pub fn log_event(
+///     #[binding(connection = "my_connection")] trigger: EventHubTrigger
+/// ) {
 ///     log::info!("{:?}", trigger);
 /// }
 /// ```
@@ -62,7 +63,7 @@ pub struct EventHubTrigger {
 impl EventHubTrigger {
     #[doc(hidden)]
     pub fn new(data: TypedData, mut metadata: HashMap<String, TypedData>) -> Self {
-        EventHubTrigger {
+        Self {
             message: data.into(),
             partition_context: from_str(
                 match &metadata
@@ -212,7 +213,7 @@ mod tests {
 
         let trigger = EventHubTrigger::new(data, metadata);
 
-        assert_eq!(trigger.message.as_str().unwrap(), MESSAGE);
+        assert_eq!(trigger.message.to_str().unwrap(), MESSAGE);
         assert_eq!(
             trigger.partition_context.consumer_group_name,
             CONSUMER_GROUP

--- a/azure-functions/src/bindings/generic_input.rs
+++ b/azure-functions/src/bindings/generic_input.rs
@@ -23,24 +23,25 @@ use crate::{generic::Value, http::Body, rpc::TypedData};
 /// use serde_json::from_str;
 ///
 /// #[func]
-/// #[binding(name = "req", route = "read/{id}")]
-/// #[binding(
-///     type = "cosmosDB",
-///     name = "document",
-///     connectionStringSetting = "connection",
-///     databaseName = "exampledb",
-///     collectionName = "documents",
-///     id = "{id}",
-///     partitionKey = "{id}"
-/// )]
-/// pub fn read_document(req: HttpRequest, document: GenericInput) -> HttpResponse {
+/// pub fn read_document(
+///     #[binding(route = "read/{id}")] req: HttpRequest,
+///     #[binding(
+///         type = "cosmosDB",
+///         connectionStringSetting = "connection",
+///         databaseName = "exampledb",
+///         collectionName = "documents",
+///         id = "{id}",
+///         partitionKey = "{id}"
+///     )]
+///     document: GenericInput,
+/// ) -> HttpResponse {
 ///     match document.data {
 ///         Value::String(s) => {
 ///             let v: serde_json::Value = from_str(&s).expect("expected JSON data");
 ///             if v.is_null() {
 ///                 format!(
 ///                     "Document with id '{}' does not exist.",
-///                     req.route_params().get("id").unwrap()
+///                     req.route_params.get("id").unwrap()
 ///                 )
 ///                 .into()
 ///             } else {
@@ -57,8 +58,8 @@ pub struct GenericInput {
     pub data: Value,
 }
 
-impl<'a> Into<Body<'a>> for GenericInput {
-    fn into(self) -> Body<'a> {
+impl Into<Body> for GenericInput {
+    fn into(self) -> Body {
         self.data.into()
     }
 }
@@ -66,7 +67,7 @@ impl<'a> Into<Body<'a>> for GenericInput {
 #[doc(hidden)]
 impl From<TypedData> for GenericInput {
     fn from(data: TypedData) -> Self {
-        GenericInput { data: data.into() }
+        Self { data: data.into() }
     }
 }
 

--- a/azure-functions/src/bindings/generic_output.rs
+++ b/azure-functions/src/bindings/generic_output.rs
@@ -25,7 +25,6 @@ use crate::{
 /// use serde_json::json;
 ///
 /// #[func]
-/// #[binding(name = "req", route = "create/{id}")]
 /// #[binding(
 ///     type = "cosmosDB",
 ///     name = "output1",
@@ -34,12 +33,14 @@ use crate::{
 ///     collectionName = "documents",
 ///     createIfNotExists = true
 /// )]
-/// pub fn create_document(req: HttpRequest) -> (HttpResponse, GenericOutput) {
+/// pub fn create_document(
+///     #[binding(route = "create/{id}")] mut req: HttpRequest,
+/// ) -> (HttpResponse, GenericOutput) {
 ///     (
 ///         "Document was created.".into(),
 ///         json!({
-///             "id": req.route_params().get("id").unwrap(),
-///             "name": req.query_params().get("name").map_or("stranger", |x| x)
+///             "id": req.route_params.remove("id").unwrap(),
+///             "name": req.query_params.remove("name").expect("expected a 'name' query parameter"),
 ///         })
 ///         .into(),
 ///     )
@@ -53,7 +54,7 @@ pub struct GenericOutput {
 
 impl From<&str> for GenericOutput {
     fn from(s: &str) -> Self {
-        GenericOutput {
+        Self {
             data: Value::String(s.to_owned()),
         }
     }
@@ -61,7 +62,7 @@ impl From<&str> for GenericOutput {
 
 impl From<String> for GenericOutput {
     fn from(s: String) -> Self {
-        GenericOutput {
+        Self {
             data: Value::String(s),
         }
     }
@@ -69,7 +70,7 @@ impl From<String> for GenericOutput {
 
 impl From<serde_json::Value> for GenericOutput {
     fn from(value: serde_json::Value) -> Self {
-        GenericOutput {
+        Self {
             data: Value::Json(value),
         }
     }
@@ -77,7 +78,7 @@ impl From<serde_json::Value> for GenericOutput {
 
 impl From<Vec<u8>> for GenericOutput {
     fn from(bytes: Vec<u8>) -> Self {
-        GenericOutput {
+        Self {
             data: Value::Bytes(bytes),
         }
     }
@@ -85,7 +86,7 @@ impl From<Vec<u8>> for GenericOutput {
 
 impl From<i64> for GenericOutput {
     fn from(integer: i64) -> Self {
-        GenericOutput {
+        Self {
             data: Value::Integer(integer),
         }
     }
@@ -93,7 +94,7 @@ impl From<i64> for GenericOutput {
 
 impl From<f64> for GenericOutput {
     fn from(double: f64) -> Self {
-        GenericOutput {
+        Self {
             data: Value::Double(double),
         }
     }

--- a/azure-functions/src/bindings/generic_trigger.rs
+++ b/azure-functions/src/bindings/generic_trigger.rs
@@ -52,7 +52,7 @@ impl GenericTrigger {
         for (k, v) in metadata.into_iter() {
             md.insert(k, v.into());
         }
-        GenericTrigger {
+        Self {
             data: data.into(),
             metadata: md,
         }

--- a/azure-functions/src/bindings/queue_message.rs
+++ b/azure-functions/src/bindings/queue_message.rs
@@ -3,10 +3,7 @@ use crate::{
     rpc::{typed_data::Data, TypedData},
     FromVec,
 };
-use serde::de::Error;
-use serde::Deserialize;
-use serde_json::{from_str, Result, Value};
-use std::borrow::Cow;
+use serde_json::{from_str, Value};
 use std::fmt;
 use std::str::from_utf8;
 
@@ -69,7 +66,7 @@ impl QueueMessage {
     /// Gets the content of the message as a string.
     ///
     /// Returns None if there is no valid string representation of the message.
-    pub fn as_str(&self) -> Option<&str> {
+    pub fn to_str(&self) -> Option<&str> {
         match &self.0.data {
             Some(Data::String(s)) => Some(s),
             Some(Data::Json(s)) => Some(s),
@@ -89,28 +86,17 @@ impl QueueMessage {
             _ => panic!("unexpected data for queue message content"),
         }
     }
-
-    /// Deserializes the message as JSON to the requested type.
-    pub fn as_json<'b, T>(&'b self) -> Result<T>
-    where
-        T: Deserialize<'b>,
-    {
-        from_str(
-            self.as_str()
-                .ok_or_else(|| ::serde_json::Error::custom("queue message is not valid UTF-8"))?,
-        )
-    }
 }
 
 impl fmt::Display for QueueMessage {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.as_str().unwrap_or(""))
+        write!(f, "{}", self.to_str().unwrap_or(""))
     }
 }
 
-impl<'a> From<&'a str> for QueueMessage {
-    fn from(content: &'a str) -> Self {
-        QueueMessage(TypedData {
+impl From<&str> for QueueMessage {
+    fn from(content: &str) -> Self {
+        Self(TypedData {
             data: Some(Data::String(content.to_owned())),
         })
     }
@@ -118,7 +104,7 @@ impl<'a> From<&'a str> for QueueMessage {
 
 impl From<String> for QueueMessage {
     fn from(content: String) -> Self {
-        QueueMessage(TypedData {
+        Self(TypedData {
             data: Some(Data::String(content)),
         })
     }
@@ -126,7 +112,7 @@ impl From<String> for QueueMessage {
 
 impl From<&Value> for QueueMessage {
     fn from(content: &Value) -> Self {
-        QueueMessage(TypedData {
+        Self(TypedData {
             data: Some(Data::Json(content.to_string())),
         })
     }
@@ -134,15 +120,15 @@ impl From<&Value> for QueueMessage {
 
 impl From<Value> for QueueMessage {
     fn from(content: Value) -> Self {
-        QueueMessage(TypedData {
+        Self(TypedData {
             data: Some(Data::Json(content.to_string())),
         })
     }
 }
 
-impl<'a> From<&'a [u8]> for QueueMessage {
-    fn from(content: &'a [u8]) -> Self {
-        QueueMessage(TypedData {
+impl From<&[u8]> for QueueMessage {
+    fn from(content: &[u8]) -> Self {
+        Self(TypedData {
             data: Some(Data::Bytes(content.to_owned())),
         })
     }
@@ -150,7 +136,7 @@ impl<'a> From<&'a [u8]> for QueueMessage {
 
 impl From<Vec<u8>> for QueueMessage {
     fn from(content: Vec<u8>) -> Self {
-        QueueMessage(TypedData {
+        Self(TypedData {
             data: Some(Data::Bytes(content)),
         })
     }
@@ -159,14 +145,14 @@ impl From<Vec<u8>> for QueueMessage {
 #[doc(hidden)]
 impl From<TypedData> for QueueMessage {
     fn from(data: TypedData) -> Self {
-        QueueMessage(data)
+        Self(data)
     }
 }
 
 #[doc(hidden)]
 impl FromVec<QueueMessage> for TypedData {
     fn from_vec(vec: Vec<QueueMessage>) -> Self {
-        TypedData {
+        Self {
             data: Some(Data::Json(
                 Value::Array(vec.into_iter().map(Into::into).collect()).to_string(),
             )),
@@ -225,15 +211,9 @@ impl Into<Vec<u8>> for QueueMessage {
     }
 }
 
-impl<'a> Into<Body<'a>> for QueueMessage {
-    fn into(self) -> Body<'a> {
-        match self.0.data {
-            Some(Data::String(s)) => s.into(),
-            Some(Data::Json(s)) => Body::Json(Cow::from(s)),
-            Some(Data::Bytes(b)) => b.into(),
-            Some(Data::Stream(s)) => s.into(),
-            _ => panic!("unexpected data for queue message content"),
-        }
+impl Into<Body> for QueueMessage {
+    fn into(self) -> Body {
+        self.0.into()
     }
 }
 
@@ -248,7 +228,7 @@ impl Into<TypedData> for QueueMessage {
 mod tests {
     use super::*;
     use serde::{Deserialize, Serialize};
-    use serde_json::{json, to_value};
+    use serde_json::{from_slice, json, to_value};
     use std::fmt::Write;
 
     #[test]
@@ -256,7 +236,7 @@ mod tests {
         const MESSAGE: &'static str = "test message";
 
         let message: QueueMessage = MESSAGE.into();
-        assert_eq!(message.as_str().unwrap(), MESSAGE);
+        assert_eq!(message.to_str().unwrap(), MESSAGE);
 
         let data: TypedData = message.into();
         assert_eq!(data.data, Some(Data::String(MESSAGE.to_string())));
@@ -275,11 +255,9 @@ mod tests {
             message: MESSAGE.to_string(),
         };
 
-        let message: QueueMessage = ::serde_json::to_value(data).unwrap().into();
-        assert_eq!(
-            message.as_json::<SerializedData>().unwrap().message,
-            MESSAGE
-        );
+        let message: QueueMessage = to_value(data).unwrap().into();
+        let data: SerializedData = from_slice(message.as_bytes()).unwrap();
+        assert_eq!(data.message, MESSAGE);
 
         let data: TypedData = message.into();
         assert_eq!(
@@ -314,19 +292,19 @@ mod tests {
     #[test]
     fn it_converts_from_str() {
         let message: QueueMessage = "test".into();
-        assert_eq!(message.as_str().unwrap(), "test");
+        assert_eq!(message.to_str().unwrap(), "test");
     }
 
     #[test]
     fn it_converts_from_string() {
         let message: QueueMessage = "test".to_string().into();
-        assert_eq!(message.as_str().unwrap(), "test");
+        assert_eq!(message.to_str().unwrap(), "test");
     }
 
     #[test]
     fn it_converts_from_json() {
         let message: QueueMessage = to_value("hello world").unwrap().into();
-        assert_eq!(message.as_str().unwrap(), r#""hello world""#);
+        assert_eq!(message.to_str().unwrap(), r#""hello world""#);
     }
 
     #[test]
@@ -366,11 +344,11 @@ mod tests {
     fn it_converts_to_body() {
         let message: QueueMessage = "hello world!".into();
         let body: Body = message.into();
-        assert_eq!(body.as_str().unwrap(), "hello world!");
+        assert_eq!(body.to_str().unwrap(), "hello world!");
 
         let message: QueueMessage = json!({"hello": "world"}).into();
         let body: Body = message.into();
-        assert_eq!(body.as_str().unwrap(), r#"{"hello":"world"}"#);
+        assert_eq!(body.to_str().unwrap(), r#"{"hello":"world"}"#);
 
         let message: QueueMessage = vec![1, 2, 3].into();
         let body: Body = message.into();

--- a/azure-functions/src/bindings/queue_trigger.rs
+++ b/azure-functions/src/bindings/queue_trigger.rs
@@ -33,8 +33,10 @@ const POP_RECEIPT_KEY: &str = "PopReceipt";
 /// use log::info;
 ///
 /// #[func]
-/// #[binding(name = "trigger", queue_name = "example")]
-/// pub fn run_on_message(trigger: QueueTrigger) {
+///
+/// pub fn run_on_message(
+///     #[binding(queue_name = "example")] trigger: QueueTrigger
+/// ) {
 ///     info!("Rust function ran due to queue message: {}", trigger.message);
 /// }
 /// ```
@@ -59,7 +61,7 @@ pub struct QueueTrigger {
 impl QueueTrigger {
     #[doc(hidden)]
     pub fn new(data: TypedData, mut metadata: HashMap<String, TypedData>) -> Self {
-        QueueTrigger {
+        Self {
             message: data.into(),
             id: metadata
                 .remove(ID_KEY)
@@ -170,6 +172,6 @@ mod tests {
         assert_eq!(trigger.insertion_time.to_rfc3339(), now.to_rfc3339());
         assert_eq!(trigger.next_visible_time.to_rfc3339(), now.to_rfc3339());
         assert_eq!(trigger.pop_receipt, POP_RECEIPT);
-        assert_eq!(trigger.message.as_str().unwrap(), MESSAGE);
+        assert_eq!(trigger.message.to_str().unwrap(), MESSAGE);
     }
 }

--- a/azure-functions/src/bindings/send_grid_message.rs
+++ b/azure-functions/src/bindings/send_grid_message.rs
@@ -32,14 +32,12 @@ use std::collections::HashMap;
 /// #[func]
 /// #[binding(name = "output1", from = "azure.functions.for.rust@example.com")]
 /// pub fn send_email(req: HttpRequest) -> (HttpResponse, SendGridMessage) {
-///     let params = req.query_params();
-///
 ///     (
 ///         "The email was sent.".into(),
 ///         SendGridMessage::build()
-///             .to(params.get("to").unwrap().as_str())
-///             .subject(params.get("subject").unwrap().as_str())
-///             .content(params.get("content").unwrap().as_str())
+///             .to(req.query_params.get("to").unwrap().as_str())
+///             .subject(req.query_params.get("subject").unwrap().as_str())
+///             .content(req.query_params.get("content").unwrap().as_str())
 ///             .finish(),
 ///     )
 /// }
@@ -136,7 +134,7 @@ impl Into<TypedData> for SendGridMessage {
 #[doc(hidden)]
 impl FromVec<SendGridMessage> for TypedData {
     fn from_vec(vec: Vec<SendGridMessage>) -> Self {
-        TypedData {
+        Self {
             data: Some(Data::Json(
                 Value::Array(vec.into_iter().map(|m| to_value(m).unwrap()).collect()).to_string(),
             )),

--- a/azure-functions/src/bindings/signalr_group_action.rs
+++ b/azure-functions/src/bindings/signalr_group_action.rs
@@ -28,12 +28,14 @@ use serde_json::{to_string, to_value, Value};
 /// };
 ///
 /// #[func]
-/// #[binding(name = "req", auth_level = "anonymous", methods = "post")]
+///
 /// #[binding(name = "$return", hub_name = "chat", connection = "myconnection")]
-/// pub fn add_to_group(req: HttpRequest) -> SignalRGroupAction {
+/// pub fn add_to_group(
+///     #[binding(auth_level = "anonymous", methods = "post")] mut req: HttpRequest
+/// ) -> SignalRGroupAction {
 ///     SignalRGroupAction {
-///         user_id: req.query_params().get("user").unwrap().to_owned(),
-///         group_name: req.query_params().get("group").unwrap().to_owned(),
+///         user_id: req.query_params.remove("user").unwrap(),
+///         group_name: req.query_params.remove("group").unwrap(),
 ///         action: GroupAction::Add,
 ///     }
 /// }
@@ -63,7 +65,7 @@ impl Into<TypedData> for SignalRGroupAction {
 #[doc(hidden)]
 impl FromVec<SignalRGroupAction> for TypedData {
     fn from_vec(vec: Vec<SignalRGroupAction>) -> Self {
-        TypedData {
+        Self {
             data: Some(Data::Json(
                 Value::Array(vec.into_iter().map(|a| to_value(a).unwrap()).collect()).to_string(),
             )),

--- a/azure-functions/src/bindings/signalr_message.rs
+++ b/azure-functions/src/bindings/signalr_message.rs
@@ -27,14 +27,15 @@ use serde_json::{to_string, to_value, Value};
 /// use serde_json::{to_value, Value};
 ///
 /// #[func]
-/// #[binding(name = "req", auth_level = "anonymous", methods = "post")]
 /// #[binding(name = "$return", hub_name = "chat", connection = "myconnection")]
-/// pub fn send_message(req: HttpRequest) -> SignalRMessage {
+/// pub fn send_message(
+///     #[binding(auth_level = "anonymous", methods = "post")] mut req: HttpRequest
+/// ) -> SignalRMessage {
 ///     SignalRMessage {
-///         user_id: req.query_params().get("user").map(|v| v.to_owned()),
-///         group_name: req.query_params().get("group").map(|v| v.to_owned()),
+///         user_id: req.query_params.remove("user"),
+///         group_name: req.query_params.remove("group"),
 ///         target: "newMessage".to_owned(),
-///         arguments: vec![req.query_params().get("message").map_or(Value::Null, |v| to_value(v).unwrap())],
+///         arguments: vec![req.query_params.remove("message").map_or(Value::Null, |v| to_value(v).unwrap())],
 ///     }
 /// }
 /// ```
@@ -65,7 +66,7 @@ impl Into<TypedData> for SignalRMessage {
 #[doc(hidden)]
 impl FromVec<SignalRMessage> for TypedData {
     fn from_vec(vec: Vec<SignalRMessage>) -> Self {
-        TypedData {
+        Self {
             data: Some(Data::Json(
                 Value::Array(vec.into_iter().map(|m| to_value(m).unwrap()).collect()).to_string(),
             )),

--- a/azure-functions/src/bindings/timer_info.rs
+++ b/azure-functions/src/bindings/timer_info.rs
@@ -27,8 +27,9 @@ use std::collections::HashMap;
 /// use log::info;
 ///
 /// #[func]
-/// #[binding(name = "_info", schedule = "0 */5 * * * *")]
-/// pub fn timer(_info: TimerInfo) {
+/// pub fn timer(
+///     #[binding(schedule = "0 */5 * * * *")] _info: TimerInfo
+/// ) {
 ///     info!("Rust Azure function ran!");
 /// }
 /// ```

--- a/azure-functions/src/bindings/twilio_sms_message.rs
+++ b/azure-functions/src/bindings/twilio_sms_message.rs
@@ -26,18 +26,18 @@ use serde_json::{to_string, to_value, Value};
 ///     bindings::{HttpRequest, HttpResponse, TwilioSmsMessage},
 ///     func,
 /// };
-/// use std::borrow::ToOwned;
 ///
 /// #[func]
 /// #[binding(name = "output1", from = "+15555555555")]
-/// pub fn send_sms(req: HttpRequest) -> (HttpResponse, TwilioSmsMessage) {
-///     let params = req.query_params();
-///
+/// pub fn send_sms(mut req: HttpRequest) -> (HttpResponse, TwilioSmsMessage) {
 ///     (
 ///         "Text message sent.".into(),
 ///         TwilioSmsMessage {
-///             to: params.get("to").unwrap().to_owned(),
-///             body: params.get("body").map(ToOwned::to_owned),
+///             to: req
+///                 .query_params
+///                 .remove("to")
+///                 .expect("expected a 'to' query parameter"),
+///             body: req.query_params.remove("body"),
 ///             ..Default::default()
 ///         },
 ///     )
@@ -68,7 +68,7 @@ impl Into<TypedData> for TwilioSmsMessage {
 #[doc(hidden)]
 impl FromVec<TwilioSmsMessage> for TypedData {
     fn from_vec(vec: Vec<TwilioSmsMessage>) -> Self {
-        TypedData {
+        Self {
             data: Some(Data::Json(
                 Value::Array(vec.into_iter().map(|m| to_value(m).unwrap()).collect()).to_string(),
             )),

--- a/azure-functions/src/blob/properties.rs
+++ b/azure-functions/src/blob/properties.rs
@@ -16,7 +16,7 @@ pub enum BlobType {
 
 impl Default for BlobType {
     fn default() -> Self {
-        BlobType::Unspecified
+        Self::Unspecified
     }
 }
 
@@ -33,7 +33,7 @@ pub enum LeaseDuration {
 
 impl Default for LeaseDuration {
     fn default() -> Self {
-        LeaseDuration::Unspecified
+        Self::Unspecified
     }
 }
 
@@ -56,7 +56,7 @@ pub enum LeaseState {
 
 impl Default for LeaseState {
     fn default() -> Self {
-        LeaseState::Unspecified
+        Self::Unspecified
     }
 }
 
@@ -73,7 +73,7 @@ pub enum LeaseStatus {
 
 impl Default for LeaseStatus {
     fn default() -> Self {
-        LeaseStatus::Unspecified
+        Self::Unspecified
     }
 }
 
@@ -102,7 +102,7 @@ pub enum PremiumPageBlobTier {
 
 impl Default for PremiumPageBlobTier {
     fn default() -> Self {
-        PremiumPageBlobTier::Unknown
+        Self::Unknown
     }
 }
 
@@ -119,7 +119,7 @@ pub enum RehydrationStatus {
 
 impl Default for RehydrationStatus {
     fn default() -> Self {
-        RehydrationStatus::Unknown
+        Self::Unknown
     }
 }
 
@@ -138,7 +138,7 @@ pub enum StandardBlobTier {
 
 impl Default for StandardBlobTier {
     fn default() -> Self {
-        StandardBlobTier::Unknown
+        Self::Unknown
     }
 }
 

--- a/azure-functions/src/commands/init.rs
+++ b/azure-functions/src/commands/init.rs
@@ -520,7 +520,7 @@ impl<'a> Init<'a> {
             .any(|p| match p {
                 Ok(p) => {
                     let p = p.path();
-                    p.is_file() && p.extension().map(|x| x == "rs").unwrap_or(false)
+                    p.is_file() && p.extension().map_or(false, |x| x == "rs")
                 }
                 _ => false,
             })

--- a/azure-functions/src/commands/sync_extensions.rs
+++ b/azure-functions/src/commands/sync_extensions.rs
@@ -208,7 +208,7 @@ impl SyncExtensions {
 
 impl<'a> From<&ArgMatches<'a>> for SyncExtensions {
     fn from(args: &ArgMatches<'a>) -> Self {
-        SyncExtensions {
+        Self {
             script_root: current_dir()
                 .expect("failed to get current directory")
                 .join(

--- a/azure-functions/src/durable/action_future.rs
+++ b/azure-functions/src/durable/action_future.rs
@@ -26,7 +26,7 @@ impl<T> ActionFuture<T> {
                 || (result.is_some() && event_index.is_some())
         );
 
-        ActionFuture {
+        Self {
             result,
             state,
             event_index,

--- a/azure-functions/src/durable/activity_output.rs
+++ b/azure-functions/src/durable/activity_output.rs
@@ -12,7 +12,7 @@ where
     T: Into<Value>,
 {
     fn from(t: T) -> Self {
-        ActivityOutput(t.into())
+        Self(t.into())
     }
 }
 
@@ -21,7 +21,7 @@ impl FromIterator<Value> for ActivityOutput {
     where
         I: IntoIterator<Item = Value>,
     {
-        ActivityOutput(Value::from_iter(iter))
+        Self(Value::from_iter(iter))
     }
 }
 

--- a/azure-functions/src/durable/join_all.rs
+++ b/azure-functions/src/durable/join_all.rs
@@ -52,7 +52,7 @@ where
             })
             .unwrap_or(None);
 
-        JoinAll {
+        Self {
             inner: join_all(inner),
             state,
             event_index,

--- a/azure-functions/src/durable/orchestration_output.rs
+++ b/azure-functions/src/durable/orchestration_output.rs
@@ -12,7 +12,7 @@ where
     T: Into<Value>,
 {
     fn from(t: T) -> Self {
-        OrchestrationOutput(t.into())
+        Self(t.into())
     }
 }
 
@@ -21,7 +21,7 @@ impl FromIterator<Value> for OrchestrationOutput {
     where
         I: IntoIterator<Item = Value>,
     {
-        OrchestrationOutput(Value::from_iter(iter))
+        Self(Value::from_iter(iter))
     }
 }
 

--- a/azure-functions/src/durable/orchestration_state.rs
+++ b/azure-functions/src/durable/orchestration_state.rs
@@ -36,7 +36,7 @@ impl OrchestrationState {
             .position(|event| event.event_type == EventType::OrchestratorCompleted)
             .map(|pos| pos + started_index);
 
-        OrchestrationState {
+        Self {
             history,
             result: ExecutionResult::default(),
             started_index,

--- a/azure-functions/src/durable/select_all.rs
+++ b/azure-functions/src/durable/select_all.rs
@@ -39,7 +39,7 @@ where
         // The event index of a select is the minimum present index of the sequence
         let event_index = inner.iter().filter_map(|f| f.event_index()).min();
 
-        SelectAll {
+        Self {
             inner,
             state,
             event_index,

--- a/azure-functions/src/generic.rs
+++ b/azure-functions/src/generic.rs
@@ -4,7 +4,6 @@ use crate::{
     rpc::{typed_data::Data, TypedData},
 };
 use serde_json::from_str;
-use std::borrow::Cow;
 
 /// Represents a value passed to or from a generic binding.
 #[derive(Debug, Clone, PartialEq)]
@@ -23,16 +22,10 @@ pub enum Value {
     Double(f64),
 }
 
-impl<'a> Into<Body<'a>> for Value {
-    fn into(self) -> Body<'a> {
-        match self {
-            Value::None => Body::Empty,
-            Value::String(s) => Body::String(Cow::Owned(s)),
-            Value::Json(v) => Body::Json(Cow::Owned(v.to_string())),
-            Value::Bytes(b) => Body::Bytes(Cow::Owned(b)),
-            Value::Integer(i) => Body::String(Cow::Owned(i.to_string())),
-            Value::Double(d) => Body::String(Cow::Owned(d.to_string())),
-        }
+impl Into<Body> for Value {
+    fn into(self) -> Body {
+        let d: TypedData = self.into();
+        d.into()
     }
 }
 
@@ -40,14 +33,14 @@ impl<'a> Into<Body<'a>> for Value {
 impl From<TypedData> for Value {
     fn from(data: TypedData) -> Self {
         match data.data {
-            None => Value::None,
-            Some(Data::String(s)) => Value::String(s),
-            Some(Data::Json(s)) => Value::Json(from_str(&s).unwrap()),
-            Some(Data::Bytes(b)) => Value::Bytes(b),
-            Some(Data::Stream(b)) => Value::Bytes(b),
-            Some(Data::Int(i)) => Value::Integer(i),
-            Some(Data::Double(d)) => Value::Double(d),
-            _ => panic!("unsupported type data")
+            None => Self::None,
+            Some(Data::String(s)) => Self::String(s),
+            Some(Data::Json(s)) => Self::Json(from_str(&s).unwrap()),
+            Some(Data::Bytes(b)) => Self::Bytes(b),
+            Some(Data::Stream(b)) => Self::Bytes(b),
+            Some(Data::Int(i)) => Self::Integer(i),
+            Some(Data::Double(d)) => Self::Double(d),
+            _ => panic!("unsupported type data"),
         }
     }
 }
@@ -56,20 +49,20 @@ impl From<TypedData> for Value {
 impl Into<TypedData> for Value {
     fn into(self) -> TypedData {
         match self {
-            Value::None => TypedData { data: None },
-            Value::String(s) => TypedData {
+            Self::None => TypedData { data: None },
+            Self::String(s) => TypedData {
                 data: Some(Data::String(s)),
             },
-            Value::Json(v) => TypedData {
+            Self::Json(v) => TypedData {
                 data: Some(Data::Json(v.to_string())),
             },
-            Value::Bytes(b) => TypedData {
+            Self::Bytes(b) => TypedData {
                 data: Some(Data::Bytes(b)),
             },
-            Value::Integer(i) => TypedData {
+            Self::Integer(i) => TypedData {
                 data: Some(Data::Int(i)),
             },
-            Value::Double(d) => TypedData {
+            Self::Double(d) => TypedData {
                 data: Some(Data::Double(d)),
             },
         }

--- a/azure-functions/src/generic.rs
+++ b/azure-functions/src/generic.rs
@@ -45,9 +45,9 @@ impl From<TypedData> for Value {
             Some(Data::Json(s)) => Value::Json(from_str(&s).unwrap()),
             Some(Data::Bytes(b)) => Value::Bytes(b),
             Some(Data::Stream(b)) => Value::Bytes(b),
-            Some(Data::Http(_)) => panic!("generic bindings cannot contain HTTP data"),
             Some(Data::Int(i)) => Value::Integer(i),
             Some(Data::Double(d)) => Value::Double(d),
+            _ => panic!("unsupported type data")
         }
     }
 }

--- a/azure-functions/src/http.rs
+++ b/azure-functions/src/http.rs
@@ -1,8 +1,10 @@
 //! Module for HTTP types.
 mod body;
+mod cookie;
 mod response_builder;
 mod status;
 
 pub use self::body::*;
+pub use self::cookie::*;
 pub use self::response_builder::*;
 pub use self::status::*;

--- a/azure-functions/src/http/cookie.rs
+++ b/azure-functions/src/http/cookie.rs
@@ -1,0 +1,240 @@
+use crate::rpc::{
+    nullable_bool::Bool, nullable_double::Double, nullable_string::String as StringValue,
+    nullable_timestamp::Timestamp, NullableBool, NullableDouble, NullableString, NullableTimestamp,
+    RpcHttpCookie,
+};
+use chrono::{DateTime, NaiveDateTime, Utc};
+
+/// The same site policy for HTTP cookies.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SameSitePolicy {
+    /// Allow the cookie to be sent in cross-site browsing contexts for any methods.
+    None = 0,
+    /// Allow the cookie to be sent in cross-site browsing contexts, but block CSRF request methods.
+    Lax = 1,
+    /// Prevents the cookie from being sent in all cross-site browsing contexts.
+    Strict = 2,
+}
+
+impl Default for SameSitePolicy {
+    fn default() -> Self {
+        Self::None
+    }
+}
+
+/// Represents a HTTP cookie.
+#[derive(Default, Clone, Debug)]
+pub struct Cookie {
+    /// The name of the cookie.
+    pub name: String,
+    /// The value of the cookie.
+    pub value: String,
+    /// The domain of the cookie.
+    pub domain: Option<String>,
+    /// The path of the cookie.
+    pub path: Option<String>,
+    /// The expiration time of the cookie.
+    pub expires: Option<DateTime<Utc>>,
+    /// Whether or not the cookie is secure.
+    pub secure: Option<bool>,
+    /// Whether or not the cookie is HTTP only.
+    pub http_only: Option<bool>,
+    /// The same sity policy of the cookie.
+    pub same_site_policy: SameSitePolicy,
+    /// The maximum age of the cookie.
+    pub max_age: Option<f64>,
+}
+
+#[doc(hidden)]
+impl From<RpcHttpCookie> for Cookie {
+    fn from(cookie: RpcHttpCookie) -> Self {
+        Self {
+            name: cookie.name,
+            value: cookie.value,
+            domain: cookie.domain.and_then(|s| {
+                s.string.map(|s| match s {
+                    StringValue::Value(s) => s,
+                })
+            }),
+            path: cookie.path.and_then(|s| {
+                s.string.map(|s| match s {
+                    StringValue::Value(s) => s,
+                })
+            }),
+            expires: cookie.expires.and_then(|t| {
+                t.timestamp.map(|t| match t {
+                    Timestamp::Value(t) => DateTime::<Utc>::from_utc(
+                        NaiveDateTime::from_timestamp(t.seconds, t.nanos as u32),
+                        Utc,
+                    ),
+                })
+            }),
+            secure: cookie.secure.and_then(|b| {
+                b.r#bool.map(|b| match b {
+                    Bool::Value(b) => b,
+                })
+            }),
+            http_only: cookie.http_only.and_then(|b| {
+                b.r#bool.map(|b| match b {
+                    Bool::Value(b) => b,
+                })
+            }),
+            same_site_policy: match cookie.same_site {
+                0 => SameSitePolicy::None,
+                1 => SameSitePolicy::Lax,
+                2 => SameSitePolicy::Strict,
+                _ => panic!("unsupported cookie same site policy value"),
+            },
+            max_age: cookie.max_age.and_then(|d| {
+                d.double.map(|d| match d {
+                    Double::Value(b) => b,
+                })
+            }),
+        }
+    }
+}
+
+impl Into<RpcHttpCookie> for Cookie {
+    fn into(self) -> RpcHttpCookie {
+        RpcHttpCookie {
+            name: self.name,
+            value: self.value,
+            domain: self.domain.map(|s| NullableString {
+                string: Some(StringValue::Value(s)),
+            }),
+            path: self.path.map(|s| NullableString {
+                string: Some(StringValue::Value(s)),
+            }),
+            expires: self.expires.map(|t| NullableTimestamp {
+                timestamp: Some(Timestamp::Value(prost_types::Timestamp {
+                    seconds: t.timestamp(),
+                    nanos: t.timestamp_subsec_nanos() as i32,
+                })),
+            }),
+            secure: self.secure.map(|b| NullableBool {
+                r#bool: Some(Bool::Value(b)),
+            }),
+            http_only: self.http_only.map(|b| NullableBool {
+                r#bool: Some(Bool::Value(b)),
+            }),
+            same_site: self.same_site_policy as i32,
+            max_age: self.max_age.map(|d| NullableDouble {
+                double: Some(Double::Value(d)),
+            }),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn it_converts_from_rpc_cookie() {
+        let data = RpcHttpCookie {
+            name: "name".into(),
+            value: "value".into(),
+            domain: Some(NullableString {
+                string: Some(StringValue::Value("domain".into())),
+            }),
+            path: Some(NullableString {
+                string: Some(StringValue::Value("path".into())),
+            }),
+            expires: Some(NullableTimestamp {
+                timestamp: Some(Timestamp::Value(prost_types::Timestamp {
+                    seconds: 1,
+                    nanos: 2,
+                })),
+            }),
+            secure: Some(NullableBool {
+                r#bool: Some(Bool::Value(true)),
+            }),
+            http_only: Some(NullableBool {
+                r#bool: Some(Bool::Value(true)),
+            }),
+            same_site: 1,
+            max_age: Some(NullableDouble {
+                double: Some(Double::Value(11.4)),
+            }),
+        };
+
+        let cookie: Cookie = data.into();
+        assert_eq!(cookie.name, "name");
+        assert_eq!(cookie.value, "value");
+        assert_eq!(cookie.domain, Some("domain".into()));
+        assert_eq!(cookie.path, Some("path".into()));
+        assert_eq!(
+            cookie.expires,
+            Some(DateTime::<Utc>::from_utc(
+                NaiveDateTime::from_timestamp(1, 2),
+                Utc
+            ))
+        );
+        assert_eq!(cookie.secure, Some(true));
+        assert_eq!(cookie.http_only, Some(true));
+        assert_eq!(cookie.same_site_policy, SameSitePolicy::Lax);
+        assert_eq!(cookie.max_age, Some(11.4));
+    }
+
+    #[test]
+    fn it_convert_to_rpc_cookie() {
+        let cookie = Cookie {
+            name: "name".into(),
+            value: "value".into(),
+            domain: Some("domain".into()),
+            path: Some("path".into()),
+            expires: Some(DateTime::<Utc>::from_utc(
+                NaiveDateTime::from_timestamp(1, 2),
+                Utc,
+            )),
+            secure: Some(true),
+            http_only: Some(true),
+            same_site_policy: SameSitePolicy::Lax,
+            max_age: Some(11.4),
+        };
+
+        let data: RpcHttpCookie = cookie.into();
+        assert_eq!(data.name, "name");
+        assert_eq!(data.value, "value");
+        assert_eq!(
+            data.domain,
+            Some(NullableString {
+                string: Some(StringValue::Value("domain".into())),
+            })
+        );
+        assert_eq!(
+            data.path,
+            Some(NullableString {
+                string: Some(StringValue::Value("path".into())),
+            })
+        );
+        assert_eq!(
+            data.expires,
+            Some(NullableTimestamp {
+                timestamp: Some(Timestamp::Value(prost_types::Timestamp {
+                    seconds: 1,
+                    nanos: 2,
+                })),
+            })
+        );
+        assert_eq!(
+            data.secure,
+            Some(NullableBool {
+                r#bool: Some(Bool::Value(true)),
+            })
+        );
+        assert_eq!(
+            data.http_only,
+            Some(NullableBool {
+                r#bool: Some(Bool::Value(true)),
+            })
+        );
+        assert_eq!(data.same_site, 1);
+        assert_eq!(
+            data.max_age,
+            Some(NullableDouble {
+                double: Some(Double::Value(11.4)),
+            })
+        );
+    }
+}

--- a/azure-functions/src/http/response_builder.rs
+++ b/azure-functions/src/http/response_builder.rs
@@ -1,5 +1,5 @@
 use crate::bindings::HttpResponse;
-use crate::http::{Body, Status};
+use crate::http::{Body, Cookie, SameSitePolicy, Status};
 
 /// Represents a builder for HTTP responses.
 #[derive(Default, Debug)]
@@ -7,8 +7,8 @@ pub struct ResponseBuilder(pub(crate) HttpResponse);
 
 impl ResponseBuilder {
     /// Creates a new `ResponseBuilder`.
-    pub fn new() -> ResponseBuilder {
-        ResponseBuilder(HttpResponse::new())
+    pub fn new() -> Self {
+        Self(HttpResponse::new())
     }
 
     /// Sets the status for the response.
@@ -23,7 +23,7 @@ impl ResponseBuilder {
     ///     .status(Status::InternalServerError)
     ///     .finish();
     ///
-    /// assert_eq!(response.status(), Status::InternalServerError);
+    /// assert_eq!(response.status, Status::InternalServerError);
     /// ```
     pub fn status<S: Into<Status>>(mut self, status: S) -> Self {
         self.0.status = status.into();
@@ -45,14 +45,14 @@ impl ResponseBuilder {
     ///
     /// assert_eq!(
     ///     response
-    ///         .headers()
+    ///         .headers
     ///         .get("X-Custom-Header")
     ///         .unwrap(),
     ///     value
     /// );
     /// ```
     pub fn header<T: Into<String>, U: Into<String>>(mut self, name: T, value: U) -> Self {
-        self.0.data.headers.insert(name.into(), value.into());
+        self.0.headers.insert(name.into(), value.into());
         self
     }
 
@@ -73,29 +73,54 @@ impl ResponseBuilder {
     ///     .body(message)
     ///     .finish();
     ///
-    /// assert_eq!(response.status(), Status::Created);
+    /// assert_eq!(response.status, Status::Created);
     /// assert_eq!(
-    ///     response.body().as_str().unwrap(),
+    ///     response.body.to_str().unwrap(),
     ///     message
     /// );
     /// ```
-    pub fn body<'a, B>(mut self, body: B) -> Self
+    pub fn body<B>(mut self, body: B) -> Self
     where
-        B: Into<Body<'a>>,
+        B: Into<Body>,
     {
         let body = body.into();
-        if let Body::Empty = &body {
-            self.0.data.body = None;
-            return self;
-        }
 
-        if !self.0.headers().contains_key("Content-Type") {
-            self.0.data.headers.insert(
+        if !self.0.headers.contains_key("Content-Type") {
+            self.0.headers.insert(
                 "Content-Type".to_string(),
                 body.default_content_type().to_string(),
             );
         }
-        self.0.data.body = Some(Box::new(body.into()));
+
+        self.0.body = body;
+        self
+    }
+
+    /// Adds a cookie to the response.
+    ///
+    /// The cookie will be secure, HTTP-only, and use a strict same site policy.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// # use azure_functions::http::ResponseBuilder;
+    ///
+    /// let response = ResponseBuilder::new()
+    ///     .cookie("hello", "world")
+    ///     .finish();
+    ///
+    /// assert_eq!(response.cookies[0].name, "hello");
+    /// assert_eq!(response.cookies[0].value, "world");
+    /// ```
+    pub fn cookie<T: Into<String>, U: Into<String>>(mut self, name: U, value: T) -> Self {
+        self.0.cookies.push(Cookie {
+            name: name.into(),
+            value: value.into(),
+            secure: Some(true),
+            http_only: Some(true),
+            same_site_policy: SameSitePolicy::Strict,
+            ..Default::default()
+        });
         self
     }
 
@@ -112,31 +137,28 @@ mod tests {
     #[test]
     fn it_creates_an_empty_response() {
         let response: HttpResponse = ResponseBuilder::new().finish();
-        assert_eq!(response.status(), Status::Ok);
-        assert_eq!(response.body().as_str().unwrap(), "");
+        assert_eq!(response.status, Status::Ok);
+        assert_eq!(response.body.to_str().unwrap(), "");
     }
 
     #[test]
     fn it_sets_a_status() {
         let response: HttpResponse = ResponseBuilder::new().status(Status::BadRequest).finish();
-        assert_eq!(response.status(), Status::BadRequest);
-        assert_eq!(response.body().as_str().unwrap(), "");
+        assert_eq!(response.status, Status::BadRequest);
+        assert_eq!(response.body.to_str().unwrap(), "");
     }
 
     #[test]
     fn it_sets_a_header() {
         let response: HttpResponse = ResponseBuilder::new().header("foo", "bar").finish();
-        assert_eq!(response.headers().get("foo").unwrap(), "bar");
-        assert_eq!(response.body().as_str().unwrap(), "");
+        assert_eq!(response.headers.get("foo").unwrap(), "bar");
+        assert_eq!(response.body.to_str().unwrap(), "");
     }
 
     #[test]
     fn it_sets_a_body() {
         let response: HttpResponse = ResponseBuilder::new().body("test").finish();
-        assert_eq!(
-            response.headers().get("Content-Type").unwrap(),
-            "text/plain"
-        );
-        assert_eq!(response.body().as_str().unwrap(), "test");
+        assert_eq!(response.headers.get("Content-Type").unwrap(), "text/plain");
+        assert_eq!(response.body.to_str().unwrap(), "test");
     }
 }

--- a/azure-functions/src/http/status.rs
+++ b/azure-functions/src/http/status.rs
@@ -9,7 +9,7 @@ macro_rules! statuses {
             #[doc=$code_str]
             #[doc="</b>."]
             #[allow(non_upper_case_globals)]
-            pub const $name: Status = Status($code);
+            pub const $name: Self = Self($code);
          )+
 
         /// Returns a `Status` given a status code `code`.
@@ -25,8 +25,8 @@ macro_rules! statuses {
         /// ```
         pub fn from_code(code: u16) -> Self {
             match code {
-                $($code => Status::$name,)+
-                _ => Status(code)
+                $($code => Self::$name,)+
+                _ => Self(code)
             }
         }
     };
@@ -105,7 +105,7 @@ impl ToString for Status {
 
 impl From<u16> for Status {
     fn from(code: u16) -> Self {
-        Status::from_code(code)
+        Self::from_code(code)
     }
 }
 

--- a/azure-functions/src/lib.rs
+++ b/azure-functions/src/lib.rs
@@ -89,6 +89,9 @@
 //! The expected response would be `Hello from Rust!`.
 #![deny(unused_extern_crates)]
 #![deny(missing_docs)]
+#![warn(clippy::use_self)]
+#![warn(clippy::option_map_unwrap_or)]
+#![warn(clippy::option_map_unwrap_or_else)]
 #![cfg_attr(test, recursion_limit = "128")]
 
 #[doc(no_inline)]

--- a/azure-functions/src/logger.rs
+++ b/azure-functions/src/logger.rs
@@ -10,8 +10,8 @@ pub struct Logger {
 }
 
 impl Logger {
-    pub fn new(level: Level, sender: Sender) -> Logger {
-        Logger { level, sender }
+    pub fn new(level: Level, sender: Sender) -> Self {
+        Self { level, sender }
     }
 }
 

--- a/azure-functions/src/send_grid/email_address.rs
+++ b/azure-functions/src/send_grid/email_address.rs
@@ -21,11 +21,11 @@ impl EmailAddress {
     /// assert_eq!(address.email, "foo@example.com");
     /// assert_eq!(address.name, None);
     /// ```
-    pub fn new<T>(email: T) -> EmailAddress
+    pub fn new<T>(email: T) -> Self
     where
         T: Into<String>,
     {
-        EmailAddress {
+        Self {
             email: email.into(),
             name: None,
         }
@@ -41,12 +41,12 @@ impl EmailAddress {
     /// assert_eq!(address.email, "foo@example.com");
     /// assert_eq!(address.name, Some("Peter".to_string()));
     /// ```
-    pub fn new_with_name<T, U>(email: T, name: U) -> EmailAddress
+    pub fn new_with_name<T, U>(email: T, name: U) -> Self
     where
         T: Into<String>,
         U: Into<String>,
     {
-        EmailAddress {
+        Self {
             email: email.into(),
             name: Some(name.into()),
         }
@@ -58,7 +58,7 @@ where
     T: Into<String>,
 {
     fn from(email: T) -> Self {
-        EmailAddress::new(email)
+        Self::new(email)
     }
 }
 

--- a/azure-functions/src/send_grid/message_builder.rs
+++ b/azure-functions/src/send_grid/message_builder.rs
@@ -10,8 +10,8 @@ pub struct MessageBuilder(SendGridMessage);
 
 impl MessageBuilder {
     /// Creates a new message builder.
-    pub fn new() -> MessageBuilder {
-        MessageBuilder(SendGridMessage::default())
+    pub fn new() -> Self {
+        Self(SendGridMessage::default())
     }
 
     /// Appends the given "to" email address to the first personalization of the message.
@@ -26,7 +26,7 @@ impl MessageBuilder {
     /// assert_eq!(message.personalizations[0].to[0].email, "foo@example.com");
     /// assert_eq!(message.personalizations[0].to[0].name, None);
     /// ```
-    pub fn to<T>(mut self, email: T) -> MessageBuilder
+    pub fn to<T>(mut self, email: T) -> Self
     where
         T: Into<String>,
     {
@@ -47,7 +47,7 @@ impl MessageBuilder {
     /// assert_eq!(message.personalizations[0].to[0].name, Some("Peter".to_owned()));
     /// ```
     #[allow(clippy::wrong_self_convention)]
-    pub fn to_with_name<T, U>(mut self, email: T, name: U) -> MessageBuilder
+    pub fn to_with_name<T, U>(mut self, email: T, name: U) -> Self
     where
         T: Into<String>,
         U: Into<String>,
@@ -75,7 +75,7 @@ impl MessageBuilder {
     /// assert_eq!(message.personalizations[0].to[1].email, "bar@example.com");
     /// assert_eq!(message.personalizations[0].to[1].name, Some("Peter".to_owned()));
     /// ```
-    pub fn tos<T>(mut self, addresses: T) -> MessageBuilder
+    pub fn tos<T>(mut self, addresses: T) -> Self
     where
         T: IntoIterator<Item = EmailAddress>,
     {
@@ -96,7 +96,7 @@ impl MessageBuilder {
     /// assert_eq!(message.personalizations[0].cc[0].email, "foo@example.com");
     /// assert_eq!(message.personalizations[0].cc[0].name, None);
     /// ```
-    pub fn cc<T>(mut self, email: T) -> MessageBuilder
+    pub fn cc<T>(mut self, email: T) -> Self
     where
         T: Into<String>,
     {
@@ -116,7 +116,7 @@ impl MessageBuilder {
     /// assert_eq!(message.personalizations[0].cc[0].email, "foo@example.com");
     /// assert_eq!(message.personalizations[0].cc[0].name, Some("Peter".to_owned()));
     /// ```
-    pub fn cc_with_name<T, U>(mut self, email: T, name: U) -> MessageBuilder
+    pub fn cc_with_name<T, U>(mut self, email: T, name: U) -> Self
     where
         T: Into<String>,
         U: Into<String>,
@@ -144,7 +144,7 @@ impl MessageBuilder {
     /// assert_eq!(message.personalizations[0].cc[1].email, "bar@example.com");
     /// assert_eq!(message.personalizations[0].cc[1].name, Some("Peter".to_owned()));
     /// ```
-    pub fn ccs<T>(mut self, addresses: T) -> MessageBuilder
+    pub fn ccs<T>(mut self, addresses: T) -> Self
     where
         T: IntoIterator<Item = EmailAddress>,
     {
@@ -165,7 +165,7 @@ impl MessageBuilder {
     /// assert_eq!(message.personalizations[0].bcc[0].email, "foo@example.com");
     /// assert_eq!(message.personalizations[0].bcc[0].name, None);
     /// ```
-    pub fn bcc<T>(mut self, email: T) -> MessageBuilder
+    pub fn bcc<T>(mut self, email: T) -> Self
     where
         T: Into<String>,
     {
@@ -185,7 +185,7 @@ impl MessageBuilder {
     /// assert_eq!(message.personalizations[0].bcc[0].email, "foo@example.com");
     /// assert_eq!(message.personalizations[0].bcc[0].name, Some("Peter".to_owned()));
     /// ```
-    pub fn bcc_with_name<T, U>(mut self, email: T, name: U) -> MessageBuilder
+    pub fn bcc_with_name<T, U>(mut self, email: T, name: U) -> Self
     where
         T: Into<String>,
         U: Into<String>,
@@ -213,7 +213,7 @@ impl MessageBuilder {
     /// assert_eq!(message.personalizations[0].bcc[1].email, "bar@example.com");
     /// assert_eq!(message.personalizations[0].bcc[1].name, Some("Peter".to_owned()));
     /// ```
-    pub fn bccs<T>(mut self, addresses: T) -> MessageBuilder
+    pub fn bccs<T>(mut self, addresses: T) -> Self
     where
         T: IntoIterator<Item = EmailAddress>,
     {
@@ -233,7 +233,7 @@ impl MessageBuilder {
     ///
     /// assert_eq!(message.personalizations[0].subject, Some("hello world!".to_owned()));
     /// ```
-    pub fn subject<T>(mut self, subject: T) -> MessageBuilder
+    pub fn subject<T>(mut self, subject: T) -> Self
     where
         T: Into<String>,
     {
@@ -253,7 +253,7 @@ impl MessageBuilder {
     ///
     /// assert_eq!(message.personalizations[0].headers.get("foo").map(String::as_str), Some("bar"));
     /// ```
-    pub fn header<T, U>(mut self, key: T, value: U) -> MessageBuilder
+    pub fn header<T, U>(mut self, key: T, value: U) -> Self
     where
         T: Into<String>,
         U: Into<String>,
@@ -282,7 +282,7 @@ impl MessageBuilder {
     /// assert_eq!(message.personalizations[0].headers.get("foo").map(String::as_str), Some("bar"));
     /// assert_eq!(message.personalizations[0].headers.get("bar").map(String::as_str), Some("baz"));
     /// ```
-    pub fn headers<T>(mut self, headers: T) -> MessageBuilder
+    pub fn headers<T>(mut self, headers: T) -> Self
     where
         T: IntoIterator<Item = (String, String)>,
     {
@@ -302,7 +302,7 @@ impl MessageBuilder {
     ///
     /// assert_eq!(message.personalizations[0].substitutions.get("foo").map(String::as_str), Some("bar"));
     /// ```
-    pub fn substitution<T, U>(mut self, key: T, value: U) -> MessageBuilder
+    pub fn substitution<T, U>(mut self, key: T, value: U) -> Self
     where
         T: Into<String>,
         U: Into<String>,
@@ -331,7 +331,7 @@ impl MessageBuilder {
     /// assert_eq!(message.personalizations[0].substitutions.get("foo").map(String::as_str), Some("bar"));
     /// assert_eq!(message.personalizations[0].substitutions.get("bar").map(String::as_str), Some("baz"));
     /// ```
-    pub fn substitutions<T>(mut self, substitutions: T) -> MessageBuilder
+    pub fn substitutions<T>(mut self, substitutions: T) -> Self
     where
         T: IntoIterator<Item = (String, String)>,
     {
@@ -354,7 +354,7 @@ impl MessageBuilder {
     ///
     /// assert_eq!(to_string(message.personalizations[0].template_data.as_ref().unwrap()).unwrap(), r#"{"foo":"bar"}"#);
     /// ```
-    pub fn template_data(mut self, data: Value) -> MessageBuilder {
+    pub fn template_data(mut self, data: Value) -> Self {
         if let Value::Object(map) = data {
             self.initialize_personalization();
             self.0.personalizations[0].template_data = Some(map);
@@ -376,7 +376,7 @@ impl MessageBuilder {
     ///
     /// assert_eq!(message.personalizations[0].custom_args.get("foo").map(String::as_str), Some("bar"));
     /// ```
-    pub fn custom_arg<T, U>(mut self, key: T, value: U) -> MessageBuilder
+    pub fn custom_arg<T, U>(mut self, key: T, value: U) -> Self
     where
         T: Into<String>,
         U: Into<String>,
@@ -405,7 +405,7 @@ impl MessageBuilder {
     /// assert_eq!(message.personalizations[0].custom_args.get("foo").map(String::as_str), Some("bar"));
     /// assert_eq!(message.personalizations[0].custom_args.get("bar").map(String::as_str), Some("baz"));
     /// ```
-    pub fn custom_args<T>(mut self, args: T) -> MessageBuilder
+    pub fn custom_args<T>(mut self, args: T) -> Self
     where
         T: IntoIterator<Item = (String, String)>,
     {
@@ -428,7 +428,7 @@ impl MessageBuilder {
     ///
     /// assert_eq!(message.personalizations[0].send_at, Some(1555890183));
     /// ```
-    pub fn send_at(mut self, timestamp: i64) -> MessageBuilder {
+    pub fn send_at(mut self, timestamp: i64) -> Self {
         self.initialize_personalization();
         self.0.personalizations[0].send_at = Some(timestamp);
         self
@@ -446,7 +446,7 @@ impl MessageBuilder {
     /// assert_eq!(message.from.as_ref().unwrap().email, "foo@example.com");
     /// assert_eq!(message.from.as_ref().unwrap().name, None);
     /// ```
-    pub fn from<T>(mut self, email: T) -> MessageBuilder
+    pub fn from<T>(mut self, email: T) -> Self
     where
         T: Into<String>,
     {
@@ -467,7 +467,7 @@ impl MessageBuilder {
     /// assert_eq!(message.from.as_ref().unwrap().name, Some("Peter".to_owned()));
     /// ```
     #[allow(clippy::wrong_self_convention)]
-    pub fn from_with_name<T, U>(mut self, email: T, name: U) -> MessageBuilder
+    pub fn from_with_name<T, U>(mut self, email: T, name: U) -> Self
     where
         T: Into<String>,
         U: Into<String>,
@@ -487,7 +487,7 @@ impl MessageBuilder {
     ///
     /// assert_eq!(message.subject, Some("hello world".to_owned()));
     /// ```
-    pub fn global_subject<T>(mut self, subject: T) -> MessageBuilder
+    pub fn global_subject<T>(mut self, subject: T) -> Self
     where
         T: Into<String>,
     {
@@ -507,7 +507,7 @@ impl MessageBuilder {
     /// assert_eq!(message.contents[0].mime_type, "text/plain");
     /// assert_eq!(message.contents[0].value, "hello world");
     /// ```
-    pub fn content<T>(mut self, text: T) -> MessageBuilder
+    pub fn content<T>(mut self, text: T) -> Self
     where
         T: Into<String>,
     {
@@ -531,7 +531,7 @@ impl MessageBuilder {
     /// assert_eq!(message.contents[0].mime_type, "text/plain");
     /// assert_eq!(message.contents[0].value, "hello world");
     /// ```
-    pub fn content_with_type<T, U>(mut self, content: T, mime_type: U) -> MessageBuilder
+    pub fn content_with_type<T, U>(mut self, content: T, mime_type: U) -> Self
     where
         T: Into<String>,
         U: Into<String>,
@@ -562,7 +562,7 @@ impl MessageBuilder {
     /// assert_eq!(message.contents[0].mime_type, "text/plain");
     /// assert_eq!(message.contents[0].value, "hello world");
     /// ```
-    pub fn contents<T>(mut self, contents: T) -> MessageBuilder
+    pub fn contents<T>(mut self, contents: T) -> Self
     where
         T: IntoIterator<Item = Content>,
     {
@@ -586,7 +586,7 @@ impl MessageBuilder {
     /// assert_eq!(message.attachments[0].mime_type, "text/plain");
     /// assert_eq!(message.attachments[0].content, "aGVsbG8gd29ybGQ=");
     /// ```
-    pub fn attachment<T, U, V>(mut self, filename: T, mime_type: U, content: V) -> MessageBuilder
+    pub fn attachment<T, U, V>(mut self, filename: T, mime_type: U, content: V) -> Self
     where
         T: Into<String>,
         U: Into<String>,
@@ -625,7 +625,7 @@ impl MessageBuilder {
         mime_type: U,
         content: V,
         content_id: W,
-    ) -> MessageBuilder
+    ) -> Self
     where
         T: Into<String>,
         U: Into<String>,
@@ -664,7 +664,7 @@ impl MessageBuilder {
     /// assert_eq!(message.attachments[0].mime_type, "text/plain");
     /// assert_eq!(message.attachments[0].content, "aGVsbG8gd29ybGQ=");
     /// ```
-    pub fn attachments<T>(mut self, attachments: T) -> MessageBuilder
+    pub fn attachments<T>(mut self, attachments: T) -> Self
     where
         T: IntoIterator<Item = Attachment>,
     {
@@ -683,7 +683,7 @@ impl MessageBuilder {
     ///
     /// assert_eq!(message.template_id, Some("id".to_owned()));
     /// ```
-    pub fn template_id<T>(mut self, id: T) -> MessageBuilder
+    pub fn template_id<T>(mut self, id: T) -> Self
     where
         T: Into<String>,
     {
@@ -702,7 +702,7 @@ impl MessageBuilder {
     ///
     /// assert_eq!(message.sections.get("foo").map(String::as_str), Some("bar"));
     /// ```
-    pub fn section<T, U>(mut self, key: T, value: U) -> MessageBuilder
+    pub fn section<T, U>(mut self, key: T, value: U) -> Self
     where
         T: Into<String>,
         U: Into<String>,
@@ -728,7 +728,7 @@ impl MessageBuilder {
     /// assert_eq!(message.sections.get("foo").map(String::as_str), Some("bar"));
     /// assert_eq!(message.sections.get("bar").map(String::as_str), Some("baz"));
     /// ```
-    pub fn sections<T>(mut self, sections: T) -> MessageBuilder
+    pub fn sections<T>(mut self, sections: T) -> Self
     where
         T: IntoIterator<Item = (String, String)>,
     {
@@ -747,7 +747,7 @@ impl MessageBuilder {
     ///
     /// assert_eq!(message.categories[0], "foo");
     /// ```
-    pub fn category<T>(mut self, category: T) -> MessageBuilder
+    pub fn category<T>(mut self, category: T) -> Self
     where
         T: Into<String>,
     {
@@ -768,7 +768,7 @@ impl MessageBuilder {
     /// assert_eq!(message.categories[1], "bar");
     /// assert_eq!(message.categories[2], "baz");
     /// ```
-    pub fn categories<T>(mut self, categories: T) -> MessageBuilder
+    pub fn categories<T>(mut self, categories: T) -> Self
     where
         T: IntoIterator<Item = String>,
     {
@@ -787,7 +787,7 @@ impl MessageBuilder {
     ///
     /// assert_eq!(message.headers.get("foo").map(String::as_str), Some("bar"));
     /// ```
-    pub fn global_header<T, U>(mut self, key: T, value: U) -> MessageBuilder
+    pub fn global_header<T, U>(mut self, key: T, value: U) -> Self
     where
         T: Into<String>,
         U: Into<String>,
@@ -813,7 +813,7 @@ impl MessageBuilder {
     /// assert_eq!(message.headers.get("foo").map(String::as_str), Some("bar"));
     /// assert_eq!(message.headers.get("bar").map(String::as_str), Some("baz"));
     /// ```
-    pub fn global_headers<T>(mut self, headers: T) -> MessageBuilder
+    pub fn global_headers<T>(mut self, headers: T) -> Self
     where
         T: IntoIterator<Item = (String, String)>,
     {
@@ -832,7 +832,7 @@ impl MessageBuilder {
     ///
     /// assert_eq!(message.custom_args.get("foo").map(String::as_str), Some("bar"));
     /// ```
-    pub fn global_custom_arg<T, U>(mut self, key: T, value: U) -> MessageBuilder
+    pub fn global_custom_arg<T, U>(mut self, key: T, value: U) -> Self
     where
         T: Into<String>,
         U: Into<String>,
@@ -859,7 +859,7 @@ impl MessageBuilder {
     /// assert_eq!(message.custom_args.get("foo").map(String::as_str), Some("bar"));
     /// assert_eq!(message.custom_args.get("bar").map(String::as_str), Some("baz"));
     /// ```
-    pub fn global_custom_args<T>(mut self, args: T) -> MessageBuilder
+    pub fn global_custom_args<T>(mut self, args: T) -> Self
     where
         T: IntoIterator<Item = (String, String)>,
     {
@@ -882,7 +882,7 @@ impl MessageBuilder {
     ///
     /// assert_eq!(message.send_at, Some(1555890183));
     /// ```
-    pub fn global_send_at(mut self, timestamp: i64) -> MessageBuilder {
+    pub fn global_send_at(mut self, timestamp: i64) -> Self {
         self.initialize_personalization();
         self.0.send_at = Some(timestamp);
         self
@@ -899,7 +899,7 @@ impl MessageBuilder {
     ///
     /// assert_eq!(message.batch_id.unwrap(), "HkJ5yLYULb7Rj8GKSx7u025ouWVlMgAi");
     /// ```
-    pub fn batch_id<T>(mut self, id: T) -> MessageBuilder
+    pub fn batch_id<T>(mut self, id: T) -> Self
     where
         T: Into<String>,
     {

--- a/azure-functions/src/util.rs
+++ b/azure-functions/src/util.rs
@@ -1,7 +1,13 @@
 use crate::rpc::{typed_data::Data, TypedData};
 use chrono::{DateTime, FixedOffset, Utc};
-use serde::{de::Error, de::IntoDeserializer, Deserialize, Deserializer};
-use serde_json::from_str;
+use serde::{
+    de::{
+        value::{F64Deserializer, I64Deserializer},
+        Error, IntoDeserializer,
+    },
+    Deserialize, Deserializer,
+};
+use serde_json::{error, from_str};
 use std::str::{from_utf8, FromStr};
 
 pub fn convert_from<'a, T>(data: &'a TypedData) -> Option<T>
@@ -24,13 +30,11 @@ where
             None
         }
         Some(Data::Int(i)) => {
-            let deserializer: ::serde::de::value::I64Deserializer<::serde_json::error::Error> =
-                i.into_deserializer();
+            let deserializer: I64Deserializer<error::Error> = i.into_deserializer();
             T::deserialize(deserializer).ok()
         }
         Some(Data::Double(d)) => {
-            let deserializer: ::serde::de::value::F64Deserializer<::serde_json::error::Error> =
-                d.into_deserializer();
+            let deserializer: F64Deserializer<error::Error> = d.into_deserializer();
             T::deserialize(deserializer).ok()
         }
         _ => None,

--- a/examples/blob/src/functions/blob_watcher.rs
+++ b/examples/blob/src/functions/blob_watcher.rs
@@ -1,8 +1,7 @@
 use azure_functions::{bindings::BlobTrigger, func};
 
 #[func]
-#[binding(name = "trigger", path = "watching/{name}")]
-pub fn blob_watcher(trigger: BlobTrigger) {
+pub fn blob_watcher(#[binding(path = "watching/{name}")] trigger: BlobTrigger) {
     log::info!(
         "A blob was created at '{}' with contents: {:?}.",
         trigger.path,

--- a/examples/blob/src/functions/copy_blob.rs
+++ b/examples/blob/src/functions/copy_blob.rs
@@ -4,9 +4,10 @@ use azure_functions::{
 };
 
 #[func]
-#[binding(name = "_req", route = "copy/blob/{container}/{name}")]
-#[binding(name = "blob", path = "{container}/{name}")]
 #[binding(name = "output1", path = "{container}/{name}.copy")]
-pub fn copy_blob(_req: HttpRequest, blob: Blob) -> (HttpResponse, Blob) {
+pub fn copy_blob(
+    #[binding(route = "copy/blob/{container}/{name}")] _req: HttpRequest,
+    #[binding(path = "{container}/{name}")] blob: Blob,
+) -> (HttpResponse, Blob) {
     ("blob has been copied.".into(), blob)
 }

--- a/examples/blob/src/functions/create_blob.rs
+++ b/examples/blob/src/functions/create_blob.rs
@@ -5,14 +5,16 @@ use azure_functions::{
 };
 
 #[func]
-#[binding(name = "req", route = "create/blob/{container}/{name}")]
 #[binding(name = "output1", path = "{container}/{name}")]
-pub fn create_blob(req: HttpRequest) -> (HttpResponse, Blob) {
+pub fn create_blob(
+    #[binding(route = "create/blob/{container}/{name}")] req: HttpRequest,
+) -> (HttpResponse, Blob) {
+    let data: Vec<u8> = req.body.into();
     (
         HttpResponse::build()
             .status(Status::Created)
             .body("blob has been created.")
             .finish(),
-        req.body().as_bytes().into(),
+        data.into(),
     )
 }

--- a/examples/blob/src/functions/print_blob.rs
+++ b/examples/blob/src/functions/print_blob.rs
@@ -4,8 +4,9 @@ use azure_functions::{
 };
 
 #[func]
-#[binding(name = "_req", route = "print/blob/{container}/{path}")]
-#[binding(name = "blob", path = "{container}/{path}")]
-pub fn print_blob(_req: HttpRequest, blob: Blob) -> HttpResponse {
+pub fn print_blob(
+    #[binding(route = "print/blob/{container}/{path}")] _req: HttpRequest,
+    #[binding(path = "{container}/{path}")] blob: Blob,
+) -> HttpResponse {
     blob.into()
 }

--- a/examples/cosmosdb/src/functions/create_document.rs
+++ b/examples/cosmosdb/src/functions/create_document.rs
@@ -5,7 +5,6 @@ use azure_functions::{
 use serde_json::json;
 
 #[func]
-#[binding(name = "req", route = "create/{id}")]
 #[binding(
     name = "output1",
     connection = "connection",
@@ -13,12 +12,14 @@ use serde_json::json;
     collection_name = "documents",
     create_collection = true
 )]
-pub fn create_document(req: HttpRequest) -> (HttpResponse, CosmosDbDocument) {
+pub fn create_document(
+    #[binding(route = "create/{id}")] mut req: HttpRequest,
+) -> (HttpResponse, CosmosDbDocument) {
     (
         "Document was created.".into(),
         json!({
-            "id": req.route_params().get("id").unwrap(),
-            "name": req.query_params().get("name").map_or("stranger", |x| x)
+            "id": req.route_params.remove("id").unwrap(),
+            "name": req.query_params.remove("name").expect("expected a 'name' query parameter"),
         })
         .into(),
     )

--- a/examples/cosmosdb/src/functions/log_documents.rs
+++ b/examples/cosmosdb/src/functions/log_documents.rs
@@ -2,14 +2,15 @@ use azure_functions::{bindings::CosmosDbTrigger, func};
 use log::info;
 
 #[func]
-#[binding(
-    name = "trigger",
-    connection = "connection",
-    database_name = "exampledb",
-    collection_name = "documents",
-    create_lease_collection = true
-)]
-pub fn log_documents(trigger: CosmosDbTrigger) {
+pub fn log_documents(
+    #[binding(
+        connection = "connection",
+        database_name = "exampledb",
+        collection_name = "documents",
+        create_lease_collection = true
+    )]
+    trigger: CosmosDbTrigger,
+) {
     for document in trigger.documents {
         info!("{:#?}", document);
     }

--- a/examples/cosmosdb/src/functions/query_documents.rs
+++ b/examples/cosmosdb/src/functions/query_documents.rs
@@ -4,15 +4,16 @@ use azure_functions::{
 };
 
 #[func]
-#[binding(name = "_req", route = "query/{name}")]
-#[binding(
-    name = "documents",
-    connection = "connection",
-    database_name = "exampledb",
-    collection_name = "documents",
-    sql_query = "select * from documents d where contains(d.name, {name})",
-    create_collection = true
-)]
-pub fn query_documents(_req: HttpRequest, documents: Vec<CosmosDbDocument>) -> HttpResponse {
+pub fn query_documents(
+    #[binding(route = "query/{name}")] _req: HttpRequest,
+    #[binding(
+        connection = "connection",
+        database_name = "exampledb",
+        collection_name = "documents",
+        sql_query = "select * from documents d where contains(d.name, {name})",
+        create_collection = true
+    )]
+    documents: Vec<CosmosDbDocument>,
+) -> HttpResponse {
     documents.into()
 }

--- a/examples/cosmosdb/src/functions/read_document.rs
+++ b/examples/cosmosdb/src/functions/read_document.rs
@@ -4,20 +4,21 @@ use azure_functions::{
 };
 
 #[func]
-#[binding(name = "req", route = "read/{id}")]
-#[binding(
-    name = "document",
-    connection = "connection",
-    database_name = "exampledb",
-    collection_name = "documents",
-    id = "{id}",
-    partition_key = "{id}"
-)]
-pub fn read_document(req: HttpRequest, document: CosmosDbDocument) -> HttpResponse {
+pub fn read_document(
+    #[binding(route = "read/{id}")] req: HttpRequest,
+    #[binding(
+        connection = "connection",
+        database_name = "exampledb",
+        collection_name = "documents",
+        id = "{id}",
+        partition_key = "{id}"
+    )]
+    document: CosmosDbDocument,
+) -> HttpResponse {
     if document.is_null() {
         format!(
             "Document with id '{}' does not exist.",
-            req.route_params().get("id").unwrap()
+            req.route_params.get("id").unwrap()
         )
         .into()
     } else {

--- a/examples/durable-functions/README.md
+++ b/examples/durable-functions/README.md
@@ -17,7 +17,7 @@ use serde_json::Value;
 pub async fn start(req: HttpRequest, client: DurableOrchestrationClient) -> HttpResponse {
     match client
         .start_new(
-            req.query_params()
+            req.query_params
                 .get("function")
                 .expect("expected a function parameter"),
             None,
@@ -202,17 +202,17 @@ use azure_functions::{
 #[func]
 pub async fn raise_event(req: HttpRequest, client: DurableOrchestrationClient) -> HttpResponse {
     let id = req
-        .query_params()
+        .query_params
         .get("id")
         .expect("expected a 'id' parameter");
 
     let name = req
-        .query_params()
+        .query_params
         .get("name")
         .expect("expected a 'name' parameter");
 
     let value = req
-        .query_params()
+        .query_params
         .get("value")
         .expect("expected a 'value' parameter")
         .clone();

--- a/examples/durable-functions/src/functions/raise_event.rs
+++ b/examples/durable-functions/src/functions/raise_event.rs
@@ -6,17 +6,17 @@ use azure_functions::{
 #[func]
 pub async fn raise_event(req: HttpRequest, client: DurableOrchestrationClient) -> HttpResponse {
     let id = req
-        .query_params()
+        .query_params
         .get("id")
         .expect("expected a 'id' parameter");
 
     let name = req
-        .query_params()
+        .query_params
         .get("name")
         .expect("expected a 'name' parameter");
 
     let value = req
-        .query_params()
+        .query_params
         .get("value")
         .expect("expected a 'value' parameter")
         .clone();

--- a/examples/durable-functions/src/functions/start.rs
+++ b/examples/durable-functions/src/functions/start.rs
@@ -8,7 +8,7 @@ use serde_json::Value;
 pub async fn start(req: HttpRequest, client: DurableOrchestrationClient) -> HttpResponse {
     match client
         .start_new(
-            req.query_params()
+            req.query_params
                 .get("function")
                 .expect("expected a function parameter"),
             None,

--- a/examples/event-hub/README.md
+++ b/examples/event-hub/README.md
@@ -8,15 +8,13 @@ An example Event Hub triggered Azure Function that runs when a new message is po
 to the `example` Event Hub:
 
 ```rust
-use azure_functions::{
-    bindings::EventHubTrigger,
-    func,
-};
+use azure_functions::{bindings::EventHubTrigger, func};
 
 #[func]
-#[binding(name = "trigger", connection = "connection", event_hub_name = "example")]
-pub fn log_event(trigger: EventHubTrigger) {
-    log::info!("Event hub message: {}", trigger.message.as_str().unwrap());
+pub fn log_event(
+    #[binding(connection = "connection", event_hub_name = "example")] trigger: EventHubTrigger,
+) {
+    log::info!("Event hub message: {}", trigger.message.to_str().unwrap());
 }
 ```
 
@@ -24,16 +22,20 @@ An example HTTP-triggered Azure Function that outputs a message to the `example`
 
 ```rust
 use azure_functions::{
-    bindings::{HttpRequest, HttpResponse, EventHubMessage},
+    bindings::{EventHubMessage, HttpRequest, HttpResponse},
     func,
 };
 
 #[func]
-#[binding(name = "output1", connection = "connection", event_hub_name = "example")]
+#[binding(
+    name = "output1",
+    connection = "connection",
+    event_hub_name = "example"
+)]
 pub fn create_event(_req: HttpRequest) -> (HttpResponse, EventHubMessage) {
     (
         "Created Event Hub message.".into(),
-        "Hello from Rust!".into()
+        "Hello from Rust!".into(),
     )
 }
 ```

--- a/examples/event-hub/src/functions/log_event.rs
+++ b/examples/event-hub/src/functions/log_event.rs
@@ -1,11 +1,8 @@
 use azure_functions::{bindings::EventHubTrigger, func};
 
 #[func]
-#[binding(
-    name = "trigger",
-    connection = "connection",
-    event_hub_name = "example"
-)]
-pub fn log_event(trigger: EventHubTrigger) {
-    log::info!("Event hub message: {}", trigger.message.as_str().unwrap());
+pub fn log_event(
+    #[binding(connection = "connection", event_hub_name = "example")] trigger: EventHubTrigger,
+) {
+    log::info!("Event hub message: {}", trigger.message.to_str().unwrap());
 }

--- a/examples/generic/src/functions/create_document.rs
+++ b/examples/generic/src/functions/create_document.rs
@@ -5,7 +5,6 @@ use azure_functions::{
 use serde_json::json;
 
 #[func]
-#[binding(name = "req", route = "create/{id}")]
 #[binding(
     type = "cosmosDB",
     name = "output1",
@@ -14,12 +13,14 @@ use serde_json::json;
     collectionName = "documents",
     createIfNotExists = true
 )]
-pub fn create_document(req: HttpRequest) -> (HttpResponse, GenericOutput) {
+pub fn create_document(
+    #[binding(route = "create/{id}")] mut req: HttpRequest,
+) -> (HttpResponse, GenericOutput) {
     (
         "Document was created.".into(),
         json!({
-            "id": req.route_params().get("id").unwrap(),
-            "name": req.query_params().get("name").map_or("stranger", |x| x)
+            "id": req.route_params.remove("id").unwrap(),
+            "name": req.query_params.remove("name").expect("expected a 'name' query parameter"),
         })
         .into(),
     )

--- a/examples/generic/src/functions/log_documents.rs
+++ b/examples/generic/src/functions/log_documents.rs
@@ -2,15 +2,16 @@ use azure_functions::{bindings::GenericTrigger, func, generic::Value};
 use log::info;
 
 #[func]
-#[binding(
-    type = "cosmosDBTrigger",
-    name = "trigger",
-    connectionStringSetting = "connection",
-    databaseName = "exampledb",
-    collectionName = "documents",
-    createLeaseCollectionIfNotExists = true
-)]
-pub fn log_documents(trigger: GenericTrigger) {
+pub fn log_documents(
+    #[binding(
+        type = "cosmosDBTrigger",
+        connectionStringSetting = "connection",
+        databaseName = "exampledb",
+        collectionName = "documents",
+        createLeaseCollectionIfNotExists = true
+    )]
+    trigger: GenericTrigger,
+) {
     match trigger.data {
         Value::Json(v) => {
             info!("{}", v);

--- a/examples/generic/src/functions/query_documents.rs
+++ b/examples/generic/src/functions/query_documents.rs
@@ -4,16 +4,17 @@ use azure_functions::{
 };
 
 #[func]
-#[binding(name = "_req", route = "query/{name}")]
-#[binding(
-    type = "cosmosDB",
-    name = "documents",
-    connectionStringSetting = "connection",
-    databaseName = "exampledb",
-    collectionName = "documents",
-    sqlQuery = "select * from documents d where contains(d.name, {name})",
-    createIfNotExists = true
-)]
-pub fn query_documents(_req: HttpRequest, documents: GenericInput) -> HttpResponse {
+pub fn query_documents(
+    #[binding(route = "query/{name}")] _req: HttpRequest,
+    #[binding(
+        type = "cosmosDB",
+        connectionStringSetting = "connection",
+        databaseName = "exampledb",
+        collectionName = "documents",
+        sqlQuery = "select * from documents d where contains(d.name, {name})",
+        createIfNotExists = true
+    )]
+    documents: GenericInput,
+) -> HttpResponse {
     documents.into()
 }

--- a/examples/generic/src/functions/read_document.rs
+++ b/examples/generic/src/functions/read_document.rs
@@ -6,24 +6,25 @@ use azure_functions::{
 use serde_json::from_str;
 
 #[func]
-#[binding(name = "req", route = "read/{id}")]
-#[binding(
-    type = "cosmosDB",
-    name = "document",
-    connectionStringSetting = "connection",
-    databaseName = "exampledb",
-    collectionName = "documents",
-    id = "{id}",
-    partitionKey = "{id}"
-)]
-pub fn read_document(req: HttpRequest, document: GenericInput) -> HttpResponse {
+pub fn read_document(
+    #[binding(route = "read/{id}")] req: HttpRequest,
+    #[binding(
+        type = "cosmosDB",
+        connectionStringSetting = "connection",
+        databaseName = "exampledb",
+        collectionName = "documents",
+        id = "{id}",
+        partitionKey = "{id}"
+    )]
+    document: GenericInput,
+) -> HttpResponse {
     match document.data {
         Value::String(s) => {
             let v: serde_json::Value = from_str(&s).expect("expected JSON data");
             if v.is_null() {
                 format!(
                     "Document with id '{}' does not exist.",
-                    req.route_params().get("id").unwrap()
+                    req.route_params.get("id").unwrap()
                 )
                 .into()
             } else {

--- a/examples/http/src/functions/greet.rs
+++ b/examples/http/src/functions/greet.rs
@@ -7,7 +7,7 @@ use azure_functions::{
 pub fn greet(req: HttpRequest) -> HttpResponse {
     format!(
         "Hello from Rust, {}!\n",
-        req.query_params().get("name").map_or("stranger", |x| x)
+        req.query_params.get("name").map_or("stranger", |x| x)
     )
     .into()
 }

--- a/examples/http/src/functions/greet_async.rs
+++ b/examples/http/src/functions/greet_async.rs
@@ -8,7 +8,7 @@ use futures::future::ready;
 pub async fn greet_async(req: HttpRequest) -> HttpResponse {
     let response = format!(
         "Hello from Rust, {}!\n",
-        req.query_params().get("name").map_or("stranger", |x| x)
+        req.query_params.get("name").map_or("stranger", |x| x)
     );
 
     // Use ready().await to simply demonstrate the async/await feature

--- a/examples/http/src/functions/greet_with_json.rs
+++ b/examples/http/src/functions/greet_with_json.rs
@@ -4,7 +4,7 @@ use azure_functions::{
     http::Status,
 };
 use serde::{Deserialize, Serialize};
-use serde_json::to_value;
+use serde_json::{from_slice, to_value};
 
 #[derive(Deserialize)]
 struct Request {
@@ -18,7 +18,7 @@ struct Response {
 
 #[func]
 pub fn greet_with_json(req: HttpRequest) -> HttpResponse {
-    if let Ok(request) = req.body().as_json::<Request>() {
+    if let Ok(request) = from_slice::<Request>(req.body.as_bytes()) {
         let response = Response {
             message: format!("Hello from Rust, {}!", request.name),
         };

--- a/examples/queue/README.md
+++ b/examples/queue/README.md
@@ -11,8 +11,7 @@ to the `test` Azure Storage Queue.
 use azure_functions::{bindings::QueueTrigger, func};
 
 #[func]
-#[binding(name = "trigger", queue_name = "test")]
-pub fn queue(trigger: QueueTrigger) {
+pub fn queue(#[binding(queue_name = "test")] trigger: QueueTrigger) {
     log::info!("Message: {}", trigger.message);
 }
 ```
@@ -26,12 +25,11 @@ use azure_functions::{
 };
 
 #[func]
-#[binding(name = "trigger", queue_name = "echo-in")]
 #[binding(name = "$return", queue_name = "echo-out")]
-pub fn queue_with_output(trigger: QueueTrigger) -> QueueMessage {
+pub fn queue_with_output(#[binding(queue_name = "echo-in")] trigger: QueueTrigger) -> QueueMessage {
     log::info!("Message: {}", trigger.message);
 
-    trigger.message.clone()
+    trigger.message
 }
 ```
 

--- a/examples/queue/src/functions/queue.rs
+++ b/examples/queue/src/functions/queue.rs
@@ -1,7 +1,6 @@
 use azure_functions::{bindings::QueueTrigger, func};
 
 #[func]
-#[binding(name = "trigger", queue_name = "test")]
-pub fn queue(trigger: QueueTrigger) {
+pub fn queue(#[binding(queue_name = "test")] trigger: QueueTrigger) {
     log::info!("Message: {}", trigger.message);
 }

--- a/examples/queue/src/functions/queue_with_output.rs
+++ b/examples/queue/src/functions/queue_with_output.rs
@@ -4,9 +4,8 @@ use azure_functions::{
 };
 
 #[func]
-#[binding(name = "trigger", queue_name = "echo-in")]
 #[binding(name = "$return", queue_name = "echo-out")]
-pub fn queue_with_output(trigger: QueueTrigger) -> QueueMessage {
+pub fn queue_with_output(#[binding(queue_name = "echo-in")] trigger: QueueTrigger) -> QueueMessage {
     log::info!("Message: {}", trigger.message);
 
     trigger.message

--- a/examples/sendgrid/README.md
+++ b/examples/sendgrid/README.md
@@ -9,22 +9,30 @@ An example HTTP-triggered Azure Function that outputs a SendGrid email message:
 ```rust
 use azure_functions::{
     bindings::{HttpRequest, HttpResponse, SendGridMessage},
-    send_grid::MessageBuilder,
     func,
 };
 
 #[func]
 #[binding(name = "output1", from = "azure.functions.for.rust@example.com")]
-pub fn send_email(req: HttpRequest) -> (HttpResponse, SendGridMessage) {
-    let params = req.query_params();
-
+pub fn send_email(mut req: HttpRequest) -> (HttpResponse, SendGridMessage) {
     (
         "The email was sent.".into(),
-        MessageBuilder::new()
-            .to(params.get("to").unwrap().as_str())
-            .subject(params.get("subject").unwrap().as_str())
-            .content(params.get("content").unwrap().as_str())
-            .build(),
+        SendGridMessage::build()
+            .to(req
+                .query_params
+                .remove("to")
+                .expect("expected a 'to' query parameter"))
+            .subject(
+                req.query_params
+                    .remove("subject")
+                    .expect("expected a 'subject' query parameter"),
+            )
+            .content(
+                req.query_params
+                    .remove("content")
+                    .expect("expected a 'content' query parameter"),
+            )
+            .finish(),
     )
 }
 ```

--- a/examples/sendgrid/src/functions/send_email.rs
+++ b/examples/sendgrid/src/functions/send_email.rs
@@ -5,15 +5,24 @@ use azure_functions::{
 
 #[func]
 #[binding(name = "output1", from = "azure.functions.for.rust@example.com")]
-pub fn send_email(req: HttpRequest) -> (HttpResponse, SendGridMessage) {
-    let params = req.query_params();
-
+pub fn send_email(mut req: HttpRequest) -> (HttpResponse, SendGridMessage) {
     (
         "The email was sent.".into(),
         SendGridMessage::build()
-            .to(params.get("to").unwrap().as_str())
-            .subject(params.get("subject").unwrap().as_str())
-            .content(params.get("content").unwrap().as_str())
+            .to(req
+                .query_params
+                .remove("to")
+                .expect("expected a 'to' query parameter"))
+            .subject(
+                req.query_params
+                    .remove("subject")
+                    .expect("expected a 'subject' query parameter"),
+            )
+            .content(
+                req.query_params
+                    .remove("content")
+                    .expect("expected a 'content' query parameter"),
+            )
             .finish(),
     )
 }

--- a/examples/service-bus/README.md
+++ b/examples/service-bus/README.md
@@ -11,9 +11,10 @@ to the `example` queue:
 use azure_functions::{bindings::ServiceBusTrigger, func};
 
 #[func]
-#[binding(name = "trigger", queue_name = "example", connection = "connection")]
-pub fn log_queue_message(trigger: ServiceBusTrigger) {
-    log::info!("{}", trigger.message.as_str().unwrap());
+pub fn log_queue_message(
+    #[binding(queue_name = "example", connection = "connection")] trigger: ServiceBusTrigger,
+) {
+    log::info!("{}", trigger.message.to_str().unwrap());
 }
 ```
 
@@ -30,7 +31,7 @@ use azure_functions::{
 pub fn create_queue_message(req: HttpRequest) -> ServiceBusMessage {
     format!(
         "Hello from Rust, {}!\n",
-        req.query_params().get("name").map_or("stranger", |x| x)
+        req.query_params.get("name").map_or("stranger", |x| x)
     )
     .into()
 }
@@ -43,14 +44,15 @@ to the `mytopic` topic and `mysubscription` subscription:
 use azure_functions::{bindings::ServiceBusTrigger, func};
 
 #[func]
-#[binding(
-    name = "trigger",
-    topic_name = "mytopic",
-    subscription_name = "mysubscription",
-    connection = "connection"
-)]
-pub fn log_topic_message(trigger: ServiceBusTrigger) {
-    log::info!("{}", trigger.message.as_str().unwrap());
+pub fn log_topic_message(
+    #[binding(
+        topic_name = "mytopic",
+        subscription_name = "mysubscription",
+        connection = "connection"
+    )]
+    trigger: ServiceBusTrigger,
+) {
+    log::info!("{}", trigger.message.to_str().unwrap());
 }
 ```
 
@@ -72,7 +74,7 @@ use azure_functions::{
 pub fn create_topic_message(req: HttpRequest) -> ServiceBusMessage {
     format!(
         "Hello from Rust, {}!\n",
-        req.query_params().get("name").map_or("stranger", |x| x)
+        req.query_params.get("name").map_or("stranger", |x| x)
     )
     .into()
 }

--- a/examples/service-bus/src/functions/create_queue_message.rs
+++ b/examples/service-bus/src/functions/create_queue_message.rs
@@ -8,7 +8,7 @@ use azure_functions::{
 pub fn create_queue_message(req: HttpRequest) -> ServiceBusMessage {
     format!(
         "Hello from Rust, {}!\n",
-        req.query_params().get("name").map_or("stranger", |x| x)
+        req.query_params.get("name").map_or("stranger", |x| x)
     )
     .into()
 }

--- a/examples/service-bus/src/functions/create_topic_message.rs
+++ b/examples/service-bus/src/functions/create_topic_message.rs
@@ -13,7 +13,7 @@ use azure_functions::{
 pub fn create_topic_message(req: HttpRequest) -> ServiceBusMessage {
     format!(
         "Hello from Rust, {}!\n",
-        req.query_params().get("name").map_or("stranger", |x| x)
+        req.query_params.get("name").map_or("stranger", |x| x)
     )
     .into()
 }

--- a/examples/service-bus/src/functions/log_queue_message.rs
+++ b/examples/service-bus/src/functions/log_queue_message.rs
@@ -1,7 +1,8 @@
 use azure_functions::{bindings::ServiceBusTrigger, func};
 
 #[func]
-#[binding(name = "trigger", queue_name = "example", connection = "connection")]
-pub fn log_queue_message(trigger: ServiceBusTrigger) {
-    log::info!("{}", trigger.message.as_str().unwrap());
+pub fn log_queue_message(
+    #[binding(queue_name = "example", connection = "connection")] trigger: ServiceBusTrigger,
+) {
+    log::info!("{}", trigger.message.to_str().unwrap());
 }

--- a/examples/service-bus/src/functions/log_topic_message.rs
+++ b/examples/service-bus/src/functions/log_topic_message.rs
@@ -1,12 +1,13 @@
 use azure_functions::{bindings::ServiceBusTrigger, func};
 
 #[func]
-#[binding(
-    name = "trigger",
-    topic_name = "mytopic",
-    subscription_name = "mysubscription",
-    connection = "connection"
-)]
-pub fn log_topic_message(trigger: ServiceBusTrigger) {
-    log::info!("{}", trigger.message.as_str().unwrap());
+pub fn log_topic_message(
+    #[binding(
+        topic_name = "mytopic",
+        subscription_name = "mysubscription",
+        connection = "connection"
+    )]
+    trigger: ServiceBusTrigger,
+) {
+    log::info!("{}", trigger.message.to_str().unwrap());
 }

--- a/examples/signalr/README.md
+++ b/examples/signalr/README.md
@@ -15,14 +15,15 @@ use azure_functions::{
 };
 
 #[func]
-#[binding(name = "_req", auth_level = "anonymous")]
-#[binding(
-    name = "info",
-    hub_name = "simplechat",
-    user_id = "{headers.x-ms-signalr-userid}",
-    connection = "connection"
-)]
-pub fn negotiate(_req: HttpRequest, info: SignalRConnectionInfo) -> HttpResponse {
+pub fn negotiate(
+    #[binding(auth_level = "anonymous")] _req: HttpRequest,
+    #[binding(
+        hub_name = "simplechat",
+        user_id = "{headers.x-ms-signalr-userid}",
+        connection = "connection"
+    )]
+    info: SignalRConnectionInfo,
+) -> HttpResponse {
     info.into()
 }
 ```
@@ -37,16 +38,15 @@ use azure_functions::{
     bindings::{HttpRequest, SignalRMessage},
     func,
 };
-use serde_json::to_value;
+use serde_json::{from_slice, to_value};
 
 #[func(name = "messages")]
-#[binding(name = "req", auth_level = "anonymous", methods = "post")]
 #[binding(name = "$return", hub_name = "simplechat", connection = "connection")]
-pub fn send_message(req: HttpRequest) -> SignalRMessage {
-    let message: ChatMessage = req
-        .body()
-        .as_json()
-        .expect("failed to deserialize chat message");
+pub fn send_message(
+    #[binding(auth_level = "anonymous", methods = "post")] req: HttpRequest,
+) -> SignalRMessage {
+    let message: ChatMessage =
+        from_slice(req.body.as_bytes()).expect("failed to deserialize chat message");
 
     SignalRMessage {
         user_id: message.recipient.clone(),
@@ -68,15 +68,16 @@ use azure_functions::{
     func,
     signalr::GroupAction,
 };
+use serde_json::from_slice;
 
 #[func(name = "addToGroup")]
-#[binding(name = "req", auth_level = "anonymous", methods = "post")]
 #[binding(name = "$return", hub_name = "simplechat", connection = "connection")]
-pub fn add_to_group(req: HttpRequest) -> SignalRGroupAction {
-    let message: ChatMessage = req
-        .body()
-        .as_json()
-        .expect("failed to deserialize chat message");
+pub fn add_to_group(
+    #[binding(auth_level = "anonymous", methods = "post")] req: HttpRequest,
+) -> SignalRGroupAction {
+    let message: ChatMessage =
+        from_slice(req.body.as_bytes()).expect("failed to deserialize chat message");
+
     SignalRGroupAction {
         user_id: message.recipient.unwrap(),
         group_name: message.group_name.unwrap(),
@@ -94,15 +95,16 @@ use azure_functions::{
     func,
     signalr::GroupAction,
 };
+use serde_json::from_slice;
 
 #[func(name = "removeFromGroup")]
-#[binding(name = "req", auth_level = "anonymous", methods = "post")]
 #[binding(name = "$return", hub_name = "simplechat", connection = "connection")]
-pub fn remove_from_group(req: HttpRequest) -> SignalRGroupAction {
-    let message: ChatMessage = req
-        .body()
-        .as_json()
-        .expect("failed to deserialize chat message");
+pub fn remove_from_group(
+    #[binding(auth_level = "anonymous", methods = "post")] req: HttpRequest,
+) -> SignalRGroupAction {
+    let message: ChatMessage =
+        from_slice(req.body.as_bytes()).expect("failed to deserialize chat message");
+
     SignalRGroupAction {
         user_id: message.recipient.unwrap(),
         group_name: message.group_name.unwrap(),

--- a/examples/signalr/src/functions/add_to_group.rs
+++ b/examples/signalr/src/functions/add_to_group.rs
@@ -4,15 +4,16 @@ use azure_functions::{
     func,
     signalr::GroupAction,
 };
+use serde_json::from_slice;
 
 #[func(name = "addToGroup")]
-#[binding(name = "req", auth_level = "anonymous", methods = "post")]
 #[binding(name = "$return", hub_name = "simplechat", connection = "connection")]
-pub fn add_to_group(req: HttpRequest) -> SignalRGroupAction {
-    let message: ChatMessage = req
-        .body()
-        .as_json()
-        .expect("failed to deserialize chat message");
+pub fn add_to_group(
+    #[binding(auth_level = "anonymous", methods = "post")] req: HttpRequest,
+) -> SignalRGroupAction {
+    let message: ChatMessage =
+        from_slice(req.body.as_bytes()).expect("failed to deserialize chat message");
+
     SignalRGroupAction {
         user_id: message.recipient.unwrap(),
         group_name: message.group_name.unwrap(),

--- a/examples/signalr/src/functions/negotiate.rs
+++ b/examples/signalr/src/functions/negotiate.rs
@@ -4,13 +4,14 @@ use azure_functions::{
 };
 
 #[func]
-#[binding(name = "_req", auth_level = "anonymous")]
-#[binding(
-    name = "info",
-    hub_name = "simplechat",
-    user_id = "{headers.x-ms-signalr-userid}",
-    connection = "connection"
-)]
-pub fn negotiate(_req: HttpRequest, info: SignalRConnectionInfo) -> HttpResponse {
+pub fn negotiate(
+    #[binding(auth_level = "anonymous")] _req: HttpRequest,
+    #[binding(
+        hub_name = "simplechat",
+        user_id = "{headers.x-ms-signalr-userid}",
+        connection = "connection"
+    )]
+    info: SignalRConnectionInfo,
+) -> HttpResponse {
     info.into()
 }

--- a/examples/signalr/src/functions/remove_from_group.rs
+++ b/examples/signalr/src/functions/remove_from_group.rs
@@ -4,15 +4,16 @@ use azure_functions::{
     func,
     signalr::GroupAction,
 };
+use serde_json::from_slice;
 
 #[func(name = "removeFromGroup")]
-#[binding(name = "req", auth_level = "anonymous", methods = "post")]
 #[binding(name = "$return", hub_name = "simplechat", connection = "connection")]
-pub fn remove_from_group(req: HttpRequest) -> SignalRGroupAction {
-    let message: ChatMessage = req
-        .body()
-        .as_json()
-        .expect("failed to deserialize chat message");
+pub fn remove_from_group(
+    #[binding(auth_level = "anonymous", methods = "post")] req: HttpRequest,
+) -> SignalRGroupAction {
+    let message: ChatMessage =
+        from_slice(req.body.as_bytes()).expect("failed to deserialize chat message");
+
     SignalRGroupAction {
         user_id: message.recipient.unwrap(),
         group_name: message.group_name.unwrap(),

--- a/examples/signalr/src/functions/send_message.rs
+++ b/examples/signalr/src/functions/send_message.rs
@@ -3,16 +3,15 @@ use azure_functions::{
     bindings::{HttpRequest, SignalRMessage},
     func,
 };
-use serde_json::to_value;
+use serde_json::{from_slice, to_value};
 
 #[func(name = "messages")]
-#[binding(name = "req", auth_level = "anonymous", methods = "post")]
 #[binding(name = "$return", hub_name = "simplechat", connection = "connection")]
-pub fn send_message(req: HttpRequest) -> SignalRMessage {
-    let message: ChatMessage = req
-        .body()
-        .as_json()
-        .expect("failed to deserialize chat message");
+pub fn send_message(
+    #[binding(auth_level = "anonymous", methods = "post")] req: HttpRequest,
+) -> SignalRMessage {
+    let message: ChatMessage =
+        from_slice(req.body.as_bytes()).expect("failed to deserialize chat message");
 
     SignalRMessage {
         user_id: message.recipient.clone(),

--- a/examples/table/src/functions/create_row.rs
+++ b/examples/table/src/functions/create_row.rs
@@ -2,22 +2,23 @@ use azure_functions::{
     bindings::{HttpRequest, Table},
     func,
 };
-use serde_json::Value;
+use serde_json::from_slice;
 
 #[func]
-#[binding(name = "req", route = "create/{table}/{partition}/{row}")]
 #[binding(name = "output1", table_name = "{table}")]
-pub fn create_row(req: HttpRequest) -> ((), Table) {
+pub fn create_row(
+    #[binding(route = "create/{table}/{partition}/{row}")] req: HttpRequest,
+) -> ((), Table) {
     let mut table = Table::new();
     {
         let row = table.add_row(
-            req.route_params().get("partition").unwrap(),
-            req.route_params().get("row").unwrap(),
+            req.route_params.get("partition").unwrap(),
+            req.route_params.get("row").unwrap(),
         );
 
         row.insert(
             "body".to_string(),
-            Value::String(req.body().as_str().unwrap().to_owned()),
+            from_slice(req.body.as_bytes()).expect("expected JSON body"),
         );
     }
     ((), table)

--- a/examples/table/src/functions/read_row.rs
+++ b/examples/table/src/functions/read_row.rs
@@ -4,13 +4,14 @@ use azure_functions::{
 };
 
 #[func]
-#[binding(name = "_req", route = "read/{table}/{partition}/{row}")]
-#[binding(
-    name = "table",
-    table_name = "{table}",
-    partition_key = "{partition}",
-    row_key = "{row}"
-)]
-pub fn read_row(_req: HttpRequest, table: Table) -> HttpResponse {
+pub fn read_row(
+    #[binding(route = "read/{table}/{partition}/{row}")] _req: HttpRequest,
+    #[binding(
+        table_name = "{table}",
+        partition_key = "{partition}",
+        row_key = "{row}"
+    )]
+    table: Table,
+) -> HttpResponse {
     table.into()
 }

--- a/examples/timer/README.md
+++ b/examples/timer/README.md
@@ -10,8 +10,7 @@ The example timer-triggered Azure Function that runs every minute:
 use azure_functions::{bindings::TimerInfo, func};
 
 #[func]
-#[binding(name = "info", schedule = "0 */1 * * * *")]
-pub fn timer(info: TimerInfo) {
+pub fn timer(#[binding(schedule = "0 */1 * * * *")] info: TimerInfo) {
     log::info!("Hello from Rust!");
     log::info!("Timer information: {:?}", info);
 }

--- a/examples/timer/src/functions/timer.rs
+++ b/examples/timer/src/functions/timer.rs
@@ -1,8 +1,7 @@
 use azure_functions::{bindings::TimerInfo, func};
 
 #[func]
-#[binding(name = "info", schedule = "0 */1 * * * *")]
-pub fn timer(info: TimerInfo) {
+pub fn timer(#[binding(schedule = "0 */1 * * * *")] info: TimerInfo) {
     log::info!("Hello from Rust!");
     log::info!("Timer information: {:?}", info);
 }

--- a/examples/twilio/README.md
+++ b/examples/twilio/README.md
@@ -8,21 +8,24 @@ An example HTTP-triggered Azure Function that outputs a Twilio SMS message:
 
 ```rust
 use azure_functions::{
-    bindings::{HttpRequest, TwilioSmsMessage},
+    bindings::{HttpRequest, HttpResponse, TwilioSmsMessage},
     func,
 };
-use std::borrow::ToOwned;
 
 #[func]
-#[binding(name = "$return", from = "+15555555555")]
-pub fn send_sms(req: HttpRequest) -> TwilioSmsMessage {
-    let params = req.query_params();
-
-    TwilioSmsMessage {
-        to: params.get("to").unwrap().to_owned(),
-        body: params.get("body").map(ToOwned::to_owned),
-        ..Default::default()
-    }
+#[binding(name = "output1", from = "+15555555555")]
+pub fn send_sms(mut req: HttpRequest) -> (HttpResponse, TwilioSmsMessage) {
+    (
+        "Text message sent.".into(),
+        TwilioSmsMessage {
+            to: req
+                .query_params
+                .remove("to")
+                .expect("expected a 'to' query parameter"),
+            body: req.query_params.remove("body"),
+            ..Default::default()
+        },
+    )
 }
 ```
 

--- a/examples/twilio/src/functions/send_sms.rs
+++ b/examples/twilio/src/functions/send_sms.rs
@@ -2,18 +2,18 @@ use azure_functions::{
     bindings::{HttpRequest, HttpResponse, TwilioSmsMessage},
     func,
 };
-use std::borrow::ToOwned;
 
 #[func]
 #[binding(name = "output1", from = "+15555555555")]
-pub fn send_sms(req: HttpRequest) -> (HttpResponse, TwilioSmsMessage) {
-    let params = req.query_params();
-
+pub fn send_sms(mut req: HttpRequest) -> (HttpResponse, TwilioSmsMessage) {
     (
         "Text message sent.".into(),
         TwilioSmsMessage {
-            to: params.get("to").unwrap().to_owned(),
-            body: params.get("body").map(ToOwned::to_owned),
+            to: req
+                .query_params
+                .remove("to")
+                .expect("expected a 'to' query parameter"),
+            body: req.query_params.remove("body"),
             ..Default::default()
         },
     )


### PR DESCRIPTION
This PR refactors HttpRequest and HttpResponse to directly store the data
rather than an inner `RpcHttp`.

It also implements support for cookies in `HttpRequest`, `HttpResponse`, and
`ResponseBuilder`.

Also enables more lints and fixes the clippy warnings.

Binding attributes for parameters have moved to the parameters in the examples
and documentation.

Fixes #346.
Fixes #281.