### PR TITLE
Use Debian Stretch for build image.

### DIFF
--- a/docker/build-image/Dockerfile
+++ b/docker/build-image/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:slim
+FROM rust:slim-stretch
 LABEL MAINTAINER Peter Huene <peterhuene@protonmail.com>
 
 ENV PATH "$PATH:/root/.cargo/bin"


### PR DESCRIPTION
This commit uses the Stretch image for the build image, which is required
because the .NET Core runtime deps are currently built for Stretch.

Fixes #467.
