### PR TITLE
address clippy warnings (including build issues with current rust)

### DIFF
--- a/azure-functions-codegen/src/func.rs
+++ b/azure-functions-codegen/src/func.rs
@@ -65,7 +65,7 @@ fn validate_orchestration_function(func: &ItemFn) {
         );
     }
 
-    if !match func.sig.inputs.iter().nth(0).unwrap() {
+    if !match func.sig.inputs.iter().next().unwrap() {
         FnArg::Typed(arg) => match &*arg.ty {
             Type::Path(tp) => last_segment_in_path(&tp.path).ident == ORCHESTRATION_CONTEXT_TYPE,
             _ => false,
@@ -112,7 +112,7 @@ fn validate_activity_function(func: &ItemFn) {
     fn validate_return_binding(ty: &Type) {
         match ty {
             Type::Tuple(tuple) => {
-                if let Some(first) = tuple.elems.iter().nth(0) {
+                if let Some(first) = tuple.elems.iter().next() {
                     validate_return_binding(first)
                 }
             }
@@ -201,7 +201,7 @@ fn get_generic_argument_type<'a>(
             if gen_args.args.len() != 1 {
                 return None;
             }
-            match gen_args.args.iter().nth(0) {
+            match gen_args.args.iter().next() {
                 Some(GenericArgument::Type(t)) => Some(t),
                 _ => None,
             }
@@ -572,7 +572,7 @@ pub fn func_impl(
         }
     }
 
-    if let Some((_, args)) = binding_args.iter().nth(0) {
+    if let Some((_, args)) = binding_args.iter().next() {
         iter_attribute_args(&args.0, |k, v| {
             if k != "name" {
                 return true;

--- a/azure-functions-codegen/src/func/output_bindings.rs
+++ b/azure-functions-codegen/src/func/output_bindings.rs
@@ -144,7 +144,7 @@ impl<'a> OutputBindings<'a> {
             }
         } else {
             if let Type::Tuple(tuple) = &*ty {
-                if let Some(first) = tuple.elems.iter().nth(0) {
+                if let Some(first) = tuple.elems.iter().next() {
                     return OutputBindings::get_return_binding(first, true);
                 }
                 return None;

--- a/azure-functions-codegen/src/lib.rs
+++ b/azure-functions-codegen/src/lib.rs
@@ -4,8 +4,6 @@
 #![recursion_limit = "128"]
 #![deny(unused_extern_crates)]
 #![cfg_attr(feature = "unstable", feature(proc_macro_diagnostic))]
-extern crate proc_macro;
-
 mod export;
 mod func;
 

--- a/azure-functions-shared-codegen/src/lib.rs
+++ b/azure-functions-shared-codegen/src/lib.rs
@@ -4,8 +4,6 @@
 #![deny(unused_extern_crates)]
 #![recursion_limit = "128"]
 #![cfg_attr(feature = "unstable", feature(proc_macro_diagnostic))]
-extern crate proc_macro;
-
 mod binding;
 
 use binding::binding_impl;

--- a/azure-functions-shared/build.rs
+++ b/azure-functions-shared/build.rs
@@ -24,7 +24,7 @@ fn compile_protobufs(out_dir: &PathBuf, cache_dir: &PathBuf) {
     for file in OUTPUT_FILES {
         let cached_output = cache_dir.join(file);
 
-        fs::copy(out_dir.join(file), &cached_output).expect(&format!(
+        fs::copy(out_dir.join(file), &cached_output).unwrap_or_else(|_| panic!(
             "can't update cache file '{}'",
             cached_output.display()
         ));
@@ -35,7 +35,7 @@ fn compile_protobufs(out_dir: &PathBuf, cache_dir: &PathBuf) {
 
 fn use_cached_files(out_dir: &PathBuf, cache_dir: &PathBuf) {
     for file in OUTPUT_FILES {
-        fs::copy(cache_dir.join(file), out_dir.join(file)).expect(&format!(
+        fs::copy(cache_dir.join(file), out_dir.join(file)).unwrap_or_else(|_| panic!(
             "can't copy cache file '{}' to output directory",
             file
         ));


### PR DESCRIPTION
## What is the goal of this pull request?

Address build failures & clippy warnings

## What does this pull request change?

Minimal changes to deal with a handful of warnings & build failures in current release of rust.

## What work remains to be done?

N/A

## Do you consider it adequately tested?

YES

## Related Issues

## Notes